### PR TITLE
discovery - fix using routes for services correctly

### DIFF
--- a/middleware/common/include/common/message/service.h
+++ b/middleware/common/include/common/message/service.h
@@ -62,6 +62,7 @@ namespace casual
             service::Type type = service::Type::sequential;
 
             inline friend bool operator == ( const Base& lhs, const std::string& rhs) { return lhs.name == rhs;}
+            inline friend bool operator == ( const std::string& lhs, const Base& rhs) { return rhs == lhs;}
 
             inline auto tie() const noexcept { return std::tie( name);}
 

--- a/middleware/common/include/common/message/type.h
+++ b/middleware/common/include/common/message/type.h
@@ -284,6 +284,9 @@ namespace casual
          domain_discovery_reply     = 7301,
          domain_discovery_topology_implicit_update = 7302, // 1.2
 
+         domain_discovery_internal_request,
+         domain_discovery_internal_reply,
+
          //! sent to _discovery_ when current domain gets a new outbound connection
          domain_discovery_topology_direct_update,
 

--- a/middleware/common/include/common/unittest/file.h
+++ b/middleware/common/include/common/unittest/file.h
@@ -28,9 +28,11 @@ namespace casual
                return result;
             }
 
-
             common::file::scoped::Path name( std::string_view extension);
          } // temporary
+
+         common::file::scoped::Path content( const std::filesystem::path& file, std::string_view content);
+
       } // file
 
       namespace directory
@@ -50,13 +52,14 @@ namespace casual
                Scoped( const Scoped&) = delete;
                Scoped& operator =( const Scoped&) = delete;
 
-               inline const std::string& path() const & { return m_path;}
-               inline operator const std::string&() const & { return m_path;}
+               inline auto& path() const & { return m_path;}
+               inline auto string() const { return m_path.string();}
+               inline operator const std::filesystem::path&() const & { return m_path;}
 
                friend std::ostream& operator << ( std::ostream& out, const Scoped& value);
 
             private:
-               std::string m_path;
+               std::filesystem::path m_path;
             };
             
          } // temporary

--- a/middleware/common/source/message/type.cpp
+++ b/middleware/common/source/message/type.cpp
@@ -171,6 +171,8 @@ namespace casual
             case Type::gateway_domain_connected: return "gateway_domain_connected";
             case Type::domain_discovery_request: return "domain_discovery_request";
             case Type::domain_discovery_reply: return "domain_discovery_reply";
+            case Type::domain_discovery_internal_request: return "domain_discovery_internal_request";
+            case Type::domain_discovery_internal_reply: return "domain_discovery_internal_reply";
             case Type::domain_discovery_topology_implicit_update: return "domain_discovery_topology_implicit_update";
             case Type::domain_discovery_topology_direct_update: return "domain_discovery_topology_direct_update";
             case Type::configuration_request: return "configuration_request";

--- a/middleware/common/source/unittest/file.cpp
+++ b/middleware/common/source/unittest/file.cpp
@@ -46,6 +46,14 @@ namespace casual
             }
 
          } // temporary
+
+         common::file::scoped::Path content( const std::filesystem::path& path, std::string_view content)
+         {
+            std::ofstream file{ path};
+            file << content;
+            return { path};
+         }
+
       } // file
 
       namespace directory

--- a/middleware/common/unittest/source/test_file.cpp
+++ b/middleware/common/unittest/source/test_file.cpp
@@ -80,10 +80,10 @@ namespace casual
          common::unittest::Trace trace;
 
          unittest::directory::temporary::Scoped dir;
-         file::Output a{ dir.path() + "/a_foo.yaml"};
-         file::Output b{ dir.path() + "/b_foo.yaml"};
+         file::Output a{ dir.path() / "a_foo.yaml"};
+         file::Output b{ dir.path() / "b_foo.yaml"};
          
