### PR TITLE
service - add lookup restrictions depending on caller location

### DIFF
--- a/middleware/common/include/common/server/handle/service.h
+++ b/middleware/common/include/common/server/handle/service.h
@@ -161,8 +161,7 @@ namespace casual
          // - commit/rollback transaction if service has "auto-transaction"
          auto execute_transaction = execute::scope( [&]()
          {
-            reply.transaction = policy.transaction(
-                  reply.transaction.state == message::service::Transaction::State::active);
+            reply.transaction = policy.transaction( reply.transaction.state == decltype( reply.transaction.state)::active);
          });
 
          // Nothing did go wrong

--- a/middleware/common/include/common/service/lookup.h
+++ b/middleware/common/include/common/service/lookup.h
@@ -22,9 +22,9 @@ namespace casual
       {
          struct Lookup
          {
-            using Context = message::service::lookup::Request::Context;
+            using Context = message::service::lookup::request::Context;
             using Reply = message::service::lookup::Reply;
-            using State = Reply::State;
+            using State = message::service::lookup::reply::State;
 
             Lookup() noexcept;
                            

--- a/middleware/common/source/server/handle/policy.cpp
+++ b/middleware/common/source/server/handle/policy.cpp
@@ -202,7 +202,7 @@ namespace casual
 
                   common::service::Lookup lookup{
                      forward.parameter.service.name,
-                     common::service::Lookup::Context::forward};
+                     decltype( common::service::Lookup::Context::semantic)::forward};
 
                   auto request = message;
 

--- a/middleware/common/source/server/handle/service.cpp
+++ b/middleware/common/source/server/handle/service.cpp
@@ -125,12 +125,12 @@ namespace casual
 
             if( result.transaction == common::service::invoke::Result::Transaction::commit)
             {
-               reply.transaction.state = message::service::Transaction::State::active;
+               reply.transaction.state = decltype( reply.transaction.state)::active;
                reply.code.result = code::xatmi::ok;
             }
             else
             {
-               reply.transaction.state = message::service::Transaction::State::rollback;
+               reply.transaction.state = decltype( reply.transaction.state)::rollback;
                reply.code.result = code::xatmi::service_fail;
             }
 

--- a/middleware/common/source/service/call/context.cpp
+++ b/middleware/common/source/service/call/context.cpp
@@ -65,8 +65,10 @@ namespace casual
                   {
                      // if no-reply we treat it as a _forward-call_, and we'll not block until the service is idle.
                      // Hence, it's a fire-and-forget message.
-                     return flags.exist( call::async::Flag::no_reply) ?
-                        message::service::lookup::Request::Context::forward : message::service::lookup::Request::Context::regular;
+
+                     message::service::lookup::request::Context context;
+                     context.semantic = flags.exist( call::async::Flag::no_reply) ? decltype( context.semantic)::forward : decltype( context.semantic)::regular;
+                     return context;
                   };
 
                   if( auto& current = common::transaction::Context::instance().current())

--- a/middleware/common/source/service/lookup.cpp
+++ b/middleware/common/source/service/lookup.cpp
@@ -31,7 +31,7 @@ namespace casual
          }
 
          Lookup::Lookup( std::string service, std::optional< platform::time::point::type> deadline) 
-            : Lookup( std::move( service), Context::regular, std::move( deadline)) 
+            : Lookup( std::move( service), Context{}, std::move( deadline)) 
          {}
 
          Lookup::~Lookup()

--- a/middleware/common/source/transaction/context.cpp
+++ b/middleware/common/source/transaction/context.cpp
@@ -559,7 +559,7 @@ namespace casual
 
             message::service::Transaction result;
             result.trid = std::move( caller);
-            result.state = message::service::Transaction::State::active;
+            result.state = message::service::transaction::State::active;
 
             auto pending_check = [&]( Transaction& transaction)
             {
@@ -571,7 +571,7 @@ namespace casual
                      log::line( log::category::transaction, transaction);
 
                      transaction.state = Transaction::State::rollback;
-                     result.state = message::service::Transaction::State::error;
+                     result.state = message::service::transaction::State::error;
                   }
 
                   // Discard pending
