### PR TITLE
gateway - immediately send error reply on failed resource request

### DIFF
--- a/middleware/administration/makefile.cmk
+++ b/middleware/administration/makefile.cmk
@@ -15,6 +15,7 @@ make.IncludePaths( [
     '../queue/include',
     '../transaction/include',
     '../gateway/include',
+    '../gateway/unittest/include',
     '../tools/include',
     '../buffer/include']
     + make.optional_include_paths()
@@ -98,12 +99,16 @@ make.LinkUnittest( 'unittest/bin/test-casual-administration',
       make.Compile( 'unittest/source/cli/test_domain.cpp'),
       make.Compile( 'unittest/source/cli/configuration/test_normalize.cpp'),
       make.Compile( 'unittest/source/cli/test_internal.cpp'),
+      make.Compile( 'unittest/source/cli/test_transaction.cpp'),
    ],
    [ 
       unittest_lib,
-      'casual-common', 
+      'casual-common',
+      'casual-xatmi',
       'casual-unittest',
       'casual-domain-unittest',
+      'casual-gateway-unittest',
+      'casual-serviceframework',
    ])
 
 

--- a/middleware/administration/unittest/source/cli/test_transaction.cpp
+++ b/middleware/administration/unittest/source/cli/test_transaction.cpp
@@ -1,0 +1,106 @@
+//!
+//! Copyright (c) 2022, The casual project
+//!
+//! This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+//!
+
+#include "common/unittest.h"
+
+#include "domain/unittest/manager.h"
+
+#include "administration/unittest/cli/command.h"
+
+#include "gateway/unittest/utility.h"
+
+#include "casual/tx.h"
+#include "casual/xatmi.h"
+
+namespace casual
+{
+   using namespace common;
+
+   namespace administration
+   {
+      namespace local
+      {
+         namespace
+         {
+            namespace cli
+            {
+               constexpr auto base = R"(
+domain:
+   servers:
+      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager"
+      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/casual-transaction-manager"
+      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/gateway/bin/casual-gateway-manager"
+)";
+
+               template< typename... C>
+               auto domain( C&&... configurations)
+               {
+                  return casual::domain::unittest::manager( base, std::forward< C>( configurations)...);
+               }
+
+               auto call( std::string_view service)
+               {
+                  auto buffer = tpalloc( X_OCTET, nullptr, 128);
+                  common::unittest::random::range( range::make( buffer, 128));
+                  auto len = tptypes( buffer, nullptr, nullptr);
+
+                  tpcall( service.data(), buffer, 128, &buffer, &len, 0);
+                  EXPECT_TRUE( tperrno == 0) << "tperrno: " << tperrnostring( tperrno);
+
+                  return memory::guard( buffer, &tpfree);
+               };
+
+            } // cli
+         } // <unnamed>
+      } // local
+
+      TEST( cli_transaction, list_external_resources__expect_outbound_gateways_to_be_listed)
+      {
+         common::unittest::Trace trace;
+
+         auto b = local::cli::domain( R"(
+domain: 
+   name: B
+
+   servers:
+      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+
+   gateway:
+      inbound:
+         groups:
+            -  connections: 
+               -  address: 127.0.0.1:7001
+)");
+
+         auto a = local::cli::domain( R"(
+domain: 
+   name: A
+
+   gateway:
+      outbound:
+         groups:
+            -  alias: outbound_B
+               connections:
+                  -  address: 127.0.0.1:7001
+)");
+         gateway::unittest::fetch::until( gateway::unittest::fetch::predicate::outbound::connected());
+
+         EXPECT_TRUE( administration::unittest::cli::command::execute( R"(casual transaction --list-external-resources --porcelain true)").string().empty());
+
+         // Call B in transaction to 'discover' outbound as external resource
+         ASSERT_TRUE( tx_begin() == TX_OK);
+         local::cli::call( "casual/example/domain/echo/B");
+         ASSERT_TRUE( tx_commit() == TX_OK);
+
+         std::string output = administration::unittest::cli::command::execute( R"(casual transaction --list-external-resources --porcelain true | cut -d '|' -f 2)").string();
+
+         constexpr auto expected = R"(outbound_B
+)";
+         EXPECT_TRUE( output == expected) << "output:  " << output << "expected: " << expected;
+      }
+
+   } // administration
+} // casual

--- a/middleware/domain/source/manager/task/create.cpp
+++ b/middleware/domain/source/manager/task/create.cpp
@@ -562,7 +562,7 @@ namespace casual
                }
             };
 
-            return manager::Task{ "remove alieases", scale::local::group::task( std::move( groups), std::move( done_callback)),
+            return manager::Task{ "remove aliases", scale::local::group::task( std::move( groups), std::move( done_callback)),
             {
                Task::Property::Execution::sequential,
                Task::Property::Completion::mandatory

--- a/middleware/gateway/source/group/outbound/handle.cpp
+++ b/middleware/gateway/source/group/outbound/handle.cpp
@@ -61,7 +61,7 @@ namespace casual
                   }
 
                   return {};
-               }     
+               }
             } // tcp
 
             namespace internal
