### PR TITLE
transaction - fix core when resources in distributed prepare (service) fails

### DIFF
--- a/middleware/common/include/common/code/convert.h
+++ b/middleware/common/include/common/code/convert.h
@@ -15,20 +15,12 @@
 
 namespace casual
 {
-   namespace common
+   namespace common::code::convert::to
    {
-      namespace code
-      {
-         namespace convert
-         {
-            namespace to
-            {
-               code::tx tx( code::xa code);
+      code::tx tx( code::xa code);
 
-               code::casual casual( std::errc code);
-            } // to
-         } // convert
-      } // code
-   } // common
+      code::casual casual( std::errc code);
+
+   } // common::code::convert::to
 } // casual
 

--- a/middleware/common/include/common/code/tx.h
+++ b/middleware/common/include/common/code/tx.h
@@ -39,6 +39,12 @@ namespace casual
       };
       std::string_view description( code::tx code) noexcept;
 
+
+      //! "adds" two tx codes, and return the most severe, which could be
+      //! the aggregated `no_begin_*` set. 
+      tx operator + ( tx lhs, tx rhs) noexcept;
+      tx& operator += ( tx& lhs, tx rhs) noexcept;
+
       static_assert( static_cast< int>( tx::ok) == 0, "tx::ok has to be 0");
 
       std::error_code make_error_code( code::tx code);

--- a/middleware/common/include/common/message/service.h
+++ b/middleware/common/include/common/message/service.h
@@ -131,6 +131,12 @@ namespace casual
                error,
             };
 
+            //! 'accumulate' State, only more severe
+            //! @{
+            inline State operator + ( State lhs, State rhs) noexcept { return std::max( lhs, rhs);}
+            inline State& operator += ( State& lhs, State rhs) noexcept { return lhs = lhs + rhs;}
+            //! @}
+
             inline constexpr std::string_view description( State value) noexcept
             {
                switch( value)
@@ -142,6 +148,8 @@ namespace casual
                }
                return "<unknown>";
             }
+
+            
             
          } // transaction
 

--- a/middleware/common/include/common/transaction/context.h
+++ b/middleware/common/include/common/transaction/context.h
@@ -53,32 +53,32 @@ namespace casual
 
          //! Correspond to the tx API
          //! @{
-         void open();
-         void close();
+         [[nodiscard]] code::tx open();
+         [[nodiscard]] code::tx close();
 
-         void begin();
-         void commit();
-         void rollback();
+         [[nodiscard]] code::tx begin();
+         [[nodiscard]] code::tx commit();
+         [[nodiscard]] code::tx rollback();
 
-         void set_commit_return( commit::Return value) noexcept;
-         commit::Return get_commit_return() const noexcept;
+         [[nodiscard]] code::tx set_commit_return( commit::Return value) noexcept;
+         [[nodiscard]] commit::Return get_commit_return() const noexcept;
          
-         void set_transaction_control( transaction::Control control);
-         void set_transaction_timeout( platform::time::unit timeout);
+         [[nodiscard]] code::tx set_transaction_control( transaction::Control control);
+         [[nodiscard]] code::tx set_transaction_timeout( platform::time::unit timeout);
          
          bool info( TXINFO* info);
          //! @}
 
          //! Correspond to casual extension of the tx API
          //! @{
-         void suspend( XID* xid);
-         void resume( const XID* xid);
+         [[nodiscard]] code::tx suspend( XID* xid);
+         [[nodiscard]] code::tx resume( const XID* xid);
          //! @}
 
          //! Correspond to the ax API
          //! @{
-         code::ax resource_registration( strong::resource::id rmid, XID* xid);
-         void resource_unregistration( strong::resource::id rmid);
+         [[nodiscard]] code::ax resource_registration( strong::resource::id rmid, XID* xid);
+         [[nodiscard]] code::ax resource_unregistration( strong::resource::id rmid);
          //! @}
 
          //! @ingroup service-start
@@ -117,13 +117,15 @@ namespace casual
          //! process
          bool pending() const;
 
-         std::vector< strong::resource::id> resources() const;
+         [[nodiscard]] std::vector< strong::resource::id> resources() const noexcept;
 
          //! @attention only for unittest... temporary until we fix the "context-fiasco".
          static Context& clear();
 
          //! return true if the context holds no transactions, only (?) for unittest
-         bool empty() const;
+         bool empty() const noexcept;
+
+         inline Control control() const noexcept { return m_control;}
          
          void resources_suspend( Transaction& transaction);
          void resources_resume( Transaction& transaction);
@@ -154,14 +156,15 @@ namespace casual
          Context();
          ~Context();
 
-         void commit( const Transaction& transaction);
-         void rollback( const Transaction& transaction);
+         [[nodiscard]] code::tx commit( const Transaction& transaction);
+         [[nodiscard]] code::tx rollback( const Transaction& transaction);
 
 
-         void resource_commit( strong::resource::id rm, const Transaction& transaction, flag::xa::Flags flags);
-         void resource_rollback( strong::resource::id rm, const Transaction& transaction);
+         [[nodiscard]] code::tx resource_commit( strong::resource::id rm, const Transaction& transaction, flag::xa::Flags flags);
+         [[nodiscard]] code::tx resource_rollback( strong::resource::id rm, const Transaction& transaction);
 
-         void pop_transaction();
+         [[nodiscard]] code::tx control_continuation( code::tx code);
+         
 
 
       };