-         auto paths = common::file::find( { dir.path() + "/b*.yaml", dir.path() + "/a*.yaml"});
+         auto paths = common::file::find( { dir.path() / "b*.yaml", dir.path() / "a*.yaml"});
          ASSERT_TRUE( paths.size() == 2) << trace.compose( "paths: ", paths);
          EXPECT_TRUE( paths.at( 0) == b.path()) << trace.compose( "paths: ", paths);
          EXPECT_TRUE( paths.at( 1) == a.path()) << trace.compose( "paths: ", paths);
@@ -94,10 +94,10 @@ namespace casual
          common::unittest::Trace trace;
 
          unittest::directory::temporary::Scoped dir;
-         file::Output b{ dir.path() + "/b_foo.yaml"};
-         file::Output a{ dir.path() + "/a_foo.yaml"};
+         file::Output b{ dir.path() / "b_foo.yaml"};
+         file::Output a{ dir.path() / "a_foo.yaml"};
          
-         auto paths = common::file::find( dir.path() + "/*.yaml");
+         auto paths = common::file::find( ( dir.path() / "*.yaml").string());
          ASSERT_TRUE( paths.size() == 2) << trace.compose( "paths: ", paths);
          EXPECT_TRUE( paths.at( 0) == a.path()) << trace.compose( "paths: ", paths);
          EXPECT_TRUE( paths.at( 1) == b.path()) << trace.compose( "paths: ", paths);