@@ -590,7 +590,7 @@ namespace casual
                }
                catch( ...)
                {
-                  result.state = message::service::Transaction::State::error;
+                  result.state = message::service::transaction::State::error;
                   log::line( log::category::error, exception::capture(), " failed to rollback transaction: ", transaction.trid);
                }
             };
@@ -605,7 +605,7 @@ namespace casual
                   }
                   catch( ...)
                   {
-                     result.state = message::service::Transaction::State::error;
+                     result.state = message::service::transaction::State::error;
                      log::line( log::category::error, exception::capture(), " failed to commit transaction: ", transaction.trid);
                   } 
                }
@@ -645,10 +645,10 @@ namespace casual
                auto transform_state = []( Transaction::State state){
                   switch( state)
                   {
-                     case Transaction::State::active: return message::service::Transaction::State::active;
-                     case Transaction::State::rollback: return message::service::Transaction::State::rollback;
-                     case Transaction::State::timeout: return message::service::Transaction::State::timeout;
-                     default: return message::service::Transaction::State::error;
+                     case Transaction::State::active: return message::service::transaction::State::active;
+                     case Transaction::State::rollback: return message::service::transaction::State::rollback;
+                     case Transaction::State::timeout: return message::service::transaction::State::timeout;
+                     default: return message::service::transaction::State::error;
                   }
                };
 
@@ -658,8 +658,8 @@ namespace casual
 
                   result.state = transform_state( not_owner->state);
 
-                  if( ! commit && result.state == message::service::Transaction::State::active)
-                     result.state = message::service::Transaction::State::rollback;
+                  if( ! commit && result.state == message::service::transaction::State::active)
+                     result.state = message::service::transaction::State::rollback;
 
                   // end resource
                   local::resources::end::invoke( local::resources::end::policy::Success{}, *not_owner, m_resources.all);                  

--- a/middleware/common/source/unittest.cpp
+++ b/middleware/common/source/unittest.cpp
@@ -49,7 +49,7 @@ namespace casual
             {
                common::message::service::lookup::Request request{ process::handle()};
                request.requested = std::move( service);
-               request.context = decltype( request.context)::no_busy_intermediate;
+               request.context.semantic = decltype( request.context.semantic)::no_busy_intermediate;
                communication::device::blocking::send( communication::instance::outbound::service::manager::device(), request);
             }
             

--- a/middleware/common/unittest/source/communication/test_ipc.cpp
+++ b/middleware/common/unittest/source/communication/test_ipc.cpp
@@ -321,7 +321,7 @@ namespace casual
             message.correlation = strong::correlation::id::emplace( uuid::make());
             message.execution = strong::execution::id::emplace( uuid::make());
             message.transaction.trid = transaction::id::create( process::handle());
-            message.transaction.state = common::message::service::Transaction::State::rollback;
+            message.transaction.state = decltype( message.transaction.state)::rollback;
             message.buffer.type = ".binary";
             message.code.result = common::code::xatmi::ok;
             message.code.user = 0;

--- a/middleware/common/unittest/source/message/test_pending.cpp
+++ b/middleware/common/unittest/source/message/test_pending.cpp
@@ -64,7 +64,7 @@ namespace casual
                message::service::lookup::Request message;
 
                message.process = common::process::handle();
-               message.context = decltype( message.context)::forward;
+               message.context.semantic = decltype( message.context.semantic)::forward;
                message.requested = "foo";
 
                return message;