--- a/middleware/common/include/common/transaction/resource.h
+++ b/middleware/common/include/common/transaction/resource.h
@@ -21,64 +21,60 @@
 
 namespace casual
 {
-   namespace common
+   namespace common::transaction
    {
-      namespace transaction
+      class ID;
+
+      struct Resource
       {
-         class ID;
+         using Flag = flag::xa::Flag;
+         using Flags = flag::xa::Flags;
 
-         struct Resource
-         {
-            using code = code::xa;
-            using Flag = flag::xa::Flag;
-            using Flags = flag::xa::Flags;
-
-            Resource( resource::Link link, strong::resource::id id, std::string openinfo, std::string closeinfo);
-            
-            code start( const transaction::ID& transaction, Flags flags) noexcept;
-            code end( const transaction::ID& transaction, Flags flags) noexcept;
-
-            code open( Flags flags = Flag::no_flags) noexcept;
-            code close( Flags flags = Flag::no_flags) noexcept;
-
-            code prepare( const transaction::ID& transaction, Flags flags) noexcept;
-
-            code commit( const transaction::ID& transaction, Flags flags) noexcept;
-            code rollback( const transaction::ID& transaction, Flags flags) noexcept;
-
-            bool dynamic() const noexcept;
-
-            inline const std::string& key() const noexcept { return m_key;}
-            inline strong::resource::id id() const noexcept { return m_id;}
-            inline std::string_view name() const noexcept { return m_xa->name;}
-
-            bool migrate() const noexcept;
+         Resource( resource::Link link, strong::resource::id id, std::string openinfo, std::string closeinfo);
          
+         code::xa start( const transaction::ID& transaction, Flags flags) noexcept;
+         code::xa end( const transaction::ID& transaction, Flags flags) noexcept;
 
-            friend std::ostream& operator << ( std::ostream& out, const Resource& resource);
-            friend bool operator == ( const Resource& lhs, strong::resource::id rhs) { return lhs.m_id == rhs;}
-            friend bool operator == ( strong::resource::id lhs, const Resource& rhs) { return lhs == rhs.m_id;}
+         code::xa open( Flags flags = Flag::no_flags) noexcept;
+         code::xa close( Flags flags = Flag::no_flags) noexcept;
 
-         private:
-            //! tries to reopen the resource
-            code reopen();
+         code::xa prepare( const transaction::ID& transaction, Flags flags) noexcept;
 
-            //! if `functor` returns xa::resource_fail, reopen the resource, 
-            //! and apply the `functor` again
-            template< typename F>
-            code reopen_guard( F&& functor);
+         code::xa commit( const transaction::ID& transaction, Flags flags) noexcept;
+         code::xa rollback( const transaction::ID& transaction, Flags flags) noexcept;
 
-            bool prepared( const transaction::ID& transaction);
+         bool dynamic() const noexcept;
+
+         inline const std::string& key() const noexcept { return m_key;}
+         inline strong::resource::id id() const noexcept { return m_id;}
+         inline std::string_view name() const noexcept { return m_xa->name;}
+
+         bool migrate() const noexcept;
+      
+
+         friend std::ostream& operator << ( std::ostream& out, const Resource& resource);
+         friend bool operator == ( const Resource& lhs, strong::resource::id rhs) { return lhs.m_id == rhs;}
+         friend bool operator == ( strong::resource::id lhs, const Resource& rhs) { return lhs == rhs.m_id;}
+
+      private:
+         //! tries to reopen the resource
+         code::xa reopen();
+
+         //! if `functor` returns xa::resource_fail, reopen the resource, 
+         //! and apply the `functor` again
+         template< typename F>
+         code::xa reopen_guard( F&& functor);
+
+         bool prepared( const transaction::ID& transaction);
 
 
-            std::string m_key;
-            xa_switch_t* m_xa;
-            strong::resource::id m_id;
+         std::string m_key;
+         xa_switch_t* m_xa;
+         strong::resource::id m_id;
 
-            std::string m_openinfo;
-            std::string m_closeinfo;
-         };
+         std::string m_openinfo;
+         std::string m_closeinfo;
+      };
 
-      } // transaction
-   } //common
+   } //common::transaction
 } // casual

--- a/middleware/common/include/common/transaction/transaction.h
+++ b/middleware/common/include/common/transaction/transaction.h
@@ -42,10 +42,10 @@ namespace casual
          State state = State::active;
 
          //! @return true if `trid` is _active_ 
-         explicit operator bool() const;
+         explicit operator bool() const noexcept;
 
          //! associated rm:s to this transaction
-         inline const std::vector< strong::resource::id>& involved() const { return m_involved;}
+         inline const std::vector< strong::resource::id>& involved() const noexcept { return m_involved;}
          
          //! associate resource
          void involve( strong::resource::id id);
@@ -58,7 +58,7 @@ namespace casual
          }  
 
          //! dynamic associated rm:s to this transaction, a subset to `involved`
-         inline const std::vector< strong::resource::id>& dynamic() const { return m_dynamic;}
+         inline const std::vector< strong::resource::id>& dynamic() const noexcept { return m_dynamic;}
          
          //! associate id to dynamic registration
          //! @attention will not associate with involved
@@ -74,31 +74,31 @@ namespace casual
 
          //! @return true if this transaction has any pending replies
          //! associated
-         bool pending() const;
+         bool pending() const noexcept;
 
          //! @return true if this transaction has @p correlation associated
-         bool associated( const correlation_type& correlation) const;
+         bool associated( const correlation_type& correlation) const noexcept;
 
          //! associated descriptors to this transaction
-         const std::vector< correlation_type>& correlations() const;
+         const std::vector< correlation_type>& correlations() const noexcept;
 
          //! functions to deduce or set if the transaction is suspended
          //! or not.
          void suspend();
          void resume();
-         bool suspended() const;
+         bool suspended() const noexcept;
 
          //! @return true if the transaction is only local, current process 
          //!  is the owner, no pending calls, and no external involvement
-         bool local() const;
+         bool local() const noexcept;
 
 
          //! Associate this transaction with 'external' resources. That is,
          //! make it "not local" so it will trigger a commit request to the TM
          void external();
 
