### PR TITLE
Feature/1.6/fix creating unnecessary paths

### DIFF
--- a/middleware/common/include/common/file.h
+++ b/middleware/common/include/common/file.h
@@ -140,9 +140,12 @@ namespace casual
          //! takes soft links into account when creating the path, if any.
          std::filesystem::path create( std::filesystem::path path);
 
+         //! creates all parent directories, but not the leaf
+         std::filesystem::path create_parent_path( std::filesystem::path path);
+
          namespace shared
          {
-            //! creates directory with group write.
+            //! creates directory with group rwx.
             std::filesystem::path create( std::filesystem::path path);
          } // shared
 

--- a/middleware/common/include/common/file.h
+++ b/middleware/common/include/common/file.h
@@ -140,6 +140,12 @@ namespace casual
          //! takes soft links into account when creating the path, if any.
          std::filesystem::path create( std::filesystem::path path);
 
+         namespace shared
+         {
+            //! creates directory with group write.
+            std::filesystem::path create( std::filesystem::path path);
+         } // shared
+
       } // directory
 
    } // common

--- a/middleware/common/include/common/message/transaction.h
+++ b/middleware/common/include/common/message/transaction.h
@@ -368,7 +368,7 @@ namespace casual
                         return involved;
                      }
                   } // involved
-               } // domain
+               } // external
             } // resource
          } // transaction
 

--- a/middleware/common/include/common/message/type.h
+++ b/middleware/common/include/common/message/type.h
@@ -55,6 +55,9 @@ namespace casual
          domain_process_lookup_request,
          domain_process_lookup_reply,
 
+         domain_process_information_request,
+         domain_process_information_reply,
+
          domain_configuration_request = DOMAIN_BASE + 200,
          domain_configuration_reply,
          domain_server_configuration_request,

--- a/middleware/common/source/communication/instance.cpp
+++ b/middleware/common/source/communication/instance.cpp
@@ -5,6 +5,7 @@
 //!
 
 
+#include "common/instance.h"
 #include "common/communication/instance.h"
 #include "common/communication/ipc.h"
 #include "common/communication/log.h"
@@ -126,6 +127,8 @@ namespace casual
          {
             common::message::domain::process::connect::Request request{ process::handle()};
             request.whitelist = true;
+            request.information.alias = common::instance::alias();
+            request.information.path = common::process::path();
             local::connect( request);
 
          }
@@ -138,6 +141,8 @@ namespace casual
             request.whitelist = true;
             request.singleton.identification = identity.id;
             request.singleton.environment = identity.environment;
+            request.information.alias = common::instance::alias();
+            request.information.path = common::process::path();
 
             local::connect( request);
          }
@@ -151,7 +156,7 @@ namespace casual
          {
             connect( instance::Identity{ id, {}});
          }
-         
+
       } // whitelist
 
 

--- a/middleware/common/source/communication/ipc.cpp
+++ b/middleware/common/source/communication/ipc.cpp
@@ -12,6 +12,7 @@
 #include "common/log.h"
 #include "common/signal.h"
 #include "common/environment.h"
+#include "common/file.h"
 
 #include "common/exception/capture.h"
 #include "common/code/raise.h"
@@ -416,6 +417,8 @@ namespace casual
                      strong::ipc::id ipc{ uuid::make()};
 
                      Address address{ ipc};
