### PR TITLE
common - add set container abstraction with contiguous memory

### DIFF
--- a/middleware/common/include/casual/container/sorted/set.h
+++ b/middleware/common/include/casual/container/sorted/set.h
@@ -1,0 +1,178 @@
+//!
+//! Copyright (c) 2022, The casual project
+//!
+//! This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+//!
+
+#pragma once
+
+#include "common/traits.h"
+
+#include "common/algorithm/sorted.h"
+#include "common/algorithm/container.h"
+#include "common/compare.h"
+
+#include "common/serialize/macro.h"
+
+#include <vector>
+
+namespace casual
+{
+   namespace common::traits::is::allocator
+   {
+      //! traits to help deduce if type is allocator like.
+      //! if needed elsewhere, we move it to common/traits.h
+      template< typename Allocator, typename = void, typename = void>
+      struct like : std::false_type {};
+
+      template< typename Allocator>
+      struct like< Allocator,
+         std::void_t< typename Allocator::value_type>,
+         std::void_t< decltype( std::declval< Allocator&>().allocate( std::size_t( 0)))>>
+         : std::true_type {};
+
+      template< typename Allocator>
+      constexpr bool like_v = like< Allocator>::value;
+      
+   } // common::traits::is::allocator
+
+   namespace container::sorted
+   {
+      //! A sorted _unique_ set that uses contigious memory
+      template< typename Value, typename Compare = std::less< Value>, typename Allocator = std::allocator< Value>>
+      struct Set : common::Compare< Set< Value, Compare, Allocator>>
+      {
+         using value_type = Value;
+         using container_type = std::vector< value_type, Allocator>;
+         using range_type = common::range::type_t< container_type>;
+         using size_type = platform::size::type;
+         using compare_type = Compare;
+         using const_iterator = typename std::vector< value_type, Allocator>::const_iterator;
+         using iterator = const_iterator;
+
+         Set() = default;
+
+         template< typename Iter> 
+         Set( Iter first, Iter last, const compare_type& compare = compare_type(), const Allocator& allocator = Allocator())
+            : m_compare( compare), m_values( allocator) 
+         { 
+            insert( first, last);
+         }
+
+         template< typename Range, typename = std::enable_if_t< common::traits::is::iterable_v< std::decay_t< Range>>>>
+         explicit Set( Range&& range, const compare_type& compare = compare_type(), const Allocator& allocator = Allocator())
+            : Set( std::begin( range), std::end( range), compare, allocator)
+         {}
+            
+
+         explicit Set( const Compare& compare, const Allocator& allocator = Allocator()) : m_compare{ compare}, m_values{ allocator} {}
+         explicit Set( const Allocator& allocator ) : Set{ Compare(), allocator} {};
+
+
+         template< typename... Args >
+         std::pair< iterator, bool> emplace( Args&&... args)
+         {
+            auto value = value_type{ std::forward< Args>( args)...};
+
+            if( auto found = find( value))
+            {  
+               // check if value is equal to found ( not less then found )
+               if( ! ( value < *found))
+                  return { std::begin( found), false};
+               
+               return { m_values.insert( std::begin( found), std::move( value)), true};
+            }
+
+            m_values.push_back( std::move( value));
+            return { std::prev( std::end( m_values)), true};
+         }
+
+         std::pair< iterator, bool> insert( const value_type& value) { return insert_implementation( value);}
+         std::pair< iterator, bool> insert( value_type&& value) { return insert_implementation( std::move( value));}
+
+         template< typename Iter >
+         auto insert( Iter first, Iter last) -> decltype( void( first != last), void( insert( *first++)))
+         {
+            while( first != last)
+               insert( *first++);
+         }
+
+         template< typename Range >
+         auto insert( Range&& range) -> decltype( insert( std::begin( range), std::end( range)))
+         {
+            insert( std::begin( range), std::end( range));
+         }
+
+
+         constexpr const_iterator erase( const_iterator where) { return m_values.erase( where);}
+         constexpr const_iterator erase( const_iterator first, const_iterator last) { return m_values.erase( first, last);}
+         template< typename Range>
+         constexpr auto erase( Range range) -> decltype( erase( std::begin( range), std::end( range)))
+         { 
+            return erase( std::begin( range), std::end( range));
+         }
+
+         void reserve( size_type capacity) { m_values.reserve( capacity);}
+         
+
+         //! @returns const-iterators since elements are immutable
+         //! @{
+         [[nodiscard]] auto cbegin() const noexcept { return std::cbegin( m_values);}
+         [[nodiscard]] auto cend() const noexcept { return std::cend( m_values);}
+         [[nodiscard]] auto begin() const noexcept { return std::cbegin( m_values);}
+         [[nodiscard]] auto end() const noexcept { return std::cend( m_values);}
+         //! @}
+
+         [[nodiscard]] auto empty() const noexcept { return m_values.empty();}
+         [[nodiscard]] size_type size() const noexcept { return m_values.size();}
+
+         constexpr auto max_size() const noexcept { return m_values.max_size();}
+
+         void clear() noexcept { m_values.clear();}
+
+         value_type extract( const_iterator where) { return common::algorithm::container::extract( m_values, where);}
+
+         CASUAL_FORWARD_SERIALIZE( m_values)
+
+         auto tie() const noexcept { return std::tie( m_values);}
+
+      private:
+
+         range_type find( const value_type& value)
+         {
+            return std::get< 1>( common::algorithm::sorted::lower_bound( m_values, value, compare_type{}));
+         }
+
+         template< typename T>
+         std::pair< iterator, bool> insert_implementation( T&& value) 
+         {
+            if( auto found = find( value))
+            {
+               if( *found == value)
+                  return { std::begin( found), false};
+               else
+                  return { m_values.insert( std::begin( found), std::move( value)), true};
+            }
+
+            m_values.push_back( std::move( value));
+            return { std::prev( std::end( m_values)), true};
+         }
+
+         compare_type m_compare;
+         container_type m_values;
+      };
+
+      //! deduction guide for range like.
+      template< typename Range,
+         typename Compare = std::less<>,
+         typename Allocator = std::allocator< common::traits::iterable::value_t< Range>>,
+         typename = std::enable_if_t< common::traits::is::allocator::like_v< Allocator>>,
+         typename = std::enable_if_t< ! common::traits::is::allocator::like_v< Compare>>
+         >
+      Set( Range&&, Compare = Compare(), Allocator = Allocator())
+         -> Set< common::traits::iterable::value_t< Range>, Compare, Allocator>;
+
+      
+      
+   } // container::sorted
+} // casual