-         friend bool operator == ( const Transaction& lhs, const ID& rhs);
-         friend bool operator == ( const Transaction& lhs, const XID& rhs);
+         friend bool operator == ( const Transaction& lhs, const ID& rhs) noexcept;
+         friend bool operator == ( const Transaction& lhs, const XID& rhs) noexcept;
 
          CASUAL_LOG_SERIALIZE({
             CASUAL_SERIALIZE( trid);

--- a/middleware/common/makefile.cmk
+++ b/middleware/common/makefile.cmk
@@ -214,6 +214,8 @@ unittest_objectfiles = [
     make.Compile( 'unittest/source/test_algorithm.cpp'),
     make.Compile( 'unittest/source/container/sorted/test_set.cpp'),
 
+    make.Compile( 'unittest/source/test_code.cpp'),
+
     make.Compile( 'unittest/source/test_range.cpp'),
     make.Compile( 'unittest/source/test_execute.cpp'),
     make.Compile( 'unittest/source/test_execution.cpp'),

--- a/middleware/common/source/transaction/resource.cpp
+++ b/middleware/common/source/transaction/resource.cpp
@@ -32,240 +32,239 @@ static std::ostream& operator << ( std::ostream& out, const xa_switch_t& xa)
 
 namespace casual
 {
-   namespace common
+   namespace common::transaction
    {
-      namespace transaction
+
+
+      namespace local
       {
-
-         namespace local
+         namespace
          {
-            namespace
+            XID* non_const_xid( const transaction::ID& transaction)
             {
-               XID* non_const_xid( const transaction::ID& transaction)
-               {
-                  return const_cast< XID*>( &transaction.xid);
-               }
-
-               Resource::code convert( int code)
-               {
-                  return static_cast<  Resource::code>( code);
-               }
-
-
-            } // <unnamed>
-         } // local
-
-         Resource::Resource( resource::Link link, strong::resource::id id, std::string openinfo, std::string closeinfo)
-            : m_key( std::move( link.key)), m_xa( link.xa), m_id(std::move( id)), m_openinfo( std::move( openinfo)), m_closeinfo( std::move( closeinfo))
-         {
-            if( ! m_xa)
-               common::code::raise::error( common::code::casual::invalid_argument, "xa-switch is null");
-
-            log::line( log::category::transaction, "associated resource: ", *this);
-         }
-
-
-         Resource::code Resource::start( const transaction::ID& transaction, Flags flags) noexcept
-         {
-            log::line( log::category::transaction, "start resource: ", m_id, " transaction: ", transaction, " flags: ", flags);
-
-            auto result = reopen_guard( [&]()
-            { 
-               return local::convert( m_xa->xa_start_entry( local::non_const_xid( transaction), m_id.value(), flags.underlying()));
-            });
-
-            // this is an extra fallback/try to mitigate possible race-conditions when 
-            // A a-calls B and C ( B, C with same rm) within same transaction and synchronisation is done with TM
-            // still the last one to get reply might do xa_start first (depending on OS context switches and so on...) 
-            if( result == code::duplicate_xid && ! flags.exist( Flag::join))
-            {
-               // Transaction is already associated with this thread of control, we try to join instead
-               log::line( log::category::transaction, result, " - action: try to join instead");
-
-               flags |= Flag::join;
-
-               result = local::convert( m_xa->xa_start_entry( local::non_const_xid( transaction), m_id.value(), flags.underlying()));
+               return const_cast< XID*>( &transaction.xid);
             }
 
-            if( result != code::ok)
-               log::line( log::category::error, result, " failed to start resource - ", m_id, " - trid: ", transaction, ", flags, ", flags);
-
-            return result;
-         }
-
-         Resource::code Resource::end( const transaction::ID& transaction, Flags flags) noexcept
-         {
-            log::line( log::category::transaction, "end resource: ", m_id, ", transaction: ", transaction, ", flags: ", flags);
-
-            auto result = reopen_guard( [&]()
+            code::xa convert( int code)
             {
-               return local::convert( m_xa->xa_end_entry( local::non_const_xid( transaction), m_id.value(), flags.underlying()));
-            });
-
-            if( result != code::ok)
-               log::line( log::category::error, result, " failed to end resource - ", m_id, " - trid: ", transaction, ", flags: ", flags);
-
-            return result;
-         }
-
-         Resource::code Resource::open( Flags flags) noexcept
-         {
-            auto info = common::environment::expand( m_openinfo);
-            log::line( log::category::transaction, "open resource: ", m_id, ", openinfo: ", info, ", flags: ", flags);
-
-            auto result = local::convert( m_xa->xa_open_entry( info.c_str(), m_id.value(), flags.underlying()));
-
-            // we send an event if we fail to open resource
-            if( result != code::ok)
-               common::event::error::send( result, "failed to open resource: ", m_id, " '", m_xa->name, "'");
-
-            return result;
-         }
-
-         Resource::code Resource::close( Flags flags) noexcept
-         {
-            auto info = common::environment::expand( m_closeinfo);
-            log::line( log::category::transaction, "close resource: ", m_id, ", closeinfo: ", info, ", flags: ", flags);
-
-            auto result = local::convert( m_xa->xa_close_entry( info.c_str(), m_id.value(), flags.underlying()));
-
-            if( result != code::ok)
-               log::line( log::category::error, result, " failed to close resource: ", m_id, " '", m_xa->name, "'");
-
-            return result;
-         }
-
-         Resource::code Resource::prepare( const transaction::ID& transaction, Flags flags) noexcept
-         {
-            log::line( log::category::transaction, "prepare resource: ", m_id, " transaction: ", transaction, " flags: ", flags);
-
-            auto result = reopen_guard( [&]()
-            {
-               return local::convert( m_xa->xa_prepare_entry( local::non_const_xid( transaction), m_id.value(), flags.underlying()));
-            });
-
-            if( result == common::code::xa::protocol)
-            {
-               // we need to check if we've already prepared the transaction to this physical RM.
-               // that is, we now we haven't in this domain, but another domain could have prepared
-               // this transaction to the same "resource-server" that both domains _have connections to_
-               if( prepared( transaction))
-               {
-                  log::line( log::category::transaction, common::code::xa::read_only, " trid already prepared: ", m_id, " trid: ", transaction, " flags: ", flags);
-                  return common::code::xa::read_only;
-               }
+               return static_cast<  code::xa>( code);
             }
 
-            log::line( log::category::transaction, result, " prepare rm: ", m_id, " trid: ", transaction, " flags: ", flags);
+            namespace log
+            {
+               template< typename... Ts>
+               auto code( code::xa code, strong::resource::id rm, Ts&&... ts)
+               {
+                  if( code != code::xa::ok)
+                     common::log::line( common::log::category::error, code, " resource: ", rm, " - ", std::forward< Ts>( ts)...);
 
+                  return code;
+               }
+            } // log
+
+
+         } // <unnamed>
+      } // local
+
+      Resource::Resource( resource::Link link, strong::resource::id id, std::string openinfo, std::string closeinfo)
+         : m_key( std::move( link.key)), m_xa( link.xa), m_id(std::move( id)), m_openinfo( std::move( openinfo)), m_closeinfo( std::move( closeinfo))
+      {
+         if( ! m_xa)
+            common::code::raise::error( common::code::casual::invalid_argument, "xa-switch is null");
+
+         log::line( log::category::transaction, "associated resource: ", *this);
+      }
+
+
+      code::xa Resource::start( const transaction::ID& transaction, Flags flags) noexcept
+      {
+         log::line( log::category::transaction, "start resource: ", m_id, " transaction: ", transaction, " flags: ", flags);
+
+         auto result = reopen_guard( [&]()
+         { 
+            return local::convert( m_xa->xa_start_entry( local::non_const_xid( transaction), m_id.value(), flags.underlying()));
+         });
+
+         // this is an extra fallback/try to mitigate possible race-conditions when 
+         // A a-calls B and C ( B, C with same rm) within same transaction and synchronisation is done with TM
+         // still the last one to get reply might do xa_start first (depending on OS context switches and so on...) 
+         if( result == code::xa::duplicate_xid && ! flags.exist( Flag::join))
+         {
+            // Transaction is already associated with this thread of control, we try to join instead
+            log::line( log::category::transaction, result, " - action: try to join instead");
+
+            flags |= Flag::join;
+            result = local::convert( m_xa->xa_start_entry( local::non_const_xid( transaction), m_id.value(), flags.underlying()));
+         }
+
+         return local::log::code( result, m_id, "failed to start trid: ", transaction, ", flags: ", flags);
+      }
+
+      code::xa Resource::end( const transaction::ID& transaction, Flags flags) noexcept
+      {
+         log::line( log::category::transaction, "end resource: ", m_id, ", transaction: ", transaction, ", flags: ", flags);
+
+         auto result = reopen_guard( [&]()
+         {
+            return local::convert( m_xa->xa_end_entry( local::non_const_xid( transaction), m_id.value(), flags.underlying()));
+         });
+
+         return local::log::code( result, m_id, "failed to end trid: ", transaction, ", flags: ", flags);
+      }
+
+      code::xa Resource::open( Flags flags) noexcept
+      {
+         auto info = common::environment::expand( m_openinfo);
+         log::line( log::category::transaction, "open resource: ", m_id, ", openinfo: ", info, ", flags: ", flags);
+
+         auto result = local::convert( m_xa->xa_open_entry( info.c_str(), m_id.value(), flags.underlying()));
+
+         // we send an event if we fail to open resource
+         if( result != code::xa::ok)
+            common::event::error::send( result, "failed to open resource: ", m_id, " '", m_xa->name, "'");
+
+         return result;
+      }
+
+      code::xa Resource::close( Flags flags) noexcept
+      {
+         auto info = common::environment::expand( m_closeinfo);
+         log::line( log::category::transaction, "close resource: ", m_id, ", closeinfo: ", info, ", flags: ", flags);
+
+         auto result = local::convert( m_xa->xa_close_entry( info.c_str(), m_id.value(), flags.underlying()));
+
+         return local::log::code( result, m_id, "failed to close - flags: ", flags);
+      }
+
+      code::xa Resource::prepare( const transaction::ID& transaction, Flags flags) noexcept
+      {
+         log::line( log::category::transaction, "prepare resource: ", m_id, " transaction: ", transaction, " flags: ", flags);
+
+         auto result = reopen_guard( [&]()
+         {
+            return local::convert( m_xa->xa_prepare_entry( local::non_const_xid( transaction), m_id.value(), flags.underlying()));
+         });
+
+         if( result == common::code::xa::protocol)
+         {
+            // we need to check if we've already prepared the transaction to this physical RM.
+            // that is, we know we haven't in this domain, but another domain could have prepared
+            // this transaction to the same "resource-server" that both domains _have connections to_
+            if( prepared( transaction))
+            {
+               log::line( log::category::transaction, common::code::xa::read_only, " trid already prepared: ", m_id, " trid: ", transaction, " flags: ", flags);
+               return common::code::xa::read_only;
+            }
+         }
+
+         log::line( log::category::transaction, result, " prepare rm: ", m_id, " trid: ", transaction, " flags: ", flags);
+
+         return result;
+      }
+
+      code::xa Resource::commit( const transaction::ID& transaction, Flags flags) noexcept
+      {
+         log::line( log::category::transaction, "commit resource: ", m_id, " transaction: ", transaction, " flags: ", flags);
+
+         return reopen_guard( [&]()
+         {
+            return local::convert( m_xa->xa_commit_entry( local::non_const_xid( transaction), m_id.value(), flags.underlying()));
+         });
+      }
+
+      code::xa Resource::rollback( const transaction::ID& transaction, Flags flags) noexcept
+      {
+         log::line( log::category::transaction, "rollback resource: ", m_id, " transaction: ", transaction, " flags: ", flags);
+
+         return reopen_guard( [&]()
+         {
+            return local::convert( m_xa->xa_rollback_entry( local::non_const_xid( transaction), m_id.value(), flags.underlying()));
+         });
+      }
+
+      bool Resource::dynamic() const noexcept
+      {
+         return static_cast< flag::xa::resource::Flags>( m_xa->flags).exist( flag::xa::resource::Flag::dynamic);
+      }
+
+      bool Resource::migrate() const noexcept
+      {
+         return ! flag::xa::resource::Flags{ m_xa->flags}.exist( flag::xa::resource::Flag::no_migrate);
+      }
+
+      code::xa Resource::reopen()
+      {
+         log::line( log::category::transaction, "reopen resource: ", m_id);
+
+         // we don't care if close "fails".
+         close();
+         return open();
+      }
+
+      template< typename F>
+      code::xa Resource::reopen_guard( F&& functor)
+      {
+         auto result = functor();
+
+         if( result != code::xa::resource_fail)
             return result;
-         }
+         
+         log::line( log::category::error, result, " failed to interact with resource ", m_id, " - action: try to reopen the resource");
+                     
+         // we try to reopen the resource, and apply the functor again
 
-         Resource::code Resource::commit( const transaction::ID& transaction, Flags flags) noexcept
+         if( reopen() != code::xa::ok)
+            return result;  // did not work, we return the original code
+
+         return functor();
+      }
+
+      bool Resource::prepared( const transaction::ID& transaction)
+      {
+         std::array< XID, platform::batch::transaction::recover> xids;
+
+         int count = xids.size();
+         flag::xa::Flags flags = flag::xa::Flag::start_scan;
+
+         while(  count == range::size( xids))
          {
-            log::line( log::category::transaction, "commit resource: ", m_id, " transaction: ", transaction, " flags: ", flags);
+            count = m_xa->xa_recover_entry( xids.data(), xids.size(), m_id.value(), flags.underlying());
 
-            return reopen_guard( [&]()
+            if( count < 0)
             {
-               return local::convert( m_xa->xa_commit_entry( local::non_const_xid( transaction), m_id.value(), flags.underlying()));
-            });
-         }
-
-         Resource::code Resource::rollback( const transaction::ID& transaction, Flags flags) noexcept
-         {
-            log::line( log::category::transaction, "rollback resource: ", m_id, " transaction: ", transaction, " flags: ", flags);
-
-            return reopen_guard( [&]()
-            {
-               return local::convert( m_xa->xa_rollback_entry( local::non_const_xid( transaction), m_id.value(), flags.underlying()));
-            });
-         }
-
-         bool Resource::dynamic() const noexcept
-         {
-            return static_cast< flag::xa::resource::Flags>( m_xa->flags).exist( flag::xa::resource::Flag::dynamic);
-         }
-
-         bool Resource::migrate() const noexcept
-         {
-            return ! flag::xa::resource::Flags{ m_xa->flags}.exist( flag::xa::resource::Flag::no_migrate);
-         }
-
-         Resource::code Resource::reopen()
-         {
-            log::line( log::category::transaction, "reopen resource: ", m_id);
-
-            // we don't care if close "fails".
-            close();
-            return open();
-         }
-
-         template< typename F>
-         Resource::code Resource::reopen_guard( F&& functor)
-         {
-            auto result = functor();
-
-            if( result != code::resource_fail)
-               return result;
-            
-            log::line( log::category::error, result, " failed to interact with resource ", m_id, " - action: try to reopen the resource");
-                        
-            // we try to reopen the resource, and apply the functor again
-
-            if( reopen() != code::ok)
-               return result;  // did not work, we return the original code
-
-            return functor();
-         }
-
-         bool Resource::prepared( const transaction::ID& transaction)
-         {
-            std::array< XID, platform::batch::transaction::recover> xids;
-
-            int count = xids.size();
-            flag::xa::Flags flags = flag::xa::Flag::start_scan;
-
-            while(  count == range::size( xids))
-            {
-               count = m_xa->xa_recover_entry( xids.data(), xids.size(), m_id.value(), flags.underlying());
-
-               if( count < 0)
-               {
-                  log::line( log::category::error, local::convert( count), " failed to invoke xa_recover - rm: ", m_id);
-                  return false;
-               }
-
-               if( common::algorithm::find( range::make( std::begin( xids), count), transaction.xid))
-               {
-                  // we found it. Make sure to end the scan if there are more.
-                  if( count == range::size( xids))
-                  {
-                     m_xa->xa_recover_entry(
-                        xids.data(), 1, m_id.value(),
-                        cast::underlying( flag::xa::Flag::end_scan));
-                  }
-
-                  return true;
-               }
-               flags = flag::xa::Flag::no_flags;
+               log::line( log::category::error, local::convert( count), " failed to invoke xa_recover - rm: ", m_id);
+               return false;
             }
 
-            return false;
+            if( common::algorithm::find( range::make( std::begin( xids), count), transaction.xid))
+            {
+               // we found it. Make sure to end the scan if there are more.
+               if( count == range::size( xids))
+               {
+                  m_xa->xa_recover_entry(
+                     xids.data(), 1, m_id.value(),
+                     cast::underlying( flag::xa::Flag::end_scan));
+               }
+
+               return true;
+            }
+            flags = flag::xa::Flag::no_flags;
          }
 
-
-         std::ostream& operator << ( std::ostream& out, const Resource& resource)
-         {
-            return stream::write( out, "{ key: ", resource.m_key,
-               ", id: ", resource.m_id,
-               ", openinfo: ", resource.m_openinfo,
-               ", closeinfo: ", resource.m_closeinfo,
-               ", xa: ", *resource.m_xa, 
-               '}');
-         }
+         return false;
+      }
 
 
-      } //transaction
-   } // common
+      std::ostream& operator << ( std::ostream& out, const Resource& resource)
+      {
+         return stream::write( out, "{ key: ", resource.m_key,
+            ", id: ", resource.m_id,
+            ", openinfo: ", resource.m_openinfo,
+            ", closeinfo: ", resource.m_closeinfo,
+            ", xa: ", *resource.m_xa, 
+            '}');
+      }
+
+   } // common::transaction
 
 } // casual

