### PR TITLE
Be conformant with flags to xa_end

### DIFF
--- a/middleware/common/include/common/flag.h
+++ b/middleware/common/include/common/flag.h
@@ -49,9 +49,9 @@ namespace casual
          constexpr Flags() = default;
 
          template< typename... Enums>
-         constexpr Flags( enum_type e, Enums... enums) : Flags( bitmask( e, enums...)) {}
+         constexpr Flags( enum_type e, Enums... enums) noexcept : Flags( bitmask( e, enums...)) {}
  
-         constexpr explicit Flags( underlaying_type flags) : m_flags( flags) {}
+         constexpr explicit Flags( underlaying_type flags) noexcept : m_flags( flags) {}
 
          constexpr Flags convert( underlaying_type flags) const
          {
@@ -71,30 +71,36 @@ namespace casual
 
          constexpr explicit operator bool() const noexcept { return ! empty();}
 
-         constexpr bool exist( enum_type flag) const
+         constexpr bool exist( enum_type flag) const noexcept
          {
             return ( m_flags & cast::underlying( flag)) == cast::underlying( flag);
          }
 
+         platform::size::type bits() const noexcept
+         {
+            return std::bitset< std::numeric_limits< underlaying_type>::digits>{ static_cast< unsigned long long>( m_flags)}.count();
+         }
+
+
 
          constexpr underlaying_type underlaying() const noexcept { return m_flags;}
 
-         constexpr friend Flags& operator |= ( Flags& lhs, Flags rhs) { lhs.m_flags |= rhs.m_flags; return lhs;}
-         constexpr friend Flags operator | ( Flags lhs, Flags rhs) { return Flags( lhs.m_flags | rhs.m_flags);}
+         constexpr friend Flags& operator |= ( Flags& lhs, Flags rhs) noexcept { lhs.m_flags |= rhs.m_flags; return lhs;}
+         constexpr friend Flags operator | ( Flags lhs, Flags rhs) noexcept { return Flags( lhs.m_flags | rhs.m_flags);}
          
-         constexpr friend Flags& operator &= ( Flags& lhs, Flags rhs) { lhs.m_flags &= rhs.m_flags; return lhs;}
-         constexpr friend Flags operator & ( Flags lhs, Flags rhs) { return Flags( lhs.m_flags & rhs.m_flags);}
+         constexpr friend Flags& operator &= ( Flags& lhs, Flags rhs) noexcept { lhs.m_flags &= rhs.m_flags; return lhs;}
+         constexpr friend Flags operator & ( Flags lhs, Flags rhs) noexcept { return Flags( lhs.m_flags & rhs.m_flags);}
 
-         constexpr friend Flags& operator ^= ( Flags& lhs, Flags rhs) { lhs.m_flags ^= rhs.m_flags; return lhs;}
-         constexpr friend Flags operator ^ ( Flags lhs, Flags rhs) { return Flags( lhs.m_flags ^ rhs.m_flags);}
+         constexpr friend Flags& operator ^= ( Flags& lhs, Flags rhs) noexcept { lhs.m_flags ^= rhs.m_flags; return lhs;}
+         constexpr friend Flags operator ^ ( Flags lhs, Flags rhs) noexcept { return Flags( lhs.m_flags ^ rhs.m_flags);}
 
-         constexpr friend Flags operator ~ ( Flags lhs) { return Flags{ ~lhs.m_flags};}
+         constexpr friend Flags operator ~ ( Flags lhs) noexcept { return Flags{ ~lhs.m_flags};}
 
-         constexpr friend bool operator == ( Flags lhs, Flags rhs) { return lhs.m_flags == rhs.m_flags;}
-         constexpr friend bool operator != ( Flags lhs, Flags rhs) { return ! ( lhs == rhs);}
+         constexpr friend bool operator == ( Flags lhs, Flags rhs) noexcept { return lhs.m_flags == rhs.m_flags;}
+         constexpr friend bool operator != ( Flags lhs, Flags rhs) noexcept { return ! ( lhs == rhs);}
 
-         constexpr friend Flags operator - ( Flags lhs, Flags rhs) { return Flags{ lhs.m_flags & ~rhs.m_flags};}
-         constexpr friend Flags& operator -= ( Flags& lhs, Flags rhs) { lhs.m_flags &= ~rhs.m_flags; return lhs;}
+         constexpr friend Flags operator - ( Flags lhs, Flags rhs) noexcept { return Flags{ lhs.m_flags & ~rhs.m_flags};}
+         constexpr friend Flags& operator -= ( Flags& lhs, Flags rhs) noexcept { lhs.m_flags &= ~rhs.m_flags; return lhs;}
 
 
          constexpr friend std::ostream& operator << ( std::ostream& out, Flags flags)

--- a/middleware/common/include/common/flag/xa.h
+++ b/middleware/common/include/common/flag/xa.h
@@ -12,47 +12,45 @@
 
 namespace casual 
 {
-   namespace common 
+   namespace common::flag::xa 
    {
-      namespace flag
+      //! Flag definition for the RM switch
+      namespace resource 
       {
-         namespace xa 
-         {
-            //! Flag definition for the RM switch
-            namespace resource 
-            {
-               enum class Flag : long
-               {  
-                  no_flags = TMNOFLAGS,
-                  dynamic = TMREGISTER,
-                  no_migrate = TMNOMIGRATE,
-                  asynchronous = TMUSEASYNC
-               };
-               using Flags = common::Flags< resource::Flag>;
-            } // resource 
+         enum class Flag : long
+         {  
+            no_flags = TMNOFLAGS,
+            dynamic = TMREGISTER,
+            no_migrate = TMNOMIGRATE,
+            asynchronous = TMUSEASYNC
+         };
+         std::string_view description( Flag value);
+         
+         using Flags = common::Flags< resource::Flag>;
+      } // resource 
 
 
-            enum class Flag : long
-            {
-               no_flags = TMNOFLAGS,
-               asynchronous = TMASYNC,
-               one_phase = TMONEPHASE,
-               fail = TMFAIL,
-               no_wait = TMNOWAIT,
-               resume = TMRESUME,
-               success = TMSUCCESS,
-               suspend = TMSUSPEND,
-               start_scan = TMSTARTRSCAN,
-               end_scan = TMENDRSCAN,
-               wait_any = TMMULTIPLE,
-               join = TMJOIN,
-               migrate = TMMIGRATE
-            };
-            using Flags = common::Flags< xa::Flag>;
+      enum class Flag : long
+      {
+         no_flags = TMNOFLAGS,
+         asynchronous = TMASYNC,
+         one_phase = TMONEPHASE,
+         fail = TMFAIL,
+         no_wait = TMNOWAIT,
+         resume = TMRESUME,
+         success = TMSUCCESS,
+         suspend = TMSUSPEND,
+         start_scan = TMSTARTRSCAN,
+         end_scan = TMENDRSCAN,
+         wait_any = TMMULTIPLE,
+         join = TMJOIN,
+         migrate = TMMIGRATE
+      };
+      std::string_view description( Flag value);
 
-         } // xa 
-      } // flag
-   } // common 
+      using Flags = common::Flags< xa::Flag>;
+
+   } // common::flag::xa 
 } // casual 
 
 //

