### PR TITLE
http - outbound configuration to control caller fresh connect

### DIFF
--- a/middleware/common/unittest/source/test_environment.cpp
+++ b/middleware/common/unittest/source/test_environment.cpp
@@ -16,6 +16,25 @@ namespace casual
 {
    namespace common
    {
+      TEST( common_environment_variable_type, boolean_default)
+      {
+         common::unittest::Trace trace;
+
+         EXPECT_TRUE( ! environment::variable::get( "SOME_VARIABLE", false));
+         EXPECT_TRUE( environment::variable::get( "SOME_VARIABLE", true));
+      }
+
+      TEST( common_environment_variable_type, boolean)
+      {
+         common::unittest::Trace trace;
+
+         environment::variable::set( "SOME_VARIABLE_5b54338bc2704", true);
+         EXPECT_TRUE( environment::variable::get< bool>( "SOME_VARIABLE_5b54338bc2704"));
+
+         environment::variable::set( "SOME_VARIABLE_5b54338bc2704", false);
+         EXPECT_TRUE( ! environment::variable::get< bool>( "SOME_VARIABLE_5b54338bc2704"));
+      }
+
       TEST( common_environment, string__no_variable__expect_same)
       {
          common::unittest::Trace trace;

--- a/middleware/http/documentation/outbound/configuration.operation.md
+++ b/middleware/http/documentation/outbound/configuration.operation.md
@@ -28,5 +28,11 @@ http:
           value: some-header-value
 
 
-
 ```
+
+## environments
+
+name                                   | type    | default | description  
+---------------------------------------|---------|---------|------------------------------------------------------------------------------------
+`CASUAL_HTTP_CURL_FORCE_FRESH_CONNECT` | `bool`  | `false` | force a new connection for every call
+`CASUAL_HTTP_CURL_VERBOSE`             | `bool`  | `false` | internal "verbose" logging from cURL 


### PR DESCRIPTION
set CASUAL_HTTP_CURL_FORCE_FRESH_CONNECT to "true" or "false", to
enforce.