--- a/middleware/common/source/transaction/transaction.cpp
+++ b/middleware/common/source/transaction/transaction.cpp
@@ -22,7 +22,7 @@ namespace casual
          Transaction::Transaction() = default;
          Transaction::Transaction( ID trid) : trid( std::move( trid)) {}
          
-         Transaction::operator bool() const { return static_cast< bool>( trid);}
+         Transaction::operator bool() const noexcept { return predicate::boolean( trid);}
 
          void Transaction::associate( const correlation_type& correlation)
          {
@@ -56,22 +56,22 @@ namespace casual
             return false;
          }
 
-         bool Transaction::pending() const
+         bool Transaction::pending() const noexcept
          {
             return ! m_pending.empty();
          }
 
-         bool Transaction::associated( const correlation_type& correlation) const
+         bool Transaction::associated( const correlation_type& correlation) const noexcept
          {
             return ! algorithm::find( m_pending, correlation).empty();
          }
 
-         const std::vector< Transaction::correlation_type>& Transaction::correlations() const
+         const std::vector< Transaction::correlation_type>& Transaction::correlations() const noexcept
          {
             return m_pending;
          }
 
-         bool Transaction::local() const
+         bool Transaction::local() const noexcept
          {
             return trid.owner().pid == process::id() && ! m_external;
          }
