### PR TITLE
Feature/1.5/conversation service exit problem

### DIFF
--- a/middleware/common/include/common/service/conversation/context.h
+++ b/middleware/common/include/common/service/conversation/context.h
@@ -52,6 +52,15 @@ namespace casual
             {
                using Flag = flag::service::conversation::send::Flag;
                using Flags = flag::service::conversation::send::Flags;
+               struct Result
+               {
+                  common::Flags< Event> event;
+                  long user = 0;
+                  CASUAL_LOG_SERIALIZE(
+                     CASUAL_SERIALIZE( event);
+                     CASUAL_SERIALIZE( user);
+                  )
+               };
             } // send
 
             namespace receive
@@ -62,10 +71,12 @@ namespace casual
                struct Result
                {
                   common::Flags< Event> event;
+                  long user = 0;
                   common::buffer::Payload buffer;
 
                   CASUAL_LOG_SERIALIZE(
                      CASUAL_SERIALIZE( event);
+                     CASUAL_SERIALIZE( user);
                      CASUAL_SERIALIZE( buffer);
                   )
                };
@@ -79,7 +90,7 @@ namespace casual
 
                strong::conversation::descriptor::id connect( const std::string& service, common::buffer::payload::Send buffer, connect::Flags flags);
 
-               common::Flags< Event> send( strong::conversation::descriptor::id descriptor, common::buffer::payload::Send&& buffer, common::Flags< send::Flag> flags);
+               send::Result send( strong::conversation::descriptor::id descriptor, common::buffer::payload::Send&& buffer, common::Flags< send::Flag> flags);
 
                receive::Result receive( strong::conversation::descriptor::id descriptor, common::Flags< receive::Flag> flags);
 

--- a/middleware/configuration/include/configuration/model.h
+++ b/middleware/configuration/include/configuration/model.h
@@ -13,6 +13,7 @@
 
 #include <vector>
 #include <string>
+#include <optional>
 #include <filesystem>
 
 namespace casual::configuration

--- a/middleware/configuration/include/configuration/model.h
+++ b/middleware/configuration/include/configuration/model.h
@@ -13,7 +13,6 @@
 
 #include <vector>
 #include <string>
-#include <optional>
 #include <filesystem>
 
 namespace casual::configuration

--- a/middleware/example/server/source/example.cpp
+++ b/middleware/example/server/source/example.cpp
@@ -248,6 +248,18 @@ namespace casual
                   tpreturn( TPFAIL, 0, nullptr, 0, 0);
                }
 
+               if( recent_data.find("execute exit") != std::string::npos)
+               {
+                  // A "hack"for testing purposes.
+                  // Force the server to exit. The intention is that this 
+                  // "emulates" the case that service code causes a fatal error
+                  // forces an exit of the server process. I.e. no return
+                  // to the Casual code. I expect caller to get a TPSVCERR in 
+                  // this case. 
+                  log::line(log::debug, "casual_example_conversation_recv_send requested to execute \"exit\"");
+                  exit(1);
+               }
+
                if( recent_data.find("execute return") != std::string::npos)
                {
                   // Also a "hack"for testing purposes.

--- a/test/unittest/source/xatmi/test_call.cpp
+++ b/test/unittest/source/xatmi/test_call.cpp
@@ -310,13 +310,8 @@ domain:
          EXPECT_TRUE( tx_rollback() == TX_OK);
       }
 