--- a/middleware/common/makefile.cmk
+++ b/middleware/common/makefile.cmk
@@ -50,6 +50,7 @@ install_headers = []
 casual_common_objectfiles = [
 
     make.Compile( 'source/strong/id.cpp'),
+    make.Compile( 'source/flag/xa.cpp'),
 
     make.Compile( 'source/server/context.cpp'),
     make.Compile( 'source/server/lifetime.cpp'),

--- a/middleware/common/source/flag/xa.cpp
+++ b/middleware/common/source/flag/xa.cpp
@@ -1,0 +1,55 @@
+//!
+//! Copyright (c) 2022, The casual project
+//!
+//! This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+//!
+
+#include "common/flag/xa.h"
+
+namespace casual
+{
+   namespace common::flag::xa 
+   {
+      namespace resource 
+      {
+         std::string_view description( Flag value)
+         {
+            switch( value)
+            {
+               case Flag::no_flags: return "no_flags";
+               case Flag::dynamic: return "dynamic";
+               case Flag::no_migrate: return "no_migrate";
+               case Flag::asynchronous: return "asynchronous";
+            }
+            return "<unknown>";
+         }
+      } // resource 
+
+      std::string_view description( Flag value)
+      {
+         switch( value)
+         {
+            case Flag::no_flags: return "no_flags";
+            case Flag::asynchronous: return "asynchronous";
+            case Flag::one_phase: return "one_phase";
+            case Flag::fail: return "fail";
+            case Flag::no_wait: return "no_wait";
+            case Flag::resume: return "resume";
+            case Flag::success: return "success";
+            case Flag::suspend: return "suspend";
+            case Flag::start_scan: return "start_scan";
+            case Flag::end_scan: return "end_scan";
+            case Flag::wait_any: return "wait_any";
+            case Flag::join: return "join";
+            case Flag::migrate: return "migrate";
+            
+         }
+         return "<unknown>";
+      }
+
+
+      using Flags = common::Flags< xa::Flag>;
+
+   } // common::flag::xa 
+   
+} // casual

--- a/middleware/common/source/transaction/context.cpp
+++ b/middleware/common/source/transaction/context.cpp
@@ -902,7 +902,7 @@ namespace casual
 
                auto xa_end = [&transaction]( auto& result)
                {
-                  result.resource->end( transaction.trid, flag::xa::Flag::no_flags);
+                  result.resource->end( transaction.trid, flag::xa::Flag::success);
                };
 
                // xa_end on the succeeded.


### PR DESCRIPTION
Make sure we always uses exactly on of [ flag::xa::Flag::success,
flag::xa::Flag::suspend, flag::xa::Flag::fail] on xa_end.

Right now we never set _fail_ since this would make it impossible to
interact with the resource after. All units of work will be rolled back,
but the user might want to interact with resources for reads after a
service has return with _fail_. Well, it's possible a quality of
implementation issue for the resource, but at least db2 makes it impossible...

fixes #28