@@ -83,11 +83,11 @@ namespace casual
 
          void Transaction::suspend() { m_suspended = true;}
          void Transaction::resume() { m_suspended = false;}
-         bool Transaction::suspended() const { return m_suspended;}
+         bool Transaction::suspended() const noexcept { return m_suspended;}
 
-         bool operator == ( const Transaction& lhs, const ID& rhs) { return lhs.trid == rhs;}
+         bool operator == ( const Transaction& lhs, const ID& rhs) noexcept { return lhs.trid == rhs;}
 
-         bool operator == ( const Transaction& lhs, const XID& rhs) { return lhs.trid.xid == rhs;}
+         bool operator == ( const Transaction& lhs, const XID& rhs) noexcept { return lhs.trid.xid == rhs;}
 
          std::string_view description( Transaction::State value) noexcept
          {

--- a/middleware/common/source/unittest/rm.cpp
+++ b/middleware/common/source/unittest/rm.cpp
@@ -147,7 +147,7 @@ namespace casual
       {
          auto& state = local::global::state.at( id);
 
-         transaction::context().resource_registration( id, &state.transactions.current.xid);
+         log::line( log, "resource registration: ", transaction::context().resource_registration( id, &state.transactions.current.xid));
 
       }
 

--- a/middleware/common/unittest/source/test_code.cpp
+++ b/middleware/common/unittest/source/test_code.cpp
@@ -1,0 +1,44 @@
+//!
+//! Copyright (c) 2022, The casual project
+//!
+//! This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+//!
+
+#include "common/unittest.h"
+
+#include "common/code/tx.h"
+
+namespace casual
+{
+   namespace common
+   {
+
+      TEST( common_code, tx_accumulate)
+      {
+         unittest::Trace trace;
+
+         auto test_code = []( auto lhs, auto rhs, auto result)
+         {
+            EXPECT_TRUE( lhs + rhs == result);
+            EXPECT_TRUE( rhs + lhs == result);
+            return lhs + rhs == result && rhs + lhs == result;
+         };
+
+         // no begin combination
+         EXPECT_TRUE( test_code( code::tx::not_supported, code::tx::argument, code::tx::not_supported));
+         EXPECT_TRUE( test_code( code::tx::no_begin , code::tx::rollback, code::tx::no_begin_rollback));
+         EXPECT_TRUE( test_code( code::tx::no_begin , code::tx::committed, code::tx::no_begin_committed));
+         EXPECT_TRUE( test_code( code::tx::no_begin , code::tx::mixed, code::tx::no_begin_mixed));
+         EXPECT_TRUE( test_code( code::tx::no_begin , code::tx::hazard, code::tx::no_begin_hazard));
+
+
+         EXPECT_TRUE( test_code( code::tx::ok, code::tx::no_begin, code::tx::no_begin));
+
+         EXPECT_TRUE( test_code( code::tx::ok, code::tx::rollback, code::tx::rollback));
+
+         
+
+      }
+      
+   } // common
+} // casual

--- a/middleware/common/unittest/source/transaction/test_context.cpp
+++ b/middleware/common/unittest/source/transaction/test_context.cpp
@@ -24,7 +24,7 @@ namespace casual
          {
             common::unittest::Trace trace;
 
-            EXPECT_TRUE( Context::instance().current().trid.null());
+            EXPECT_TRUE( context().current().trid.null());
          }
 
 
@@ -35,25 +35,25 @@ namespace casual
 
             XID xid;
 
-            EXPECT_CODE( Context::instance().suspend( &xid);, code::tx::protocol);
+            EXPECT_TRUE( context().suspend( &xid) == code::tx::protocol);
          }
 
          TEST( common_transaction_context, begin__expect_transaction)
          {
             common::unittest::Trace trace;
 
-            EXPECT_NO_THROW( Context::instance().begin());
-            EXPECT_TRUE( ! Context::instance().current().trid.null());
-            EXPECT_NO_THROW( Context::instance().commit());
+            EXPECT_EQ( context().begin(), code::tx::ok);
+            EXPECT_TRUE( ! context().current().trid.null());
+            EXPECT_EQ( context().commit(), code::tx::ok);
          }
 
          TEST( common_transaction_context, two_begin__expect_TX_PROTOCOLL_ERROR)
          {
             common::unittest::Trace trace;
 
-            EXPECT_NO_THROW( context().begin());
-            EXPECT_CODE( context().begin();, code::tx::protocol);
-            EXPECT_NO_THROW( context().rollback());
+            EXPECT_EQ( context().begin(), code::tx::ok);
+            EXPECT_EQ( context().begin(), code::tx::protocol);
+            EXPECT_EQ( context().rollback(), code::tx::ok);
          }
 
          TEST( common_transaction_context, begin_suspend_resume__rollback__expect_TX_OK)