-      // Test disabled for now. There seems to be a somewhat generic "bug"
-      // in casual related to reporting an error because of
-      // illegal flags. Discovered while adding tests for conversational.
-      // Added this test for ordinary tpcall services, and the same
-      // problem appears. Invalid flags should give TPEINVAL, but gives
-      // TPESYSTEM. Possibly related to the exception raised in Flags::convert().
-      TEST( test_xatmi_call, DISABLED_tpcall_service_echo_invalid_flag__expect_TPEINVAL)
+      // Test with invalid arguments. Invalid flags should give TPEINVAL.
+      TEST( casual_xatmi, tpcall_service_echo_invalid_flag__expect_TPEINVAL)
       {
          common::unittest::Trace trace;
 
@@ -324,8 +319,34 @@ domain:
 
          auto buffer = local::allocate( 128);
          auto len = tptypes( buffer, nullptr, nullptr);
+         // TPSENDONLY is an invalid flag to tpcall. There are many more
+         // possible invalid arguments or flags and we try some of them.
+         EXPECT_TRUE( tpcall( "casual/example/echo", buffer, 128, &buffer, &len, TPSENDONLY) == -1);
+         EXPECT_TRUE( tperrno == TPEINVAL) << "tperrno: " << tperrnostring( tperrno);
 
-         EXPECT_TRUE( tpcall( "casual/example/echo", buffer, 128, &buffer, &len, 0) == -1);
+         EXPECT_TRUE( tpcall( "casual/example/echo", buffer, 128, &buffer, &len, TPRECVONLY) == -1);
+         EXPECT_TRUE( tperrno == TPEINVAL) << "tperrno: " << tperrnostring( tperrno);
+
+         EXPECT_TRUE( tpcall( "casual/example/echo", buffer, 128, &buffer, &len, TPSENDONLY|TPRECVONLY) == -1);
+         EXPECT_TRUE( tperrno == TPEINVAL) << "tperrno: " << tperrnostring( tperrno);
+
+         EXPECT_TRUE( tpcall( "casual/example/echo", buffer, 128, &buffer, &len, TPRECVONLY) == -1);
+         EXPECT_TRUE( tperrno == TPEINVAL) << "tperrno: " << tperrnostring( tperrno);
+
+         EXPECT_TRUE( tpcall( "casual/example/echo", buffer, 128, &buffer, &len, TPTRAN) == -1);
+         EXPECT_TRUE( tperrno == TPEINVAL) << "tperrno: " << tperrnostring( tperrno);
+
+         EXPECT_TRUE( tpcall( "casual/example/echo", buffer, 128, &buffer, &len, TPNOREPLY) == -1);
+         EXPECT_TRUE( tperrno == TPEINVAL) << "tperrno: " << tperrnostring( tperrno);
+
+         EXPECT_TRUE( tpcall( "casual/example/echo", buffer, 128, &buffer, &len, TPGETANY) == -1);
+         EXPECT_TRUE( tperrno == TPEINVAL) << "tperrno: " << tperrnostring( tperrno);
+
+         EXPECT_TRUE( tpcall( "casual/example/echo", buffer, 128, &buffer, &len, TPCONV) == -1);
+         EXPECT_TRUE( tperrno == TPEINVAL) << "tperrno: " << tperrnostring( tperrno);
+
+         // nullptr for service name
+         EXPECT_TRUE( tpcall( nullptr, buffer, 128, &buffer, &len, 0) == -1);
          EXPECT_TRUE( tperrno == TPEINVAL) << "tperrno: " << tperrnostring( tperrno);
 
          tpfree( buffer);

--- a/test/unittest/source/xatmi/test_conversation.cpp
+++ b/test/unittest/source/xatmi/test_conversation.cpp
@@ -886,7 +886,7 @@ domain:
          // can "disconnect" it. Closest possibility in server side is
          // tpreturn with TPFAIL.)
          // According to the XATMI spec a tpsend (in the initiator) should get
-         // either TPEV_SVCFAIL or TPEVSVCERR in this case. Another
+         // either TPEV_SVCFAIL or TPEV_SVCERR in this case. Another
          // possiblity is of course success on the send if it is not yet
          // known that the subordinate has done a tpreturn. In that case
          // the next call will get the notification (can be a tpsend or
@@ -903,20 +903,13 @@ domain:
          //    control of the conversation
          // 3. (callee will do a tpreturn)
          // 4. short sleep
-         // 5. tpsend, hand over control
-         // 6. tprecv
+         // 5. tpsend, attempt to hand over control, expect SVCFAIL
+         // 6. tpdiscon (expected to fail)
          //
-         // In the above scenario (5) currently succeeds and (6)
-         // gives the TPEV_SVCFAIL. Seems as if caller Casual does not process
-         // the conversation_send sent by the tpreturn until tprecv is called.
-         // More tpsend() calls inserted at (5) also succeeds! This strengthens
-         // the hypothesis that incoming messages are not processed until the
-         // tprecv is called.
-         // The casual log includes an entry with:
-         // error|[casual:internal-unexpected-value] message type: conversation_send not recognized - action: discard
-         // This is presumably from the message that was sent from initiator
-         // is generated when the message is processed by the server after the
-         // service tpreturn().
+         // In the above scenario (5) currently returns TPV_SVCFAIL and (6)
+         // gives an error. In earler versions of Casual the tpsend succeded
+         // and an error was reported on a tprecv (now removed) that was
+         // done after (5).
 
          const std::string_view payload {"connect data"};
          auto connection = local::connect::invoke( "casual/example/conversation_recv_send", payload, TPSENDONLY);
@@ -938,30 +931,11 @@ domain:
             EXPECT_TRUE( result.retval == -1) << CASUAL_NAMED_VALUE( result);
             EXPECT_TRUE( result.error == TPEEVENT) << CASUAL_NAMED_VALUE( result);
             EXPECT_TRUE( result.event == TPEV_SVCFAIL) << CASUAL_NAMED_VALUE( result);
-         }
-
-         // The following is in the test code because an earlier
-         // version did not report an error on the tpsend above!
-         // With that version of Casual the send succeded and the
-         // event TPEV_SVCFAIL finally occured on the tprecv.
-         {
-            // If the previous send got an event TPEV_SVCFAIL
-            // this should fail with TPEBADDESC.
-            std::string send_data {" send data and handover"};
-            auto result = local::send::invoke ( connection.descriptor, send_data, TPSIGRSTRT|TPRECVONLY);
-            EXPECT_TRUE( result.retval == -1) << CASUAL_NAMED_VALUE(result);
-            EXPECT_TRUE( result.error == TPEBADDESC) << CASUAL_NAMED_VALUE(result);
-         }
-
-         {
-            // A receive should fail in some way as the callee terminated
-            // the conversation.
-            auto result = local::receive::invoke( connection.descriptor, TPSIGRSTRT);
-            EXPECT_TRUE( result.retval == -1) << CASUAL_NAMED_VALUE(result);
-            EXPECT_TRUE( result.error == TPEBADDESC) << CASUAL_NAMED_VALUE(result);
+            EXPECT_TRUE( result.user == 2) << CASUAL_NAMED_VALUE( result);
          }
 
          // and the conversation descriptor should now be invalid
