### PR TITLE
tcp - guard errors in socket::address::host/peer

### DIFF
--- a/middleware/common/include/common/communication/tcp.h
+++ b/middleware/common/include/common/communication/tcp.h
@@ -50,12 +50,12 @@ namespace casual
          namespace address
          {
             //! @return The address to which the socket is bound to on local host
-            Address host( strong::socket::id descriptor);
-            Address host( const Socket& socket);
+            Address host( strong::socket::id descriptor) noexcept;
+            Address host( const Socket& socket) noexcept;
 
             //! @return The address of the peer connected to the socket
-            Address peer( strong::socket::id descriptor);
-            Address peer( const Socket& socket);
+            Address peer( strong::socket::id descriptor) noexcept;
+            Address peer( const Socket& socket) noexcept;
 
          } // address
 
@@ -91,12 +91,9 @@ namespace casual
 
          namespace error
          {
-
-
-            bool recoverable( std::errc error) noexcept;
-            
+            //! answers if the errc is a tcp recoverable error, or not.
+            bool recoverable( std::errc error) noexcept;  
          } // error
-
 
          //! @returns one of:
          //!  * a socket

--- a/middleware/common/source/communication/tcp.cpp
+++ b/middleware/common/source/communication/tcp.cpp
@@ -343,36 +343,44 @@ namespace casual
       {
          namespace address
          {
-            Address host( const strong::socket::id descriptor)
+            Address host( const strong::socket::id descriptor) noexcept
             {
-               struct sockaddr info{ };
-               socklen_t size = sizeof( info);
-
-               posix::result(
-                  getsockname(
-                     descriptor.value(), &info, &size));
-
-               return local::socket::names( info, size);
+               try
+               {
+                  ::sockaddr info{};
+                  ::socklen_t size = sizeof( info);
+                  posix::result( getsockname( descriptor.value(), &info, &size));
+                  return local::socket::names( info, size);
+               }
+               catch( ...)
+               {
+                  log::line( communication::log, exception::capture(), " - failed to get host address from: ", descriptor);
+                  return {};
+               }
             }
 
-            Address host( const Socket& socket)
+            Address host( const Socket& socket) noexcept
             {
                return host( socket.descriptor());
             }
 
-            Address peer( const strong::socket::id descriptor)
+            Address peer( const strong::socket::id descriptor) noexcept
             {
-               struct sockaddr info{ };
-               socklen_t size = sizeof( info);
-
-               posix::result(
-                  getpeername(
-                     descriptor.value(), &info, &size));
-
-               return local::socket::names( info, size);
+               try
+               {
+                  ::sockaddr info{};
+                  ::socklen_t size = sizeof( info);
+                  posix::result( getpeername( descriptor.value(), &info, &size));
+                  return local::socket::names( info, size);
+               }
+               catch( ...)
+               {
+                  log::line( communication::log, exception::capture(), " - failed to get peer address from: ", descriptor);
+                  return {};
+               }
             }
 
-            Address peer( const Socket& socket)
+            Address peer( const Socket& socket) noexcept
             {
                return peer( socket.descriptor());
             }


### PR DESCRIPTION
Before:
An error could propagate and exit inbound/outbound, if a connection is
"disconnected" between a logical connection has been done, and
inbound/outbound gets notified.

After:
We guard socket::address::host/peer and return an empty _string_ if we
get any errors.