@@ -62,11 +62,11 @@ namespace casual
 
             XID xid;
 
-            ASSERT_NO_THROW( Context::instance().begin());
-            ASSERT_NO_THROW( Context::instance().suspend( &xid));
-            EXPECT_TRUE( Context::instance().current().trid.null());
-            ASSERT_NO_THROW( Context::instance().resume( &xid));
-            ASSERT_NO_THROW( Context::instance().rollback());
+            EXPECT_EQ( context().begin(), code::tx::ok);
+            ASSERT_EQ( context().suspend( &xid), code::tx::ok);
+            EXPECT_TRUE( context().current().trid.null());
+            ASSERT_EQ( context().resume( &xid), code::tx::ok);
+            ASSERT_EQ( context().rollback(), code::tx::ok);
          }
 
          TEST( common_transaction_context, begin__10__suspend_begin_suspend_resume__rollback__expect_TX_OK)
@@ -74,43 +74,43 @@ namespace casual
             common::unittest::Trace trace;
 
             // global...
-            ASSERT_NO_THROW( Context::instance().begin());
+            ASSERT_EQ( context().begin(), code::tx::ok);
 
             std::vector< XID> xids( 10);
 
             // start 10 new ones...
             for( auto& xid : xids)
             {
-               ASSERT_NO_THROW( Context::instance().suspend( &xid));
-               EXPECT_TRUE( Context::instance().current().trid.null());
-               ASSERT_NO_THROW( Context::instance().begin());
+               ASSERT_EQ( context().suspend( &xid), code::tx::ok);
+               EXPECT_TRUE( context().current().trid.null());
+               ASSERT_EQ( context().begin(), code::tx::ok);
             }
 
             for( auto& xid : xids)
             {
-               EXPECT_NO_THROW( Context::instance().commit());
-               ASSERT_NO_THROW( Context::instance().resume( &xid)) << "xid: " << xid;
-               EXPECT_TRUE( Context::instance().current().trid == xid);
+               EXPECT_EQ( context().commit(), code::tx::ok);
+               ASSERT_EQ( context().resume( &xid), code::tx::ok) << "xid: " << xid;
+               EXPECT_TRUE( context().current().trid == xid);
             }
 