@@ -114,10 +114,12 @@ namespace casual
                                  state.multiplex.send( destination.ipc, reply);
                               });
 
-                              tcp::send( state, descriptor, message);
+                              // if we fail to send we want to invoke the error callback immediately
+                              if( ! tcp::send( state, descriptor, message).valid())
+                                 state.route.consume( message.correlation).error();
                            };
                         }
-                     } // basic                       
+                     } // basic
 
                      //! These messages has the extern branched transaction.
                      //! @{

--- a/middleware/gateway/source/group/outbound/state/route.cpp
+++ b/middleware/gateway/source/group/outbound/state/route.cpp
@@ -17,7 +17,7 @@ namespace casual
       {
          void Point::error()
          {
-            Trace trace{ "gateway::group::outbound::state::rout::Point::error"};
+            Trace trace{ "gateway::group::outbound::state::route::Point::error"};
             log::line( verbose::log, "point: ", *this);
 
             callback( destination);

--- a/test/unittest/source/test_transaction.cpp
+++ b/test/unittest/source/test_transaction.cpp
@@ -22,13 +22,6 @@
 
 #include "transaction/unittest/utility.h"
 
-#include "administration/unittest/cli/command.h"
-
-#include "gateway/unittest/utility.h"
-
-#include "casual/tx.h"
-#include "casual/xatmi.h"
-
 namespace casual
 {
    using namespace common;
@@ -473,95 +466,6 @@ domain:
             // no ongoing transaction
             EXPECT_TRUE( tx_info( nullptr) == 0);
             
-         }
-
-
-         // TODO this should not be here - move it to middleware/administration/unittest
-         namespace local
-         {
-            namespace
-            {
-               namespace cli
-               {
-                  constexpr auto base = R"(
-domain:
-   servers:
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager"
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/casual-transaction-manager"
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/gateway/bin/casual-gateway-manager"
-)";
-
-                  template< typename... C>
-                  auto domain( C&&... configurations)
-                  {
-                     return casual::domain::unittest::manager( base, std::forward< C>( configurations)...);
-                  }
-
-                  auto call( std::string_view service)
-                  {
-                     auto buffer = tpalloc( X_OCTET, nullptr, 128);
-                     common::unittest::random::range( range::make( buffer, 128));
-                     auto len = tptypes( buffer, nullptr, nullptr);
-
-                     tpcall( service.data(), buffer, 128, &buffer, &len, 0);
-                     EXPECT_TRUE( tperrno == 0) << "tperrno: " << tperrnostring( tperrno);
-
-                     return memory::guard( buffer, &tpfree);
-                  };
-
-               } // cli
-            } // <unnamed>
-         } // local
-
-         // TODO this should not be here - move it to middleware/administration/unittest
-         TEST( test_transaction, cli_list_external_resources__expect_outbound_gateways_to_be_listed)
-         {
-            common::unittest::Trace trace;
-            local::Clear clear;
-
-            constexpr auto A = R"(
-domain: 
-   name: A
-  
-   gateway:
-      outbound:
-         groups:
-            -  alias: outbound_B
-               connections:
-                  -  address: 127.0.0.1:7001
-)";
-
-            constexpr auto B = R"(
-domain: 
-   name: B
-
-   servers:
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
-
-   gateway:
-      inbound:
-         groups:
-            -  connections: 
-               -  address: 127.0.0.1:7001
-)";
-
-            auto b = local::cli::domain( B);
-
-            auto a = local::cli::domain( A);
-            gateway::unittest::fetch::until( gateway::unittest::fetch::predicate::outbound::connected());
-
-            EXPECT_TRUE(administration::unittest::cli::command::execute( R"(casual transaction --list-external-resources --porcelain true)").string().empty());
-
-            // Call B in transaction to 'discover' outbound as external resource
-            ASSERT_TRUE( tx_begin() == TX_OK);
-            local::cli::call( "casual/example/domain/echo/B");
-            ASSERT_TRUE( tx_commit() == TX_OK);
-
-            std::string output = administration::unittest::cli::command::execute( R"(casual transaction --list-external-resources --porcelain true | cut -d '|' -f 2)").string();
-
-            constexpr auto expected = R"(outbound_B
-)";
-            EXPECT_TRUE( output == expected) << "output:  " << output << "expected: " << expected;
          }
 
       } // transaction


### PR DESCRIPTION
Before:
We took no immediate action when failing to correlate a descriptor with a connection when sending resource requests.
This would occasionally lead to situations where casual-queue-forward would hang waiting on a commit/rollback reply.

Now:
We confirm that the message was successfully sent and immediately invoke the error-callback if not.

Fixes #98