+
+                     directory::shared::create( environment::directory::ipc());
 
                      posix::result( ::bind(
                         socket.descriptor().value(),

--- a/middleware/common/source/domain.cpp
+++ b/middleware/common/source/domain.cpp
@@ -116,6 +116,7 @@ namespace casual
             const Model model{ process::handle(), domain::identity()};
 
             auto& path = environment::domain::singleton::file();
+            directory::create( path.parent_path());
 
             if( std::filesystem::exists( path))
             {

--- a/middleware/common/source/domain.cpp
+++ b/middleware/common/source/domain.cpp
@@ -115,8 +115,7 @@ namespace casual
 
             const Model model{ process::handle(), domain::identity()};
 
-            auto& path = environment::domain::singleton::file();
-            directory::create( path.parent_path());
+            auto path = directory::create_parent_path( environment::domain::singleton::file());
 
             if( std::filesystem::exists( path))
             {

--- a/middleware/common/source/environment.cpp
+++ b/middleware/common/source/environment.cpp
@@ -217,7 +217,7 @@ namespace casual
 
                   auto domain() -> std::filesystem::path
                   {
-                     return common::directory::create( detail::value( variable::name::directory::domain, [](){ return "./";}));
+                     return detail::value( variable::name::directory::domain, [](){ return "./";});
                   }
 
                   auto transient() -> std::filesystem::path
@@ -243,28 +243,28 @@ namespace casual
 
                   auto ipc() -> std::filesystem::path
                   {
-                     return common::directory::create( detail::value( variable::name::directory::ipc, [](){ return transient() / "ipc";}));
+                     return detail::value( variable::name::directory::ipc, [](){ return transient() / "ipc";});
                   }
 
                   auto queue() -> std::filesystem::path
                   {
-                     return common::directory::create( detail::value( variable::name::directory::queue, [](){ return persistent() / "queue";}));
+                     return detail::value( variable::name::directory::queue, [](){ return persistent() / "queue";});
                   }
 
                   auto transaction() -> std::filesystem::path
                   {
-                     return common::directory::create( detail::value( variable::name::directory::transaction, [](){ return persistent() / "transaction";}));
+                     return detail::value( variable::name::directory::transaction, [](){ return persistent() / "transaction";});
                   }
 
                   auto singleton() -> std::filesystem::path
                   {
-                     return common::directory::create( domain() / detail::casual) / "singleton";
+                     return domain() / detail::casual / "singleton";
                   }
                   
                } // path
 
 
-               //! holds "all" paths based on enviornment.
+               //! holds "all" paths based on environment.
                //! main purpose is to be able to reset when running
                //! unittests
                struct Paths 
@@ -293,7 +293,7 @@ namespace casual
                {
                   Paths paths;
                } // global
-               
+
             } // <unnamed>
          } // local
 

--- a/middleware/common/source/file.cpp
+++ b/middleware/common/source/file.cpp
@@ -206,6 +206,12 @@ namespace casual
             return path;
          }
 
+         std::filesystem::path create_parent_path( std::filesystem::path path)
+         {
+            create( path.parent_path());
+            return path;
+         }
+
          namespace shared
          {
             std::filesystem::path create( std::filesystem::path path)
@@ -214,7 +220,7 @@ namespace casual
                if( ! fs::exists( path))
                {
                   fs::create_directories( path);
-                  fs::permissions( path, fs::perms::group_write, fs::perm_options::add);
+                  fs::permissions( path, fs::perms::group_all, fs::perm_options::add);
                }
 
                return path;

--- a/middleware/common/source/file.cpp
+++ b/middleware/common/source/file.cpp
@@ -206,6 +206,20 @@ namespace casual
             return path;
          }
 
+         namespace shared
+         {
+            std::filesystem::path create( std::filesystem::path path)
+            {
+               namespace fs = std::filesystem;
+               if( ! fs::exists( path))
+               {
+                  fs::create_directories( path);
+                  fs::permissions( path, fs::perms::group_write, fs::perm_options::add);
+               }
+
+               return path;
+            }
+         } // shared
       } // directory
 
    } // common

--- a/middleware/common/source/message/type.cpp
+++ b/middleware/common/source/message/type.cpp
@@ -31,6 +31,8 @@ namespace casual
             case Type::domain_manager_shutdown_reply: return "domain_manager_shutdown_reply";
             case Type::domain_process_lookup_request: return "domain_process_lookup_request";
             case Type::domain_process_lookup_reply: return "domain_process_lookup_reply";
+            case Type::domain_process_information_request: return "domain_process_information_request";
+            case Type::domain_process_information_reply: return "domain_process_information_reply";
             case Type::domain_configuration_request: return "domain_configuration_request";
             case Type::domain_configuration_reply: return "domain_configuration_reply";
             case Type::domain_server_configuration_request: return "domain_server_configuration_request";

