### PR TITLE
http - remove debug log level as default

### DIFF
--- a/thirdparty/nginx/nginx.conf
+++ b/thirdparty/nginx/nginx.conf
@@ -1,7 +1,7 @@
 worker_processes  1;
 daemon off;
 
-error_log  logs/debug.log  debug;
+error_log  logs/debug.log  info;
 
 #
 # Set this to correct value


### PR DESCRIPTION
setting default log level as info to avoid very verbose logging

more dynamic changes can be done at user installation as the user has full control over which nginx.conf are used.
```
      - path: "${CASUAL_HOME}/nginx/sbin/nginx"
        alias: "casual-inbound-server"
        note: "nginx frontend"
        arguments:
          - "-c"
          - "/opt/casual/nginx/conf/nginx.conf"
          - "-p"
          - "/domains"
        instances: 1
        memberships:
          - ".global"
        restart: false
```