### PR TITLE
build - Fix compile errors in 1.6 stream that occurs with g++-11

### DIFF
--- a/middleware/common/include/common/communication/socket.h
+++ b/middleware/common/include/common/communication/socket.h
@@ -12,6 +12,7 @@
 
 #include <fcntl.h>
 #include <sys/socket.h>
+#include <optional>
 
 namespace casual
 {

--- a/middleware/common/unittest/source/container/sorted/test_set.cpp
+++ b/middleware/common/unittest/source/container/sorted/test_set.cpp
@@ -46,7 +46,7 @@ namespace casual
       auto origin = array::make( 5, 6, 1, 3, 34, 32425, 2342, 23, 1231);
 
       container::sorted::Set< long> set( std::begin( origin), std::end( origin));
-      EXPECT_TRUE( set.size() == origin.size());
+      EXPECT_TRUE( range::size(set) == range::size(origin));
       EXPECT_TRUE( algorithm::is::sorted( set));
       EXPECT_TRUE( algorithm::equal( set, algorithm::sort( origin)));
    }
@@ -60,7 +60,7 @@ namespace casual
       auto b = std::move( a);
       EXPECT_TRUE( a.empty());
 
-      EXPECT_TRUE( b.size() == origin.size());
+      EXPECT_TRUE( range::size( b) == range::size( origin));
       EXPECT_TRUE( algorithm::is::sorted( b));
       EXPECT_TRUE( algorithm::equal( b, algorithm::sort( origin)));
    }
@@ -192,7 +192,7 @@ namespace casual
       auto b = std::move( a);
       EXPECT_TRUE( a.empty());
 
-      EXPECT_TRUE( b.size() == origin.size()) << CASUAL_NAMED_VALUE( b);
+      EXPECT_TRUE( range::size( b) == range::size( origin)) << CASUAL_NAMED_VALUE( b);
       EXPECT_TRUE( algorithm::is::sorted( b));
    }
 

--- a/middleware/service/source/manager/handle.cpp
+++ b/middleware/service/source/manager/handle.cpp
@@ -791,7 +791,20 @@ namespace casual
                         }
 
                         // check if some of the rest has _routes_
-                        for( auto& name : std::get< 1>( algorithm::sorted::intersection( message.content.services(), reply.content.services())))
+                        // Note:
+                        // The following commented for stmt generates a warning about
+                        // use of a possibly uninitialized variable in
+                        // commmon/range.h when compiling with g++-11 (and 10)
+                        // without --debug. The warning did not occur with g++-9.
+                        // Introducing a local variable to hold the result of the
+                        // call to intersection() makes the warning go away.
+                        //
+                        // Unknown why the warning appears. Possibly some rule about
+                        // lifetimes, order of evaluation or similiar affects the
+                        // involved code. 
+                        //for( auto& name : std::get< 1>( algorithm::sorted::intersection( message.content.services(), reply.content.services())))
+                        auto intersect = algorithm::sorted::intersection( message.content.services(), reply.content.services());
+                        for( auto& name : std::get< 1>( intersect))
                            if( auto found = algorithm::find( state.reverse_routes, name))
                               reply.routes.services.emplace_back( found->first, found->second);
 

--- a/middleware/service/source/manager/handle.cpp
+++ b/middleware/service/source/manager/handle.cpp
@@ -790,25 +790,14 @@ namespace casual
                            reply.content.services( algorithm::sort( algorithm::accumulate( algorithm::sort( message.content.services()), Services{}, service_accumulate)));
                         }
 
-                        // check if some of the rest has _routes_
-                        // Note:
-                        // The following commented for stmt generates a warning about
-                        // use of a possibly uninitialized variable in
-                        // commmon/range.h when compiling with g++-11 (and 10)
-                        // without --debug. The warning did not occur with g++-9.
-                        // Introducing a local variable to hold the result of the
-                        // call to intersection() makes the warning go away.
-                        //
-                        // Unknown why the warning appears. Possibly some rule about
-                        // lifetimes, order of evaluation or similiar affects the
-                        // involved code. 
-                        //for( auto& name : std::get< 1>( algorithm::sorted::intersection( message.content.services(), reply.content.services())))
-                        auto intersect = algorithm::sorted::intersection( message.content.services(), reply.content.services());
-                        for( auto& name : std::get< 1>( intersect))
-                           if( auto found = algorithm::find( state.reverse_routes, name))
-                              reply.routes.services.emplace_back( found->first, found->second);
+                        // 'lookup' routes for services that the caller is interested in
+                        {
+                           const auto difference = std::get< 1>( algorithm::sorted::intersection( message.content.services(), reply.content.services()));
 
-
+                           for( auto& name : difference)
+                              if( auto found = algorithm::find( state.reverse_routes, name))
+                                 reply.routes.services.emplace_back( found->first, found->second); 
+                        }
 
                         local::optional::send( state, message.process.ipc, reply);
                      };


### PR DESCRIPTION
Compiling with g++-11 produces errors (or warnings treated as errors in the build) that did not occur with gcc-9.

The compiler I used showed "gcc version 11.3.0 (SUSE Linux)" when invoked with "-v".

Three problems fixed:
1) Missing #include <optional> in common/communication/socket.h.
   There was no type std::optional. Compiler suggested adding the
   include. (Header probably indirectly included with earlier versions.)

2) Warning about possible use of uninitialized variable when compiling
   service/source/manager/handle.cpp near line 795. This warning only
   showed up in builds without --debug! Introducing a local variable
   to hold the result of a call to
      algoritm::sorted::intersection()
   made the warning go away. I have not investigated if the warning
   is correct or a compiler bug (unlikely:-).
   The warning did not occur in g++-9. With g++-10 the warning occured
   but with a message that provided essentially no context.
   In g++-11 the message was much improved.

3) fix waring about integer compare with different signedness.
   (This warning has also appeared for some users with g++-9
   after the introduction of container::sorted::Set)

   test_set.cpp had three instances of integer compares with different
   signedness. Something like:
      set.size() == origin.size()
   where "set" is a container::sorted::Set and "origin" is constructed with
   array::make().

   Replaced with
     range::size( set) == range::size( origin)