--- a/middleware/domain/include/casual/domain/manager/api/model.h
+++ b/middleware/domain/include/casual/domain/manager/api/model.h
@@ -59,7 +59,7 @@ namespace casual
 
                struct base_process
                {
-                  //! @note not pid, but the internal id of the servcer/executable
+                  //! @note not pid, but the internal id of the server/executable
                   id_type id;
                   std::string alias;
                   std::filesystem::path path;

--- a/middleware/domain/include/domain/manager/admin/model.h
+++ b/middleware/domain/include/domain/manager/admin/model.h
@@ -169,6 +169,19 @@ namespace casual
             )
          };
 
+         struct Grandchild
+         {
+            common::process::Handle handle;
+            std::string alias;
+            std::filesystem::path path;
+
+            CASUAL_CONST_CORRECT_SERIALIZE(
+               CASUAL_SERIALIZE( handle);
+               CASUAL_SERIALIZE( alias);
+               CASUAL_SERIALIZE( path);
+            )
+         };
+
          namespace state
          {
             enum class Runlevel : int
@@ -200,6 +213,7 @@ namespace casual
             std::vector< model::Group> groups;
             std::vector< model::Executable> executables;
             std::vector< model::Server> servers;
+            std::vector< model::Grandchild> grandchildren;
 
             struct Tasks
             {
@@ -229,6 +243,7 @@ namespace casual
                CASUAL_SERIALIZE( groups);
                CASUAL_SERIALIZE( executables);
                CASUAL_SERIALIZE( servers);
+               CASUAL_SERIALIZE( grandchildren);
                CASUAL_SERIALIZE( tasks);
                CASUAL_SERIALIZE( event);
             })

--- a/middleware/domain/include/domain/manager/state.h
+++ b/middleware/domain/include/domain/manager/state.h
@@ -299,8 +299,9 @@ namespace casual
          };
          std::string_view description( Runlevel value);
 
-      } // state
+         using Grandchild = common::message::domain::process::Information;
 
+      } // state
 
       struct State
       {
@@ -328,7 +329,7 @@ namespace casual
 
          //! Processes that register but is not direct children of
          //! this process.
-         std::vector< common::process::Handle> grandchildren;
+         std::vector< state::Grandchild> grandchildren;
 
          //! executable id of this domain manager
          state::Server::id_type manager_id;
@@ -432,7 +433,8 @@ namespace casual
 
          Runnables runnables( std::vector< std::string> aliases);
 
-         common::process::Handle grandchild( common::strong::process::id pid) const noexcept;
+         state::Grandchild* grandchild( common::strong::process::id pid) noexcept;
+         const state::Grandchild* grandchild( common::strong::process::id pid) const noexcept;
 
          common::process::Handle singleton( const common::Uuid& id) const noexcept;
 

--- a/middleware/domain/source/manager/state.cpp
+++ b/middleware/domain/source/manager/state.cpp
@@ -364,7 +364,6 @@ namespace casual
                   return ! algorithm::find( e.instances, pid).empty();
                }).data();
             }
-
             
          } // <unnamed>
       } // local
@@ -414,6 +413,13 @@ namespace casual
                   return i.id == id;
                }));
             }
+
+            template< typename G>
+            auto grandchild( G& grandchildren, common::strong::process::id pid) noexcept
+            {
+               return algorithm::find( grandchildren, pid).data();
+            }
+
          } // <unnamed>
       } // local
 
@@ -463,12 +469,14 @@ namespace casual
          return runnables;
       }
 
-      common::process::Handle State::grandchild( common::strong::process::id pid) const noexcept
+      state::Grandchild* State::grandchild( common::strong::process::id pid) noexcept
       {
-         if( auto found = algorithm::find( grandchildren, pid)) 
-            return *found;
+         return local::grandchild( grandchildren, pid);
+      }
 
-         return {};
+      const state::Grandchild* State::grandchild( common::strong::process::id pid) const noexcept
+      {
+         return local::grandchild( grandchildren, pid);
       }
 
       common::process::Handle State::singleton( const common::Uuid& id) const noexcept