--- a/middleware/event/unittest/source/test_dispatch.cpp
+++ b/middleware/event/unittest/source/test_dispatch.cpp
@@ -158,7 +158,7 @@ domain:
             {
                common::message::service::lookup::Request request{ common::process::handle()};
                request.requested = ".casual/domain/state";
-               request.context = decltype( request.context)::no_busy_intermediate;
+               request.context.semantic = decltype( request.context.semantic)::no_busy_intermediate;
 
                return common::communication::device::async::call( 
                   common::communication::instance::outbound::service::manager::device(),

--- a/middleware/gateway/source/documentation/protocol/example.cpp
+++ b/middleware/gateway/source/documentation/protocol/example.cpp
@@ -176,7 +176,7 @@ namespace casual
             message.code.result = common::code::xatmi::service_fail;
             message.code.user = 42;
             message.transaction.trid = local::trid();
-            message.transaction.state = common::message::service::Transaction::State::active;
+            message.transaction.state = decltype( message.transaction.state)::active;
 
             message.buffer.type = ".binary/";
             message.buffer.memory = local::binary::value( 128);

--- a/middleware/queue/source/forward/handle.cpp
+++ b/middleware/queue/source/forward/handle.cpp
@@ -468,7 +468,7 @@ namespace casual
                            request.correlation = pending.correlation;
                            request.requested = forward->target.service;
                            // we'll wait 'forever'
-                           request.context = decltype( request.context)::wait;
+                           request.context.semantic = decltype( request.context.semantic)::wait;
 
                            ipc::flush::send( ipc::service::manager(), request);
 

--- a/middleware/service/include/service/manager/state.h
+++ b/middleware/service/include/service/manager/state.h
@@ -342,11 +342,19 @@ namespace casual
 
             void add( state::instance::Sequential& instance);
             void add( state::instance::Concurrent& instance, state::service::instance::Concurrent::Property property);
-            
-            //! @return a reserved instance or 'null-handle' if no one is found.
-            common::process::Handle reserve( 
+
+            inline bool sequential() const noexcept { return ! instances.sequential.empty();}
+
+            common::process::Handle reserve_sequential( 
                const common::process::Handle& caller, 
                const common::strong::correlation::id& correlation);
+            
+            //! @return a reserved instance or 'null-handle' if no one is found.
+            common::process::Handle reserve_concurrent( 
+               const common::process::Handle& caller, 
+               const common::strong::correlation::id& correlation);
+
+
 
             bool timeoutable() const noexcept;
 

--- a/middleware/service/source/forward/handle.cpp
+++ b/middleware/service/source/forward/handle.cpp
@@ -64,7 +64,7 @@ namespace casual
                         Trace trace{ "service::forward::handle::local::service::name::lookup::reply"};
                         log::line( verbose::log, "message: ", message);
 
-                        if( message.state == message::service::lookup::Reply::State::busy)
+                        if( message.state == decltype( message.state)::busy)
                         {
                            log::line( log, "service is busy - action: wait for idle");
                            return;
@@ -115,7 +115,7 @@ namespace casual
                            message::service::lookup::Request request{ process::handle()};
                            request.requested = message.service.name;
                            request.correlation = message.correlation;
-                           request.context = decltype( request.context)::no_busy_intermediate;
+                           request.context.semantic = decltype( request.context.semantic)::no_busy_intermediate;
                            state.multiplex.send( communication::instance::outbound::service::manager::device(), request);
                         }
 

--- a/middleware/service/unittest/source/manager/test_manager.cpp
+++ b/middleware/service/unittest/source/manager/test_manager.cpp
@@ -518,7 +518,7 @@ domain:
             auto service = common::service::Lookup{ "service1"}();
             EXPECT_TRUE( service.service.name == "service1");
             EXPECT_TRUE( service.process == common::process::handle());
-            EXPECT_TRUE( service.state == decltype( service)::State::idle);
+            EXPECT_TRUE( service.state == decltype( service.state)::idle);
          }
 
          {
@@ -526,7 +526,7 @@ domain:
             EXPECT_TRUE( service.service.name == "service2");
 
             // we only have one instance, we expect this to be busy
-            EXPECT_TRUE( service.state == decltype( service)::State::busy);
+            EXPECT_TRUE( service.state == decltype( service.state)::busy);
          }
       }
 
@@ -574,7 +574,7 @@ domain:
             auto service = common::service::Lookup{ "service1"}();
             EXPECT_TRUE( service.service.name == "service1");
             EXPECT_TRUE( service.process == common::process::handle());
-            EXPECT_TRUE( service.state == decltype( service)::State::idle);
+            EXPECT_TRUE( service.state == decltype( service.state)::idle);
          }
 
          common::service::Lookup lookup{ "service2"};