-            EXPECT_NO_THROW( Context::instance().rollback());
+            EXPECT_EQ( context().rollback(), code::tx::ok);
          }
 
          TEST( common_transaction_context, no_xid__expect___pending_false)
          {
             common::unittest::Trace trace;
 
-            EXPECT_TRUE( ! Context::instance().pending());
+            EXPECT_TRUE( ! context().pending());
          }
 
          TEST( common_transaction_context, begin___expect__pending_true)
          {
             common::unittest::Trace trace;
 
-            Context::instance().begin();
+            ASSERT_EQ( context().begin(), code::tx::ok);
 
-            EXPECT_TRUE( Context::instance().pending());
-            Context::instance().commit();
+            EXPECT_TRUE( context().pending());
+            EXPECT_EQ( context().commit(), code::tx::ok);
          }
 
          TEST( common_transaction_context, join_extern_trid___expect__pending_false)
@@ -119,20 +119,21 @@ namespace casual
 
             auto trid = transaction::id::create( process::Handle{ strong::process::id{ 1}, {}});
 
-            Context::instance().join( trid);
+            ASSERT_NO_THROW( context().join( trid));
 
-            EXPECT_TRUE( ! Context::instance().pending());
-            Context::instance().finalize( false);
+            EXPECT_TRUE( ! context().pending());
+            
+            context().finalize( false);
          }
 
          TEST( common_transaction_context, begin_commit__expect_context_empty)
          {
             common::unittest::Trace trace;
 
-            EXPECT_NO_THROW( context().begin());
-            EXPECT_TRUE( ! Context::instance().empty());
-            EXPECT_NO_THROW( context().commit());
-            EXPECT_TRUE( Context::instance().empty());
+            EXPECT_EQ( context().begin(), code::tx::ok);
+            EXPECT_TRUE( ! context().empty());
+            EXPECT_EQ( context().commit(), code::tx::ok);
+            EXPECT_TRUE( context().empty());
             
          }
 

--- a/middleware/example/makefile.cmk
+++ b/middleware/example/makefile.cmk
@@ -44,10 +44,10 @@ install_bin.append( target)
 # make sure we got a resource property file available when we build with a resource 
 make.Environment( 'CASUAL_RESOURCE_CONFIGURATION_FILE', casual_middleware_path + '/example/resources/resources.yaml')
 
+resource_objects = [ make.Compile( 'server/source/example/resource.cpp')]
+
 target = dsl.LinkServer( 'server/bin/casual-example-resource-server',
-    [ 
-       make.Compile( 'server/source/example/resource.cpp')
-    ],
+    resource_objects,
     [ 
         'casual-common',
         'casual-buffer'
@@ -55,6 +55,19 @@ target = dsl.LinkServer( 'server/bin/casual-example-resource-server',
     'server/source/example/resource.services.yaml')
 
 install_bin.append( target)
+
+# same as above, but does not name the resource, hence we can configure multiple
+# resources (of rm-mockup)
+target = dsl.LinkServer( 'server/bin/casual-example-dynamic-resource-server',
+    resource_objects,
+    [ 
+        'casual-common',
+        'casual-buffer'
+    ],
+    'server/source/example/dynamic.resource.services.yaml')
+
+install_bin.append( target)
+
 
 
 target = make.LinkExecutable( 'server/bin/casual-example-error-server',

--- a/middleware/example/server/source/example/dynamic.resource.services.yaml
+++ b/middleware/example/server/source/example/dynamic.resource.services.yaml
@@ -1,0 +1,23 @@
+
+server:
+  default:
+    service:
+      transaction: auto
+      category: example
+
+  resources:
+    - key: rm-mockup
+    - key: rm-mockup
+
+  services:
+    - name: casual/example/dynamic/resource/echo
+      function: casual_example_resource_echo
+
+    - name: casual/example/dynamic/resource/branch/echo
+      function: casual_example_resource_echo
+      transaction: branch
+
+    - name: casual/example/dynamic/resource/domain/name
+      function: casual_example_resource_domain_name
+
+

--- a/middleware/gateway/unittest/source/test_manager.cpp
+++ b/middleware/gateway/unittest/source/test_manager.cpp
@@ -1226,7 +1226,7 @@ domain:
          {
             using namespace std::literals;
 
-            transaction::context().begin();
+            EXPECT_EQ( transaction::context().begin(), code::tx::ok);
 
             buffer::Payload payload;
             payload.type = "X_OCTET/";
@@ -1265,6 +1265,8 @@ domain:
             EXPECT_TRUE( reply.trid == transaction::context().current().trid);
 
          }
+
+         EXPECT_EQ( transaction::context().commit(), code::tx::ok);
 
 
       }

--- a/middleware/queue/unittest/source/test_queue.cpp
+++ b/middleware/queue/unittest/source/test_queue.cpp
@@ -582,9 +582,9 @@ domain:
 
          // dequeue, and rollback
          {
-            common::transaction::context().begin();
+            EXPECT_EQ( common::transaction::context().begin(), common::code::tx::ok);
             ASSERT_TRUE( ! queue::dequeue( name).empty());
-            common::transaction::context().rollback();
+            EXPECT_EQ( common::transaction::context().rollback(), common::code::tx::ok);
          }  
 
          // not available yet
@@ -782,7 +782,7 @@ domain:
 
          {
             // simulate a uncommitted dequeue
-            common::transaction::context().begin();
+            EXPECT_EQ( common::transaction::context().begin(), common::code::tx::ok);
             queue::dequeue( "a1");
             {
                auto messages = unittest::messages( "a1");
@@ -803,7 +803,7 @@ domain:
          }
 
          // rollback simulated uncommited dequeue, otherwise casual-queue-group has ongoing transactions
-         common::transaction::context().rollback();
+         EXPECT_EQ( common::transaction::context().rollback(), common::code::tx::ok);
       }
 
       TEST( casual_queue, enqueue_1___dequeue_message___recover_rollback____expect_1_message_in_queue)
@@ -827,7 +827,7 @@ domain:
 
          {
             // simulate a uncommitted dequeue
-            common::transaction::context().begin();
+            EXPECT_EQ( common::transaction::context().begin(), common::code::tx::ok);
             queue::dequeue( "a1");
             {
                auto messages = unittest::messages( "a1");
@@ -854,7 +854,7 @@ domain:
             }
 
             // rollback simulated uncommited dequeue, otherwise casual-queue-group has ongoing transactions
-            common::transaction::context().rollback();
+            EXPECT_EQ( common::transaction::context().rollback(), common::code::tx::ok);
          }
 
      }

--- a/middleware/transaction/unittest/source/test_manager.cpp
+++ b/middleware/transaction/unittest/source/test_manager.cpp
@@ -164,8 +164,7 @@ domain:
             {
                try
                {
-                  action();
-                  return common::code::tx::ok;
+                  return action();
                }
                catch( ...)
                {
@@ -175,17 +174,17 @@ domain:
 
             auto begin() 
             {
-               return wrap( [](){ common::transaction::context().begin();});
+               return wrap( [](){ return common::transaction::context().begin();});
             }
 
             auto commit() 
             {
-               return wrap( [](){ common::transaction::context().commit();});
+               return wrap( [](){ return common::transaction::context().commit();});
             }
 
             auto rollback() 
             {
-               return wrap( [](){ common::transaction::context().rollback();});
+               return wrap( [](){ return common::transaction::context().rollback();});
             }
 
          } // <unnamed>
@@ -504,7 +503,7 @@ domain:
 
          auto domain = local::domain( local::configuration::system, local::configuration::base);
 
-         EXPECT_TRUE( local::begin() == common::code::tx::ok);
+         EXPECT_EQ( local::begin(), common::code::tx::ok);
 
          // Make sure we make the transaction distributed
          auto state = unittest::state();
@@ -521,10 +520,7 @@ domain:
             EXPECT_TRUE( reply.involved.empty());
          }
 
-         auto result = local::commit();
-         ASSERT_TRUE( result == common::code::tx::hazard) << "result: " << result;
-
-         EXPECT_TRUE( local::rollback() == common::code::tx::ok);
+         EXPECT_EQ( local::commit(), common::code::tx::hazard);
       }
 
 