+         // as the SVCFAIL terminated the conversation
          EXPECT_TRUE( tpdiscon( connection.descriptor) == -1);
 
 #ifdef HANG_WORKAROUND
@@ -969,7 +943,9 @@ domain:
 #endif
       }
 
-      TEST( casual_xatmi_conversation, DISABLED_connect_send_TPSENDONLY_service_tpreturn_with_data_send__conversation_recv_send_service)
+      // Currently disabled. The (5) tpsend incorrectly gets a TPEC_SVCFAIL
+      // instead of TPEV_SVCERR. This is a bug that need fixing. 
+      TEST( test_xatmi_conversation, DISABLED_connect_send_TPSENDONLY_service_tpreturn_with_data_send__conversation_recv_send_service)
       {
          common::unittest::Trace trace;
 
@@ -977,14 +953,13 @@ domain:
          // This test is similiar to the previous test.
          //
          // 1. connect with data, TPSENDONLY
-         // 2. send data, including a substring 
+         // 2. send data, including a substring
          //    "execute tpreturn TPFAIL with data".
          //    Keep control of the conversation
          // 3. (callee will do a tpreturn)
          // 4. short sleep
          // 5. tpsend, hand over control (expected to fail...)
-         // 6. tprecv (expected to fail)
-         //
+         // 6. tpdiscon, expected to fail
          // The difference to the previous test case is the expected
          // event on the 2:nd tpsend (5).
 
@@ -1008,29 +983,59 @@ domain:
             EXPECT_TRUE( result.retval == -1) << CASUAL_NAMED_VALUE( result);
             EXPECT_TRUE( result.error == TPEEVENT) << CASUAL_NAMED_VALUE( result);
             // TPEV_SVCERR is expected as no data is allowed in the tpreturn TPFAIL
-            // when not in control of the session. 
+            // when not in control of the session.
             EXPECT_TRUE( result.event == TPEV_SVCERR) << CASUAL_NAMED_VALUE( result);
          }
 