@@ -583,7 +583,7 @@ domain:
             EXPECT_TRUE( service.service.name == "service2");
 
             // we only have one instance, we expect this to be busy
-            EXPECT_TRUE( service.state == decltype( service)::State::busy);
+            EXPECT_TRUE( service.state == decltype( service.state)::busy);
          }
 
          {
@@ -600,7 +600,7 @@ domain:
             // get next pending reply
             auto service = lookup();
 
-            EXPECT_TRUE( service.state == decltype( service)::State::idle);
+            EXPECT_TRUE( service.state == decltype( service.state)::idle);
          }
       }
 
@@ -619,17 +619,17 @@ domain:
             auto service = common::service::Lookup{ "service1"}();
             EXPECT_TRUE( service.service.name == "service1");
             EXPECT_TRUE( service.process == common::process::handle());
-            EXPECT_TRUE( service.state == decltype( service)::State::idle);
+            EXPECT_TRUE( service.state == decltype( service.state)::idle);
          }
 
 
          {
-            common::service::Lookup lookup{ "service1", common::service::Lookup::Context::forward};
+            common::service::Lookup lookup{ "service1", decltype(common::service::Lookup::Context::semantic)::forward};
             auto service = lookup();
             EXPECT_TRUE( service.service.name == "service1");
 
             // service-manager will let us think that the service is idle, and send us the process-handle to the forward-cache
-            EXPECT_TRUE( service.state == decltype( service)::State::idle);
+            EXPECT_TRUE( service.state == decltype( service.state)::idle);
             EXPECT_TRUE( service.process);
             EXPECT_TRUE( service.process == forward);
          }
@@ -648,7 +648,7 @@ domain:
             auto service = common::service::Lookup{ "service1"}();
             EXPECT_TRUE( service.service.name == "service1");
             EXPECT_TRUE( service.process == common::process::handle());
-            EXPECT_TRUE( service.state == decltype( service)::State::idle);
+            EXPECT_TRUE( service.state == decltype( service.state)::idle);
             
             return service.correlation;
          }();
@@ -864,7 +864,7 @@ domain:
             auto service = common::service::Lookup{ "service1"}();
             EXPECT_TRUE( service.service.name == "service1");
             EXPECT_TRUE( service.process == common::process::handle());
-            EXPECT_TRUE( service.state == decltype( service)::State::idle);
+            EXPECT_TRUE( service.state == decltype( service.state)::idle);
          }
 
          // subscribe to metric event
@@ -942,7 +942,7 @@ domain:
          {
             common::message::service::lookup::Request message{ common::process::handle()};
             message.requested = "a";
-            message.context = decltype( message.context)::wait;
+            message.context.semantic = decltype( message.context.semantic)::wait;
 
             correlation = local::send( message);
          }
@@ -977,7 +977,7 @@ domain:
          {
             common::message::service::lookup::Request message{ common::process::handle()};
             message.requested = "a";
-            message.context = decltype( message.context)::wait;
+            message.context.semantic = decltype( message.context.semantic)::wait;
             return message;
          };
 