--- a/middleware/domain/source/manager/transform.cpp
+++ b/middleware/domain/source/manager/transform.cpp
@@ -252,6 +252,19 @@ namespace casual
                   return result;
                }
 
+               auto grandchild()
+               {
+                  return []( const manager::state::Grandchild& grandchild)
+                  {
+                     manager::admin::model::Grandchild result;
+                     result.handle = grandchild.handle;
+                     result.alias = grandchild.alias;
+                     result.path = grandchild.path;
+
+                     return result;
+                  };
+               }
+
             } // model
 
          } // <unnamed>
@@ -286,6 +299,7 @@ namespace casual
          result.executables = algorithm::transform( state.executables, local::model::excecutable());
          //result.event = local::model::event( state.event);
          result.tasks = local::model::tasks( state.tasks);
+         result.grandchildren = algorithm::transform( state.grandchildren, local::model::grandchild());
 
          return result;
       }

--- a/middleware/gateway/source/group/outbound/main.cpp
+++ b/middleware/gateway/source/group/outbound/main.cpp
@@ -110,10 +110,9 @@ namespace casual
                            for( auto& configuration : message.model.connections)
                               state.connect.prospects.emplace_back( std::move( configuration));
 
-
                            // we might got some addresses to try...
                            external::connect( state);
-                           
+
                            // send reply
                            state.multiplex.send( message.process.ipc, common::message::reverse::type( message, common::process::handle()));
                            
@@ -127,7 +126,7 @@ namespace casual
                      {
                         return [&state]( message::outbound::state::Request& message)
                         {
-                           Trace trace{ "gateway::group::outbound::local::handle::internal::state::request"};
+                           Trace trace{ "gateway::group::outbound::local::internal::handle::state::request"};
 
                            state.multiplex.send( message.process.ipc, tcp::connect::state::request( state, message));
                         };

--- a/middleware/queue/source/forward/main.cpp
+++ b/middleware/queue/source/forward/main.cpp
@@ -32,6 +32,9 @@ namespace casual
                   ipc::queue::manager(),
                   ipc::message::forward::group::Connect{ process::handle()});
 
+               // 'connect' to our local domain
+               common::communication::instance::whitelist::connect();
+
                return State{};
             }
 

--- a/middleware/queue/source/group/handle.cpp
+++ b/middleware/queue/source/group/handle.cpp
@@ -400,7 +400,7 @@ namespace casual
                            state.multiplex.send( message.process.ipc, reply);
                         };
                      }
-                  }
+                  } // prepare
 
                   namespace rollback
                   {
@@ -436,7 +436,7 @@ namespace casual
                            // handle::persist will take care of pending dequeue requests
                         };
                      }
-                  }
+                  } // rollback
                } // transaction
 
                namespace restore

--- a/middleware/queue/source/group/main.cpp
+++ b/middleware/queue/source/group/main.cpp
@@ -50,6 +50,9 @@ namespace casual
                      communication::instance::outbound::queue::manager::device(),
                      ipc::message::group::Connect{ process::handle()});
 
+                  // 'connect' to our local domain
+                  common::communication::instance::whitelist::connect();
+
                   return {};
                }
 

--- a/middleware/queue/source/manager/handle.cpp
+++ b/middleware/queue/source/manager/handle.cpp
@@ -24,6 +24,7 @@
 #include "common/algorithm/compare.h"
 #include "common/message/dispatch/handle.h"
 #include "common/message/internal.h"
+#include "common/instance.h"
 #include "common/communication/instance.h"
 #include "common/communication/ipc/send.h"
 
@@ -592,7 +593,10 @@ namespace casual
 
             auto spawn = []( auto& entity)
             {
-               entity.process.pid = common::process::spawn( state::entity::path( entity), {});
+               entity.process.pid = common::process::spawn(
+                  state::entity::path( entity),
+                  {},
+                  { instance::variable( instance::Information{ entity.configuration.alias})});
                entity.state = decltype( entity.state())::spawned;
             };
 