--- a/middleware/common/include/common/algorithm/sorted.h
+++ b/middleware/common/include/common/algorithm/sorted.h
@@ -66,12 +66,21 @@ namespace casual
       }
       
       //! @returns a tuple with [first, lower_bound) and [lower_bound, last)
+      //! @{
       template< typename R, typename T>
-      auto lower_bound( R&& range, T&& value)
+      auto lower_bound( R&& range, const T& value)
       {
          auto pivot = std::lower_bound( std::begin( range), std::end( range), value);
          return std::make_tuple( range::make( std::begin( range), pivot), range::make( pivot, std::end( range)));
       }
+
+      template< typename R, typename T, typename Compare>
+      auto lower_bound( R&& range, const T& value, Compare compare)
+      {
+         auto pivot = std::lower_bound( std::begin( range), std::end( range), value, compare);
+         return std::make_tuple( range::make( std::begin( range), pivot), range::make( pivot, std::end( range)));
+      }
+      //! @}
 
       //! @returns a tuple with [first, upper_bound) and [upper_bound, last)
       template< typename R, typename T>

--- a/middleware/common/include/common/range.h
+++ b/middleware/common/include/common/range.h
@@ -240,6 +240,14 @@ namespace casual
                detail::make_reverse_iterator( std::begin( range)));
          }
 