--- a/middleware/domain/include/domain/discovery/state.h
+++ b/middleware/domain/include/domain/discovery/state.h
@@ -146,14 +146,16 @@ namespace casual
          struct 
          {
             common::message::coordinate::fan::Out< message::discovery::Reply, common::strong::process::id> discovery;
+            common::message::coordinate::fan::Out< message::discovery::internal::Reply, common::strong::process::id> internal;
             common::message::coordinate::fan::Out< message::discovery::needs::Reply, common::strong::process::id> needs;
             common::message::coordinate::fan::Out< message::discovery::known::Reply, common::strong::process::id> known;
 
-            inline void failed( common::strong::process::id pid) { discovery.failed( pid); needs.failed( pid);}
-            inline bool empty() const noexcept { return discovery.empty() && needs.empty() && known.empty();}
+            inline void failed( common::strong::process::id pid) { discovery.failed( pid); internal.failed( pid); needs.failed( pid); known.failed( pid);}
+            inline bool empty() const noexcept { return discovery.empty() && internal.empty() && needs.empty() && known.empty();}
 
             CASUAL_LOG_SERIALIZE(
                CASUAL_SERIALIZE( discovery);
+               CASUAL_SERIALIZE( internal);
                CASUAL_SERIALIZE( needs);
                CASUAL_SERIALIZE( known);
             )

--- a/middleware/domain/unittest/source/manager.cpp
+++ b/middleware/domain/unittest/source/manager.cpp
@@ -290,7 +290,7 @@ domain:
                environment::variable::set( "CASUAL_DOMAIN_HOME", home);
                
                if( callback)
-                  callback( home);
+                  callback( home.string());
 
                // reset all (hopefolly) environment based 'values' 
                environment::reset();

--- a/middleware/domain/unittest/source/test_discovery.cpp
+++ b/middleware/domain/unittest/source/test_discovery.cpp
@@ -94,9 +94,9 @@ namespace casual
          request.content.services = { "a"};
          auto correlation = discovery::request( request);
 
-         // wait for the request, and send reply reply
+         // wait for the internal request, and send reply reply
          {
-            message::discovery::Request request;
+            message::discovery::internal::Request request;
             communication::device::blocking::receive( communication::ipc::inbound::device(), request);
             EXPECT_TRUE( algorithm::equal( request.content.services, array::make( "a")));
             auto reply = common::message::reverse::type( request, process::handle());
@@ -114,7 +114,7 @@ namespace casual
       }
 
 
-      TEST( domain_discovery, register_as_discover_provieder_x2__send_outbound_request___expect_2_request__then_reply)
+      TEST( domain_discovery, register_as_discover_provider_x2__send_outbound_request___expect_2_request__then_reply)
       {
          common::unittest::Trace trace;
 
@@ -173,7 +173,7 @@ namespace casual
          };
 
          // handle the means request and the discovery request
-         handle_request( message::discovery::Request{});
+         handle_request( message::discovery::internal::Request{});
          handle_request( message::discovery::Request{});
 
          // wait for the reply

--- a/middleware/http/makefile.cmk
+++ b/middleware/http/makefile.cmk
@@ -9,6 +9,9 @@ make.IncludePaths([
     '../buffer/include',
     '../domain/include',
     '../domain/unittest/include',
+    '../service/include',
+    '../service/unittest/include',
+    '../configuration/include',
     ]
     + make.optional_include_paths()
     + dsl.paths().include.gtest
@@ -21,6 +24,7 @@ make.LibraryPaths([
     '../buffer/bin',
     '../xatmi/bin',
     '../domain/bin',
+    '../service/bin',
     '../configuration/bin',
     '../serviceframework/bin']
     + make.optional_library_paths()
@@ -87,6 +91,7 @@ make.LinkUnittest( 'unittest/bin/test-http',
       common_archive,
       'casual-common',
       'casual-domain-unittest',
+      'casual-service-unittest',
       'casual-unittest',
       'casual-xatmi',
       'casual-domain-discovery',

--- a/middleware/http/source/outbound/main.cpp
+++ b/middleware/http/source/outbound/main.cpp
@@ -50,8 +50,8 @@ namespace casual
                   common::message::service::concurrent::Advertise message{ process::handle()};
                   message.alias = instance::alias();
 
-                  // highest possible order
-                  message.order = std::numeric_limits< std::decay_t< decltype( message.order)>>::max();
+                  // lowest possible order
+                  message.order = 0;
 
                   algorithm::transform( state.lookup, message.services.add, []( auto& l){
                      message::service::concurrent::advertise::Service service;

--- a/middleware/http/unittest/source/test_outbound.cpp
+++ b/middleware/http/unittest/source/test_outbound.cpp
@@ -15,6 +15,7 @@
 
 #include "domain/unittest/manager.h"
 #include "domain/discovery/api.h"
+#include "service/unittest/utility.h"
 
 
 #include "casual/xatmi.h"
@@ -47,6 +48,8 @@ http:
       -  name: discard/transaction
          url: a.example/discard/transaction
          discard_transaction: true
+      -  name: foo
+         url: foo.example
 
 )");
                   common::environment::variable::set( "CASUAL_UNITTEST_HTTP_CONFIGURATION", result.string());
@@ -107,6 +110,19 @@ domain:
          EXPECT_TRUE( tx_rollback() == TX_OK);
 
          tpfree( buffer);
+      }
+
+      TEST( http_outbound, service_instance_order)
+      {
+         common::unittest::Trace trace;
+         local::Domain domain;
+
+         auto state = casual::service::unittest::state();
+         auto service = common::algorithm::find( state.services, "foo");
+         ASSERT_TRUE( service);
+         auto& instance = service->instances.concurrent.at( 0);
+         EXPECT_TRUE( instance.order == 0);
+         EXPECT_TRUE( instance.hops == 0);
       }
 
       TEST( http_outbound, in_transaction_call_discard__expect_rollback)

--- a/middleware/queue/source/group/queuebase.cpp
+++ b/middleware/queue/source/group/queuebase.cpp
@@ -194,6 +194,10 @@ namespace casual
          // Make sure we set WAL-mode.
          m_connection.statement( "PRAGMA journal_mode=WAL;");
 
+         log::line( verbose::log, "pre_statements_path: ", m_connection.pre_statements_path());
+         m_connection.pre_statements( log::category::information);
+
+
          {
             Trace trace{ "queue::group::Queuebase::Queuebase create table queue"};
          
@@ -226,8 +230,14 @@ namespace casual
       {
          Trace trace{ "queue::group::Queuebase::~Queuebase"};
 
-         if( m_connection)
+         if( ! m_connection)
+            return;
+
+         common::exception::guard( [ this]()
+         {
             m_connection.commit();
+            m_connection.post_statements( log::category::information);
+         });
       }
 
       const std::filesystem::path& Queuebase::file() const

--- a/middleware/queue/unittest/source/group/test_queuebase.cpp
+++ b/middleware/queue/unittest/source/group/test_queuebase.cpp
@@ -12,6 +12,7 @@
 #include "common/environment.h"
 #include "common/chronology.h"
 #include "common/buffer/type.h"
+#include "common/unittest/file.h"
 
 
 namespace casual
@@ -777,6 +778,38 @@ namespace casual
 
          auto restored = database.restore( queue.id);
          EXPECT_TRUE( restored == 0) << "restored: " << restored;
+      }
+
+      TEST( casual_queue_group_database, pre_statements)
+      {
+         common::unittest::Trace trace;
+
+         auto directory = common::unittest::directory::temporary::Scoped{};
+
+         auto content = common::unittest::file::content( directory.path() / "a.pre.statements", R"(
+PRAGMA foreign_keys;
+PRAGMA journal_mode;
+)");
+
+         EXPECT_NO_THROW( 
+            group::Queuebase database( directory.path() / "a.qb"))
+         ;
+      }
+
+      TEST( casual_queue_group_database, post_statements)
+      {
+         common::unittest::Trace trace;
+
+         auto directory = common::unittest::directory::temporary::Scoped{};
+
+         auto content = common::unittest::file::content( directory.path() / "a.post.statements", R"(
+PRAGMA foreign_keys;
+PRAGMA journal_mode;
+)");
+
+         EXPECT_NO_THROW( 
+            group::Queuebase database( directory.path() / "a.qb"))
+         ;
       }
 
       TEST( casual_queue_group_database, restore__1_message_in_error_queue__expect_1_affected)

--- a/middleware/service/include/service/manager/admin/model.h
+++ b/middleware/service/include/service/manager/admin/model.h
@@ -114,11 +114,13 @@ namespace casual
             struct Concurrent
             {
                common::strong::process::id pid;
-               platform::size::type hops;
+               platform::size::type hops{};
+               platform::size::type order{};
 
                CASUAL_CONST_CORRECT_SERIALIZE(
                   CASUAL_SERIALIZE( pid);
                   CASUAL_SERIALIZE( hops);
+                  CASUAL_SERIALIZE( order);
                )
             };
 

--- a/middleware/service/include/service/manager/state.h
+++ b/middleware/service/include/service/manager/state.h
@@ -136,7 +136,7 @@ namespace casual
             {
                using base_instance::base_instance;
                
-               platform::size::type order;
+               platform::size::type order{};
                
                friend bool operator < ( const Concurrent& lhs, const Concurrent& rhs);
 

--- a/middleware/service/source/manager/transform.cpp
+++ b/middleware/service/source/manager/transform.cpp
@@ -50,6 +50,7 @@ namespace casual
                   manager::admin::model::instance::Concurrent result;
 
                   result.process = instance.process;
+                  
 
                   return result;
                }
@@ -112,7 +113,8 @@ namespace casual
                   {
                      return manager::admin::model::service::instance::Concurrent{
                         value.process().pid,
-                        value.property.hops
+                        value.property.hops,
+                        value.get().order
                      };
                   };
 


### PR DESCRIPTION
We now take routes for services into account during discovery. This is
done by splitting _internal_ and _external_ discoveries into two phases.

* first we ask internal providers (service-manager) for what is found
  _internal_, and also get _route-mapping_, for routes
* We take the difference between _wanted_ and services found _internal_.
  For each service we map the _route-name_ (if any) and use this for
  _external_ discovery.
* When we get the _external_ replies, we map the names back to the
  requested names.And send the reply with aggregated discoveries to the
  origin requester.

Verified with a few unittests.