### PR TITLE
transaction - reply with read_only if an ongoing transaction gets an external commit/prepare::Request

### DIFF
--- a/middleware/transaction/source/manager/handle.cpp
+++ b/middleware/transaction/source/manager/handle.cpp
@@ -840,9 +840,9 @@ namespace casual
                                     return;
                                  }
 
-                                 if( transaction->stage > decltype( transaction->stage())::commit)
+                                 if( transaction->stage > decltype( transaction->stage())::involved)
                                  {
-                                    common::log::line( log, "transaction stage is passed the _commit_ - stage: ", transaction->stage, " - action: reply with read-only");
+                                    common::log::line( log, "transaction stage is passed the _involved_ - stage: ", transaction->stage, " - action: reply with read-only");
                                     detail::send::read::only::reply( message);
                                     return;
                                  }


### PR DESCRIPTION

Before:
Transaction manager sometimes tried to commit stuff that had already been handled
when an external resource sent a request.