--- a/middleware/tools/source/service/call/cli.cpp
+++ b/middleware/tools/source/service/call/cli.cpp
@@ -124,14 +124,13 @@ namespace casual
             {
                namespace detail
                {
-                  auto lookup( const std::string& service)
+                  auto lookup( std::string service)
                   {
                      Trace trace{ "tools::service::call::local::handle::detail::lookup"};
 
                      common::message::service::lookup::Request request{ process::handle()};
-                     request.requested = service;
-                     // we will wait 'for ever'.
-                     request.context = decltype( request.context)::no_busy_intermediate;
+                     request.requested = std::move( service);
+                     request.context.semantic = decltype( request.context.semantic)::no_busy_intermediate;
                      auto correlation = local::flush::send( communication::instance::outbound::service::manager::device(), request);
 
                      auto reply = common::message::reverse::type( request);

--- a/test/unittest/source/test_service.cpp
+++ b/test/unittest/source/test_service.cpp
@@ -10,6 +10,10 @@
 
 #include "service/unittest/utility.h"
 
+#include "gateway/unittest/utility.h"
+
+#include "common/communication/instance.h"
+
 
 
 namespace casual
@@ -37,6 +41,8 @@ domain:
       -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager"
          memberships: [ base]
       -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/casual-transaction-manager"
+         memberships: [ base]
+      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/gateway/bin/casual-gateway-manager"
          memberships: [ base]
    
 )";
@@ -136,6 +142,110 @@ domain:
             EXPECT_TRUE( service->instances.sequential.size() == 1) << CASUAL_NAMED_VALUE( service->instances.sequential);
             EXPECT_TRUE( service->instances.concurrent.empty());
          }
+      }
+
+      namespace local
+      {
+         namespace
+         {
+            auto lookup = []( auto service, auto context)
+            {
+               auto& manager = communication::instance::outbound::service::manager::device();
+               casual::message::service::lookup::Request request( process::handle());
+               request.context = context;
+               request.requested = service;
+
+               auto reply = communication::ipc::call( manager, request);
+
+               // discard the lookup
+               {
+                  common::message::service::lookup::discard::Request message{ process::handle()};
+                  message.correlation = reply.correlation;
+                  message.reply = false;
+                  communication::device::blocking::send( manager, message);
+               }
+
+               return reply;
+            };
+            
+         } // <unnamed>
+      } // local
+
+      TEST( test_service, lookup_restriction_depending_on_where_the_lookup_comes_from)
+      {
+         common::unittest::Trace trace;
+
+
+         auto b = casual::domain::unittest::manager( local::configuration::base, R"(
+domain: 
+   name: B
+   servers:         
+      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+         memberships: [ user]
+   services:
+      -  name: casual/example/echo
+         routes: [ b]
+   gateway:
+      inbound:
+         groups:
+            -  connections:
+                  -  address: 127.0.0.1:7010
+)");
+
+         auto a = casual::domain::unittest::manager( local::configuration::base, R"(
+domain: 
+   name: A
+   servers:         
+      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+         memberships: [ user]
+   services:
+      -  name: casual/example/echo
+         routes: [ a]
+   gateway:
+      outbound:
+         groups:
+            -  connections:
+                  -  address: 127.0.0.1:7010
+)");
+         auto state = gateway::unittest::fetch::until( gateway::unittest::fetch::predicate::outbound::connected( 1));
+
+         // internal
+         {
+            casual::message::service::lookup::request::Context context;
+            context.requester = decltype( context.requester)::internal;
+            auto reply = local::lookup( "b", context);
+            EXPECT_TRUE( reply.state == decltype( reply.state)::idle);
+         }
+
+         // external
+         {
+            casual::message::service::lookup::request::Context context;
+            context.requester = decltype( context.requester)::external;
+            // remote service - absent
+            auto reply = local::lookup( "b", context);
+            EXPECT_TRUE( reply.state == decltype( reply.state)::absent);
+            // local service
+            reply = local::lookup( "a", context);
+            EXPECT_TRUE( reply.state == decltype( reply.state)::idle);
+         }
+
+         // external with discover forward
+         {
+            casual::message::service::lookup::request::Context context;
+            context.requester = decltype( context.requester)::external_discovery;
+
+            {
+               // local service
+               auto reply = local::lookup( "a", context);
+               EXPECT_TRUE( reply.state == decltype( reply.state)::idle);
+            }
+            {
+               // remote service - idle (found)
+               auto reply = local::lookup( "b", context);
+               EXPECT_TRUE( reply.state == decltype( reply.state)::idle);
+            }
+         }
+
       }
 
    } // test::domain::service


### PR DESCRIPTION
We take three "locations" in consideration:

* 'local': the lookup is done from within the domain, some client, och
  server instigate the lookup.
   * local services: OK
   * remote services: OK
   * unknown services (does a discover): OK
* 'external': the lookup is done by an inbound
   * local services: OK
   * remote services: _no-ent_
   * unknown services: _no-ent_
* 'external-with-forward-discovery': the lookup is done by an inbound
  that has `discovery.forward=true` configured.
   * local services: OK
   * remote services: OK
   * unknown services: _no-ent_