### PR TITLE
gateway - handle lost connection in tcp send correctly

### DIFF
--- a/middleware/gateway/source/group/inbound/main.cpp
+++ b/middleware/gateway/source/group/inbound/main.cpp
@@ -202,7 +202,7 @@ namespace casual
                   communication::select::dispatch::pump( 
                      local::condition( state),
                      state.directive,
-                     group::tcp::pending::send::dispatch( state),
+                     tcp::pending::send::dispatch::create( state, &handle::connection::lost),
                      ipc::dispatch::create( state, &internal::handler),
                      tcp::handle::dispatch::create( state, inbound::handle::external( state), &handle::connection::lost),
                      tcp::listen::dispatch::create( state, tcp::logical::connect::Bound::in),

--- a/middleware/gateway/source/group/inbound/reverse/main.cpp
+++ b/middleware/gateway/source/group/inbound/reverse/main.cpp
@@ -251,7 +251,7 @@ namespace casual
                communication::select::dispatch::pump( 
                   local::condition( state),
                   state.directive,
-                  group::tcp::pending::send::dispatch( state),
+                  tcp::pending::send::dispatch::create( state, &handle::connection::lost),
                   ipc::dispatch::create( state, &internal::handler),
                   tcp::handle::dispatch::create( state, inbound::handle::external( state), &handle::connection::lost),
                   // takes care of multiplexing connects

--- a/middleware/gateway/source/group/outbound/main.cpp
+++ b/middleware/gateway/source/group/outbound/main.cpp
@@ -258,7 +258,7 @@ namespace casual
                   local::condition( state),
                   state.directive,
                   tcp::handle::dispatch::create( state, outbound::handle::external( state), &handle::connection::lost),
-                  gateway::group::tcp::pending::send::dispatch( state),
+                  tcp::pending::send::dispatch::create( state, &handle::connection::lost),
                   ipc::dispatch::create( state, &internal::handler),
                   // takes care of multiplexing connects
                   tcp::connect::dispatch::create( state, tcp::logical::connect::Bound::out),

--- a/middleware/gateway/source/group/outbound/reverse/main.cpp
+++ b/middleware/gateway/source/group/outbound/reverse/main.cpp
@@ -196,7 +196,7 @@ namespace casual
                communication::select::dispatch::pump( 
                   local::condition( state),
                   state.directive,
-                  gateway::group::tcp::pending::send::dispatch( state),
+                  tcp::pending::send::dispatch::create( state, &handle::connection::lost),
                   tcp::handle::dispatch::create( state, outbound::handle::external( state), &handle::connection::lost),
                   ipc::dispatch::create( state, &internal::handler),
                   tcp::listen::dispatch::create( state, tcp::logical::connect::Bound::out),


### PR DESCRIPTION
Before this fix: If we're sending over tcp and a communication
_exception_ occurred, we did not handle this and let it propagate. Hence
the outbound exited.

Now we handle this and make sure we update state and so on, exactly the
same as with tcp multiplexing read.