--- a/middleware/queue/source/manager/transform.cpp
+++ b/middleware/queue/source/manager/transform.cpp
@@ -123,13 +123,15 @@ namespace casual
             }
 
             // find remote queues and add to model
-            for( auto [ queue_name, queue_instances] : state.queues)
+            for( auto& queue : state.queues)
             {
-               auto remote_queues = algorithm::filter( queue_instances, []( const auto& instance) { return instance.remote();});
-
-               algorithm::for_each( remote_queues, [&result, &queue_name]( const auto& remote_queue)
+               algorithm::transform_if( queue.second, std::back_inserter( result.remote.queues), [ &queue]( auto& instance)
                {
-                  result.remote.queues.push_back( admin::model::remote::Queue{ queue_name, remote_queue.process.pid});
+                  return admin::model::remote::Queue{ queue.first, instance.process.pid};
+               },
+               []( auto& instance)
+               {
+                  return instance.remote();
                });
             }
 

--- a/middleware/transaction/include/transaction/manager/state.h
+++ b/middleware/transaction/include/transaction/manager/state.h
@@ -145,7 +145,7 @@ namespace casual
             {
                struct Proxy
                {
-                  Proxy( common::process::Handle  process, common::strong::resource::id id);
+                  Proxy( common::process::Handle process, common::strong::resource::id id);
 
                   common::process::Handle process;
 
@@ -155,7 +155,7 @@ namespace casual
                   // TODO maintainence: get metrics for "external" resources
                   // Metrics metrics;
 
-                  friend bool operator == ( const Proxy& lhs, const common::process::Handle& rhs);
+                  friend bool operator == ( const Proxy& lhs, const common::strong::ipc::id& rhs);
                   inline friend bool operator == ( const Proxy& lhs, common::strong::resource::id rhs) { return lhs.id == rhs;}
 
                   CASUAL_LOG_SERIALIZE(
@@ -168,7 +168,6 @@ namespace casual
                {
                   common::strong::resource::id id( State& state, const common::process::Handle& process);
                } // proxy
-
             } // external
          } // resource
 

--- a/middleware/transaction/source/manager/state.cpp
+++ b/middleware/transaction/source/manager/state.cpp
@@ -96,12 +96,12 @@ namespace casual
 
             namespace external
             {
-               Proxy::Proxy( common::process::Handle  process, common::strong::resource::id id)
+               Proxy::Proxy( common::process::Handle process, common::strong::resource::id id)
                   : process{std::move( process)}, id{std::move( id)}
                {
                }
 
-               bool operator == ( const Proxy& lhs, const common::process::Handle& rhs)
+               bool operator == ( const Proxy& lhs, const common::strong::ipc::id& rhs)
                {
                   return lhs.process == rhs;
                }
@@ -110,14 +110,13 @@ namespace casual
                {
                   common::strong::resource::id id( State& state, const common::process::Handle& process)
                   {
-                     if( auto found = common::algorithm::find( state.externals, process))
+                     if( auto found = common::algorithm::find( state.externals, process.ipc))
                         return found->id;
 
                      static common::strong::resource::id base_id;
-                     
+
                      --base_id.underlying();
                      return state.externals.emplace_back( process, base_id).id;
-
                   }
                } // proxy
             } // external

--- a/middleware/transaction/source/manager/transform.cpp
+++ b/middleware/transaction/source/manager/transform.cpp
@@ -32,7 +32,7 @@ namespace casual
                if( ! configuration.empty())
                   return common::environment::expand( std::move( configuration));
 
-               auto file = environment::directory::transaction() / "log.db";
+               auto file = directory::create( environment::directory::transaction()) / "log.db";
 
                // TODO: remove this in 2.0 (that exist to be backward compatible)
                {


### PR DESCRIPTION
WIP

* Expanded the information that child- and grandchild processes may provide when connecting to the DM. Added a handler to the dm which responds to requests for information about the dm:s offspring.
* Fixed creating all of casuals directories whenever the casual cli was invoked.
* The TM now assigns external resources resource-id:s based on ipc rather than pid in to allow a process to have multiple external resources.