-         // The following is n the test code because an earlier
-         // version did not report an error on the tpsend above!
-         // With that version of Casual the send succeded and the
-         // tprecv got an TPEV_SVCFAIL
+         // and the conversation descriptor should now be invalid
+         EXPECT_TRUE( tpdiscon( connection.descriptor) == -1);
+
+#ifdef HANG_WORKAROUND
+         common::process::sleep( 200ms);
+#endif
+      }
+
+      TEST( test_xatmi_conversation, connect_send_TPRECVONLY_service_tpreturn_with_TPFAIL_and_data_send__conversation_recv_send_service)
+      {
+         common::unittest::Trace trace;
+
+         auto domain = local::domain();
+         // This is a test of called service calling tpreturn with TPFAIL
+         // when in control of the session. A "normal" application level
+         // service failure.
+         //
+         // 1. connect with data, TPSENDONLY
+         // 2. send data, including a substring
+         //    "execute tpreturn TPFAIL with data".
+         //    TPRECVONLY tyr transfer control of session
+         // 3. (callee will do a tpreturn)
+         // 4. tprecv (expected to get an event TPEC_SVCFAIL)
+         //
+         const std::string_view payload {"connect data"};
+         auto connection = local::connect::invoke( "casual/example/conversation_recv_send", payload, TPSENDONLY);
+         EXPECT_TRUE( connection) << CASUAL_NAMED_VALUE( connection);
+         EXPECT_TRUE( connection.error == 0) << CASUAL_NAMED_VALUE( connection);
+
          {
-            // If the previous send got an event TPEV_SVCFAIL
-            // this should fail with TPEBADDESC.
-            std::string send_data {" send data and handover"};
-            auto result = local::send::invoke ( connection.descriptor, send_data, TPSIGRSTRT|TPRECVONLY);
-            EXPECT_TRUE( result.retval == -1) << CASUAL_NAMED_VALUE(result);
-            EXPECT_TRUE( result.error == TPEBADDESC) << CASUAL_NAMED_VALUE(result);
+            std::string send_data {" execute tpreturn TPFAIL with data"};
+            auto result = local::send::invoke ( connection.descriptor, send_data, TPRECVONLY|TPSIGRSTRT);
+            EXPECT_TRUE( result) << CASUAL_NAMED_VALUE( result);
          }
 
          {
             // A receive should fail in some way as the callee terminated
             // the conversation.
+            // It should be TPPEVENT with event TPEV_SVCFAIL. The user return code
+            // and any data provided in the tpreturn should also be filled in.
+            //
+            // TODO:  Verifying the user return code need to be added to a
+            //        number of other tests, and 0 is not a good value to
+            //        return in called service. It is probably the default value!
             auto result = local::receive::invoke( connection.descriptor, TPSIGRSTRT);
-            EXPECT_TRUE( result.retval == -1) << CASUAL_NAMED_VALUE(result);
-            EXPECT_TRUE( result.error == TPEBADDESC) << CASUAL_NAMED_VALUE(result);
+            EXPECT_TRUE( result.retval == -1) << CASUAL_NAMED_VALUE( result);
+            EXPECT_TRUE( result.error == TPEEVENT) << CASUAL_NAMED_VALUE( result);
+            EXPECT_TRUE( result.event == TPEV_SVCFAIL) << CASUAL_NAMED_VALUE( result);
+            EXPECT_TRUE( result.user == 1) << CASUAL_NAMED_VALUE( result);
          }
 
          // and the conversation descriptor should now be invalid
@@ -1050,7 +1055,7 @@ domain:
          // This is a test of a scenario where the service misbehaves!
          // The service is instructed to do a "return" (instead of the expected
          // tpreturn(). This is against the rules. It might happen because of
-         // coding errors! 
+         // coding errors!
          // * connect with data, TPSENDONLY
          // * send data, including a substring "execute return". Hand over
          //   control of conversation.
@@ -1099,14 +1104,14 @@ domain:
          // coding errors!
          // There might be diferent timing cases that need to be considered!
          // Relative timing of the tpsend and the callee doing the "return"
-         // might affect behaviour.   
+         // might affect behaviour.
          // * connect with data, TPSENDONLY
          // * send data, including a substring "execute return". Keep
          //   control of the conversation
          // * (callee will do a return)
          // * tpsend, hand over control
          // * tprecv
-         
+
          const std::string_view payload {"connect data"};
          auto connection = local::connect::invoke( "casual/example/conversation_recv_send", payload, TPSENDONLY);
          EXPECT_TRUE( connection) << CASUAL_NAMED_VALUE( connection);
@@ -1156,7 +1161,7 @@ domain:
          // coding errors!
          // There might be diferent timing cases that need to be considered!
          // Relative timing of the tpsend and the callee doing the "return"
-         // might affect behaviour.   
+         // might affect behaviour.
          // * connect with data, TPSENDONLY
          // * send data, including a substring "execute return". Keep
          //   control of the conversation
@@ -1164,7 +1169,7 @@ domain:
          // * sleep for a short time
          // * tpsend, hand over control
          // * tprecv
-         
+
          const std::string_view payload {"connect data"};
          auto connection = local::connect::invoke( "casual/example/conversation_recv_send", payload, TPSENDONLY);
          EXPECT_TRUE( connection) << CASUAL_NAMED_VALUE( connection);
@@ -1180,7 +1185,7 @@ domain:
             // Should this send fail or succeed? According to XATMI spec
             // (C506.pdf) a tpsend can fail with event.
             // In this test case we sleep 1 second before the send.
-            // This gives the callee time to do its return before we 
+            // This gives the callee time to do its return before we
             // call tpsend().
             // The effect in Casual (currently) seems to be that
             // this send fails with error 12 (=TPESYSTEM).
@@ -1202,7 +1207,7 @@ domain:
          {
             // The receive should fail in some way as the callee terminates
             // in a bad way. And it seems as if the error we get in this
-            // scenario is TPEBADDESC...  
+            // scenario is TPEBADDESC...
             auto result = local::receive::invoke( connection.descriptor, TPSIGRSTRT);
             EXPECT_TRUE( result.retval == -1) << CASUAL_NAMED_VALUE( result);
             EXPECT_TRUE( result.error == TPEBADDESC) << CASUAL_NAMED_VALUE( result);


### PR DESCRIPTION
The strategy choosen to resolve the exiting process handling (issue #67 ) needs review! At least if the strategy choosen is reasonable. We may need to proceed with these changes (assuming that they are reasonable), while waiting for a better or cleaner solution. 

This PR includes the changes in PR #64.

This PR includes additional changes to handle issue #67.

The changes introduced in this PR affect error handling. In particular server processes that terminate unexpectedly while being busy with a conversational service. Could cause a hanging server (caller) to wait for a response that never will come. Could casuse serious problems for the system (lack of robustness).

The changes in PR #64 have to do with properly passing the user return code to the caller/initiator. Also error handling for services that behave badly, i.e. call tpreturn when not in control of a conversation or returning from service without calling tpreturn.

I am not certain that this is a good way to fix the issue, Do not know Casual internals well enough to say. But given my limited experience with Casual internals the changes seems reasonable. The key change is to use the correlation_id from a "lookup"  in the conversational connect. Instead of creating a new correlation_id. The other changes are to handle/recognize a possible service_reply message while doing tpsend or tprecv.

The changes seems to work in added unittests. The issue #67 changes will also be tested with the real application (with reintroduced application bug).