--- a/middleware/xatmi/source/xa.cpp
+++ b/middleware/xatmi/source/xa.cpp
@@ -35,8 +35,8 @@ extern "C"
    {
       try
       {
-         casual::common::transaction::context().resource_registration( casual::common::strong::resource::id{ rmid}, xid);
-         return casual::common::cast::underlying( casual::common::code::ax::ok);
+         return casual::common::cast::underlying( 
+            casual::common::transaction::context().resource_registration( casual::common::strong::resource::id{ rmid}, xid));
       }
       catch( ...)
       {
@@ -48,8 +48,8 @@ extern "C"
    {
       try
       {
-         casual::common::transaction::context().resource_unregistration( casual::common::strong::resource::id{ rmid});
-         return casual::common::cast::underlying( casual::common::code::ax::ok);
+         return casual::common::cast::underlying( 
+            casual::common::transaction::context().resource_unregistration( casual::common::strong::resource::id{ rmid}));
       }
       catch( ...)
       {

--- a/middleware/xatmi/unittest/source/test_tx.cpp
+++ b/middleware/xatmi/unittest/source/test_tx.cpp
@@ -143,16 +143,18 @@ namespace casual
          {
             common::unittest::Trace trace;
 
-            tx_set_transaction_control( TX_CHAINED);
+            ASSERT_EQ( tx_set_transaction_control( TX_CHAINED), TX_OK);
 
-            ASSERT_TRUE( tx_begin() == TX_OK);
-            EXPECT_TRUE( tx_info( nullptr) == 1);
-            EXPECT_TRUE( tx_commit() == TX_OK);
-            EXPECT_TRUE( tx_info( nullptr) == 1);
+            EXPECT_EQ( tx_begin(), TX_OK);
+            EXPECT_EQ( tx_info( nullptr), 1);
+            EXPECT_EQ( tx_commit(), TX_OK);
+            // expect a new transaction to start
+            EXPECT_EQ( tx_info( nullptr), 1);
 
-            tx_set_transaction_control( TX_UNCHAINED);
+            EXPECT_EQ( tx_set_transaction_control( TX_UNCHAINED), TX_OK);
 
-            EXPECT_TRUE( tx_commit() == TX_OK);
+            EXPECT_EQ( tx_commit(), TX_OK);
+            EXPECT_EQ( tx_info( nullptr), 0);
          }
 
          TEST( xatmi_tx, chained_control__tx_begin_tx_begin__expect_TX_PROTOCOLL_ERROR)

--- a/test/unittest/source/xatmi/test_call.cpp
+++ b/test/unittest/source/xatmi/test_call.cpp
@@ -298,7 +298,7 @@ domain:
 
          auto domain = local::domain();
 
-         ASSERT_TRUE( tx_begin() == TX_OK);
+         ASSERT_EQ( tx_begin(), TX_OK);
 
          auto buffer = local::allocate( 128);
          auto len = tptypes( buffer, nullptr, nullptr);
@@ -307,7 +307,7 @@ domain:
          EXPECT_TRUE( tperrno == TPESVCERR) << "tperrno: " << tperrnostring( tperrno);
          tpfree( buffer);
 
-         EXPECT_TRUE( tx_rollback() == TX_OK);
+         EXPECT_EQ( tx_rollback(), TX_OK);
       }
 
       // Test disabled for now. There seems to be a somewhat generic "bug"

--- a/test/unittest/source/xatmi/test_conversation.cpp
+++ b/test/unittest/source/xatmi/test_conversation.cpp
@@ -519,7 +519,7 @@ domain:
          // ( the service will also echo all data it receives before
          //  getting control with a tpsend before the tpreturn. In this test there
          // is no data in the connect and therefore no tpsend is done by the service)
-         EXPECT_TRUE( tx_begin() == TX_OK);
+         EXPECT_EQ( tx_begin(), TX_OK);
          auto descriptor = tpconnect( "casual/example/conversation_recv_send", nullptr, 0, TPRECVONLY);
          EXPECT_TRUE( descriptor != -1);
          EXPECT_TRUE( tperrno == 0) << "tperrno:" << tperrnostring( tperrno);
@@ -527,7 +527,7 @@ domain:
          auto result = local::receive::invoke( descriptor, TPSIGRSTRT);
          EXPECT_TRUE( result.payload == "Flags: 0x00000c10") << CASUAL_NAMED_VALUE( result);
 
-         EXPECT_TRUE( tx_rollback() == TX_OK);
+         EXPECT_EQ( tx_rollback(), TX_OK);
 
          EXPECT_TRUE( tpdiscon( descriptor) == -1);
 


### PR DESCRIPTION
Before: When the prepare stage failed we tried to _pop transaction_, which rendered a core -> we didn't have any on "the stack", by design.

Now:

* We don't core :)
* If transaction is "bad" we propagate this on the regular _reply.code.result_ channel -> service call gives error
* Fixed a few unittest where we didn't explicitly called tx_rollback() after tx_commit() returned TX_ROLLBACK.

fixes issue #96