### PR TITLE
service - fix lookup-forget-reply has _replied_ for remote services

### DIFF
--- a/middleware/service/source/manager/handle.cpp
+++ b/middleware/service/source/manager/handle.cpp
@@ -549,9 +549,10 @@ namespace casual
                                  log::line( verbose::log, "instance: ", instance);
 
                                  instance.discard();
-
-                                 reply.state = decltype( reply.state)::replied;
                               }
+
+                              // regardless, we assume we've already replied.
+                              reply.state = decltype( reply.state)::replied;
                            }
 
                            // We only send reply if caller want's it

--- a/middleware/service/unittest/include/service/unittest/utility.h
+++ b/middleware/service/unittest/include/service/unittest/utility.h
@@ -18,11 +18,20 @@ namespace casual
 {
    namespace service::unittest
    {
-      //! advertise `service` to service-manager as current process
+      //! advertise `services` to service-manager as current process
       void advertise( std::vector< std::string> services);
 
-      //! unadvertise `service` to service-manager as current process
+      //! unadvertise `services` to service-manager as current process
       void unadvertise( std::vector< std::string> services);
+
+      namespace concurrent
+      {
+         //! advertise concurrent/remote `services` to service-manager as current process
+         void advertise( std::vector< std::string> services);
+
+         //! unadvertise concurrent/remote `services` to service-manager as current process
+         void unadvertise( std::vector< std::string> services);
+      } // concurrent
 
       namespace send
       {

--- a/middleware/service/unittest/source/utility.cpp
+++ b/middleware/service/unittest/source/utility.cpp
@@ -48,6 +48,29 @@ namespace casual
          communication::device::blocking::send( local::ipc::manager(), message);
       }
 
+      namespace concurrent
+      {
+         void advertise( std::vector< std::string> services)
+         {
+            message::service::concurrent::Advertise message{ process::handle()};
+            message.alias = instance::alias();
+            message.services.add = algorithm::transform( services, []( auto& service)
+            {
+               return message::service::concurrent::advertise::Service{ std::move( service), "remote", common::service::transaction::Type::automatic};
+            });
+
+            communication::device::blocking::send( local::ipc::manager(), message);
+         }
+
+         void unadvertise( std::vector< std::string> services)
+         {
+            message::service::concurrent::Advertise message{ process::handle()};
+            message.alias = instance::alias();
+            message.services.remove = std::move( services);
+            communication::device::blocking::send( local::ipc::manager(), message);
+         }
+      } // concurrent
+
       manager::admin::model::State state()
       {
          serviceframework::service::protocol::binary::Call call;


### PR DESCRIPTION
Before:
for concurrent/remote services we did not set state to _replied_ in
the reply. Which callers expected.