### PR TITLE
common - change type of size

### DIFF
--- a/middleware/common/include/common/transaction/global.h
+++ b/middleware/common/include/common/transaction/global.h
@@ -40,7 +40,7 @@ namespace casual::common
          friend std::istream& operator >> ( std::istream& in, common::transaction::global::ID& gtrid);
 
       private:
-         short m_size{};
+         std::int8_t m_size{};
          std::array<char, 64> m_gtrid{};           
       };
       


### PR DESCRIPTION
casual now support serializing of fixed width integers and this commit changes the size type on our new global transaction type.l