### PR TITLE
queue - fix --list-remote

### DIFF
--- a/middleware/queue/include/queue/manager/transform.h
+++ b/middleware/queue/include/queue/manager/transform.h
@@ -20,6 +20,7 @@ namespace casual
       namespace model
       {
          admin::model::State state(
+            const manager::State& state,
             std::vector< ipc::message::group::state::Reply> groups,
             std::vector< ipc::message::forward::group::state::Reply> forwards);
 

--- a/middleware/queue/source/manager/admin/server.cpp
+++ b/middleware/queue/source/manager/admin/server.cpp
@@ -50,6 +50,7 @@ namespace casual
                });
 
                return transform::model::state( 
+                  state,
                   algorithm::transform( group_states, future_get),
                   algorithm::transform( forward_state, future_get));
             }

--- a/middleware/queue/unittest/source/manager/test_transform.cpp
+++ b/middleware/queue/unittest/source/manager/test_transform.cpp
@@ -103,6 +103,7 @@ alias: A
 )";
 
          auto model = transform::model::state( 
+            manager::State{},
             unittest::serialize::create::value< std::vector< ipc::message::group::state::Reply>>( "yaml", group_replies),
             unittest::serialize::create::value< std::vector< ipc::message::forward::group::state::Reply>>( "yaml", forward_replies)
          );


### PR DESCRIPTION
A "minimum viable fix" for --list-remote, leaves the model as-is. It could be argued that we should be displaying more/different information (about the outbound, for example).