+         //! @returns a _move range_ with move_iterator, that will 'move' (return rvalue reference) 
+         //!    elements during subscripts
+         template< typename R>
+         constexpr auto move( R&& range)
+         {
+            return make( std::move_iterator{ std::begin( range)}, std::move_iterator{ std::end( range)});
+         }
+
          template< typename C>
          struct type_traits
          {

--- a/middleware/common/makefile.cmk
+++ b/middleware/common/makefile.cmk
@@ -212,6 +212,8 @@ unittest_objectfiles = [
     make.Compile( 'unittest/source/test_conformance.cpp'),
     
     make.Compile( 'unittest/source/test_algorithm.cpp'),
+    make.Compile( 'unittest/source/container/sorted/test_set.cpp'),
+
     make.Compile( 'unittest/source/test_range.cpp'),
     make.Compile( 'unittest/source/test_execute.cpp'),
     make.Compile( 'unittest/source/test_execution.cpp'),

--- a/middleware/common/unittest/source/container/sorted/test_set.cpp
+++ b/middleware/common/unittest/source/container/sorted/test_set.cpp
@@ -1,0 +1,199 @@
+//!
+//! Copyright (c) 2022, The casual project
+//!
+//! This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+//!
+
+
+#include "common/unittest.h"
+
+#include "casual/container/sorted/set.h"
+
+#include "common/algorithm/is.h"
+#include "common/array.h"
+#include "common/compare.h"
+
+#include <string>
+
+namespace casual
+{
+   using namespace common;
+
+   TEST( container_sorted_set, immutability_non_const)
+   {
+      container::sorted::Set< long> set( array::make( 5, 6, 1, 3, 34));
+
+      static_assert( traits::is::same_v< const long&, decltype( *std::begin( set))>);
+      static_assert( traits::is::same_v< const long&, decltype( *std::end( set))>);  
+   }
+
+   TEST( container_sorted_set, immutability_const)
+   {
+      const container::sorted::Set< long> set( array::make( 5, 6, 1, 3, 34));
+
+      static_assert( traits::is::same_v< const long&, decltype( *std::begin( set))>);
+      static_assert( traits::is::same_v< const long&, decltype( *std::end( set))>);  
+   }
+
+   TEST( container_sorted_set, default_ctor)
+   {
+      container::sorted::Set< long> set;
+      EXPECT_TRUE( set.empty());
+   }
+
+   TEST( container_sorted_set, range_ctor)
+   {
+      auto origin = array::make( 5, 6, 1, 3, 34, 32425, 2342, 23, 1231);
+
+      container::sorted::Set< long> set( std::begin( origin), std::end( origin));
+      EXPECT_TRUE( set.size() == origin.size());
+      EXPECT_TRUE( algorithm::is::sorted( set));
+      EXPECT_TRUE( algorithm::equal( set, algorithm::sort( origin)));
+   }
+
+   TEST( container_sorted_set, move_sematics)
+   {
+      auto origin = array::make( 5, 6, 1, 3, 34, 32425, 2342, 23, 1231);
+
+      container::sorted::Set< long> a( std::begin( origin), std::end( origin));
+
+      auto b = std::move( a);
+      EXPECT_TRUE( a.empty());
+
+      EXPECT_TRUE( b.size() == origin.size());
+      EXPECT_TRUE( algorithm::is::sorted( b));
+      EXPECT_TRUE( algorithm::equal( b, algorithm::sort( origin)));
+   }
+
+   TEST( container_sorted_set, insert_long)
+   {
+      container::sorted::Set< long> set;
+      set.insert( 5);
+      set.insert( 9);
+      set.insert( 1);
+      set.insert( 3);
+      
+      EXPECT_TRUE( set.size() == 4);
+      EXPECT_TRUE( algorithm::is::sorted( set));
+   }
+
+   TEST( container_sorted_set, erase_iterator)
+   {
+      container::sorted::Set< long> set{ array::make( 1, 2, 3, 4, 5)};
+
+      EXPECT_TRUE( *std::next( std::begin( set)) == 2);
+      set.erase( std::next( std::begin( set)));
+
+      EXPECT_TRUE( algorithm::equal( set, array::make( 1, 3, 4, 5))) << CASUAL_NAMED_VALUE( set);
+   }
+
+   TEST( container_sorted_set, erase_range)
+   {
+      container::sorted::Set< long> set{ array::make( 1, 2, 3, 4, 5)};
+
+      // remove [2, 3]
+      set.erase( range::make( std::next( std::begin( set)), 2));
+
+      EXPECT_TRUE( algorithm::equal( set, array::make( 1,  4, 5))) << CASUAL_NAMED_VALUE( set);
+   }
+
+   TEST( container_sorted_set, equal)
+   {
+      using Set = container::sorted::Set< long>;
+
+      // [ 1, 3, 4, 5]
+      EXPECT_TRUE( Set( array::make( 1, 1, 3, 4, 5)) == Set( array::make( 1, 3, 3, 4, 5)));
+      EXPECT_TRUE( ! ( Set( array::make( 1, 1, 3, 4, 5)) < Set( array::make( 1, 3, 3, 4, 5))));
+      EXPECT_TRUE( ! ( Set( array::make( 1, 1, 3, 4, 5)) > Set( array::make( 1, 3, 3, 4, 5))));
+   }
+
+   TEST( container_sorted_set, less)
+   {
+      using Set = container::sorted::Set< long>;
+   
+      EXPECT_TRUE( Set( array::make( 1, 2, 3, 4)) < Set( array::make( 2, 3, 4, 5)));
+      EXPECT_TRUE( Set( array::make( 1, 2, 3, 4)) != Set( array::make( 2, 3, 4, 5)));
+   }
+
+   TEST( container_sorted_set, extract)
+   {
+      container::sorted::Set< long> set{ array::make( 1, 2, 3, 4, 5)};
+
+      // extract 2
+      auto value = set.extract( std::next( std::begin( set)));
+
+      EXPECT_TRUE( value == 2);
+      EXPECT_TRUE( algorithm::equal( set, array::make( 1, 3, 4, 5))) << CASUAL_NAMED_VALUE( set);
+   }
+
+   TEST( container_sorted_set, container_sorted_set_insert_long_range)
+   {
+      auto origin = array::make( 5, 6, 1, 3);
+
+      container::sorted::Set< long> set{ origin};
+      
+      EXPECT_TRUE( set.size() == 4);
+      EXPECT_TRUE( algorithm::is::sorted( set));
+      EXPECT_TRUE( algorithm::equal( set, algorithm::sort( origin)));
+   }
+
+   namespace local
+   {
+      namespace
+      {
+         struct Value : Compare< Value>
+         {
+            Value( std::string s, long l) 
+               : s{ std::move( s)}, l{ l} {}
+            
+            std::string s;
+            long l{};
+
+            auto tie() const noexcept { return std::tie( s, l);}
+         };
+      } // <unnamed>
+   } // local
+
+   TEST( container_sorted_set, emplace)
+   {
+      container::sorted::Set< local::Value> set;
+
+      EXPECT_TRUE( std::get< 1>( set.emplace( "b", 4)));
+      EXPECT_TRUE( *std::get< 0>( set.emplace( "a", 42)) == local::Value( "a", 42));
+      set.emplace( "b", 2);
+      EXPECT_TRUE( ! std::get< 1>( set.emplace( "b", 4)));
+
+      EXPECT_TRUE( algorithm::equal( set, array::make( local::Value( "a", 42), local::Value( "b", 2), local::Value( "b", 4))));
+   }
+
+
+   TEST( container_sorted_set, deduction_guide)
+   {
+      auto origin = array::make( 5, 6, 1, 3);
+
+      container::sorted::Set set{ origin};
+      
+      EXPECT_TRUE( set.size() == 4);
+      EXPECT_TRUE( algorithm::is::sorted( set));
+      EXPECT_TRUE( algorithm::equal( set, algorithm::sort( origin)));
+   }
+
+   TEST( container_sorted_set, move_iterator__insert)
+   {
+      using namespace std::string_literals;
+
+      auto origin = array::make( "some long string without SSO - B"s, "some long string without SSO - C"s, "some long string without SSO - A"s, "some long string without SSO - D"s);
+
+      // the "move range" should trigger move for each element from origin
+      container::sorted::Set< std::string> a( common::range::move( origin));
+
+      EXPECT_TRUE( algorithm::all_of( origin, []( auto& element){ return element.empty();}));
+
+      auto b = std::move( a);
+      EXPECT_TRUE( a.empty());
+
+      EXPECT_TRUE( b.size() == origin.size()) << CASUAL_NAMED_VALUE( b);
+      EXPECT_TRUE( algorithm::is::sorted( b));
+   }
+
+} // casual


### PR DESCRIPTION
A container that has the following attributes:

* always sorted
* unique set of elements
* contiguous memory
* elements are immutable
* most of std::set API

fixes #80