### PR TITLE
queue - add browse-peek to queue api

### DIFF
--- a/middleware/common/include/common/message/type.h
+++ b/middleware/common/include/common/message/type.h
@@ -224,17 +224,19 @@ namespace casual
          queue_group_message_meta_peek_reply,
          queue_group_message_peek_request = QUEUE_BASE + 320,
          queue_group_message_peek_reply,
-         queue_group_message_remove_request = QUEUE_BASE + 330,
+         queue_group_message_browse_request = QUEUE_BASE + 330,
+         queue_group_message_browse_reply,
+         queue_group_message_remove_request = QUEUE_BASE + 340,
          queue_group_message_remove_reply,
          queue_group_message_recovery_request,
          queue_group_message_recovery_reply,
 
-         queue_group_queue_restore_request = QUEUE_BASE + 340,
+         queue_group_queue_restore_request = QUEUE_BASE + 350,
          queue_group_queue_restore_reply,
          queue_group_queue_clear_request,
          queue_group_queue_clear_reply,
 
-         queue_group_metric_reset_request = QUEUE_BASE + 350,
+         queue_group_metric_reset_request = QUEUE_BASE + 360,
          queue_group_metric_reset_reply,
 
          queue_forward_group_connect = QUEUE_BASE + 400,

--- a/middleware/common/source/message/type.cpp
+++ b/middleware/common/source/message/type.cpp
@@ -137,6 +137,8 @@ namespace casual
             case Type::queue_group_message_meta_peek_reply: return "queue_group_message_meta_peek_reply";
             case Type::queue_group_message_peek_request: return "queue_group_message_peek_request";
             case Type::queue_group_message_peek_reply: return "queue_group_message_peek_reply";
+            case Type::queue_group_message_browse_request: return "queue_group_message_browse_request";
+            case Type::queue_group_message_browse_reply: return "queue_group_message_browse_reply";
             case Type::queue_group_message_remove_request: return "queue_group_message_remove_request";
             case Type::queue_group_message_remove_reply: return "queue_group_message_remove_reply";
             case Type::queue_group_message_recovery_request: return "queue_group_message_recovery_request";

--- a/middleware/queue/include/casual/queue/c/queue.h
+++ b/middleware/queue/include/casual/queue/c/queue.h
@@ -16,6 +16,9 @@ extern "C" {
 typedef long casual_message_descriptor_t;
 typedef long casual_selector_descriptor_t;
 
+/* */
+typedef int (*casual_browse_callback_t)( casual_selector_descriptor_t, void* state);
+
 struct casual_buffer_t 
 {
    char* data;
@@ -40,6 +43,9 @@ typedef struct casual_buffer_t casual_buffer_t;
 
 extern int casual_queue_get_errno();
 #define casual_qerrno casual_queue_get_errno()
+
+/* @returns the error string associated with the code. if not found "<unknown>" is returned*/
+extern const char* casual_queue_error_string( int code);
 
 
 
@@ -120,6 +126,17 @@ extern casual_message_descriptor_t casual_queue_dequeue( const char* queue, casu
      and call `tpfree` on the buffer associated with the descriptor
  */
 extern casual_message_descriptor_t casual_queue_peek( const char* queue, casual_selector_descriptor_t selector);
+
+/*
+   browse peek the given `queue`, for each message on the queue invoke the `callback`, with current 
+   message and the provided `state`, until the there is no messages left to peek, or user returns 
+   _false_ (0) from the callback.
+   `state` can of course bi null if no state is needed.
+   @attention No memory management is needed by the user, all memory management is taken care of by the
+         unction. Hence, no deletion of the _message description_.
+   @returns 0 on success -1 on error and casual_qerrno is set
+*/
+extern int casual_queue_browse_peek( const char* queue, casual_browse_callback_t callback, void* state);
 
 
 #ifdef __cplusplus

--- a/middleware/queue/include/queue/api/queue.h
+++ b/middleware/queue/include/queue/api/queue.h
@@ -14,6 +14,7 @@
 #include "casual/platform.h"
 #include "common/uuid.h"
 #include "common/transaction/global.h"
+#include "common/functional.h"
 
 
 namespace casual
@@ -24,21 +25,21 @@ namespace casual
 
       common::Uuid enqueue( const std::string& queue, const Message& message);
 
-      std::vector< Message> dequeue( const std::string& queue);
-      std::vector< Message> dequeue( const std::string& queue, const Selector& selector);
+      [[nodiscard]] std::vector< Message> dequeue( const std::string& queue);
+      [[nodiscard]] std::vector< Message> dequeue( const std::string& queue, const Selector& selector);
 
       namespace blocking
       {
-         Message dequeue( const std::string& queue);
-         Message dequeue( const std::string& queue, const Selector& selector);
+         [[nodiscard]] Message dequeue( const std::string& queue);
+         [[nodiscard]] Message dequeue( const std::string& queue, const Selector& selector);
 
          namespace available
          {
             //! If requested queue is not found (advertised), we will wait until it's
             //! available, and then block.
             //! @{
-            Message dequeue( const std::string& queue);
-            Message dequeue( const std::string& queue, const Selector& selector);
+            [[nodiscard]] Message dequeue( const std::string& queue);
+            [[nodiscard]] Message dequeue( const std::string& queue, const Selector& selector);
             //! @}
 
          } // available
@@ -46,19 +47,28 @@ namespace casual
 
       namespace peek
       {
-         std::vector< message::Information> information( const std::string& queue);
-         std::vector< message::Information> information( const std::string& queue, const Selector& selector);
+         [[nodiscard]] std::vector< message::Information> information( const std::string& queue);
+         [[nodiscard]] std::vector< message::Information> information( const std::string& queue, const Selector& selector);
 
-         std::vector< Message> messages( const std::string& queue, const std::vector< queue::Message::id_type>& ids);
+         [[nodiscard]] std::vector< Message> messages( const std::string& queue, const std::vector< queue::Message::id_type>& ids);
       } // peek
 
+      namespace browse
+      {
+         // we could add _browse::dequeue_ 
+
+         //! peeks the next messages until queue is empty or user return false from `callback`
+         void peek( std::string queue, common::unique_function< bool(Message&&)> callback);
+         
+      } // browse
+
+      
       namespace xatmi
       {
-
          common::Uuid enqueue( const std::string& queue, const Message& message);
 
-         std::vector< Message> dequeue( const std::string& queue);
-         std::vector< Message> dequeue( const std::string& queue, const Selector& selector);
+         [[nodiscard]] std::vector< Message> dequeue( const std::string& queue);
+         [[nodiscard]] std::vector< Message> dequeue( const std::string& queue, const Selector& selector);
 
       } // xatmi
 

--- a/middleware/queue/include/queue/common/ipc/message.h
+++ b/middleware/queue/include/queue/common/ipc/message.h
@@ -771,6 +771,43 @@ namespace casual
 
             } // peek
 
+            namespace browse
+            {
+               using base_request = common::message::basic_request< common::message::Type::queue_group_message_browse_request>;
+               struct Request : base_request
+               {
+                  using base_request::base_request;
+
+                  common::strong::queue::id queue;
+
+                  //! Should be set to the last browsed message timestamp (or nothing if it's the first request),
+                  //! hence act as the pivot point of which messages to browse.
+                  platform::time::point::type last{};
+
+                  CASUAL_CONST_CORRECT_SERIALIZE(
+                     base_request::serialize( archive);
+                     CASUAL_SERIALIZE( queue);
+                     CASUAL_SERIALIZE( last);
+                  )
+               };
+
+               using base_reply = common::message::basic_message< common::message::Type::queue_group_message_browse_reply>;
+               struct Reply : base_reply
+               {
+                  using base_reply::base_reply;
+
+                  std::optional< dequeue::Message> message;
+
+                  inline explicit operator bool() const noexcept { return common::predicate::boolean( message);}
+
+                  CASUAL_CONST_CORRECT_SERIALIZE(
+                     base_reply::serialize( archive);
+                     CASUAL_SERIALIZE( message);
+                  )
+               };
+               
+            } // browse
+
             namespace remove
             {
                using base_request = common::message::basic_request< common::message::Type::queue_group_message_remove_request>;
@@ -1026,69 +1063,64 @@ namespace casual
 
    } // queue::ipc::message
    
-   namespace common
+   namespace common::message::reverse
    {
-      namespace message
-      {
-         namespace reverse
-         {
-            template<>
-            struct type_traits< casual::queue::ipc::message::lookup::Request> : detail::type< casual::queue::ipc::message::lookup::Reply> {};
+      template<>
+      struct type_traits< casual::queue::ipc::message::lookup::Request> : detail::type< casual::queue::ipc::message::lookup::Reply> {};
 
-            template<>
-            struct type_traits< casual::queue::ipc::message::lookup::discard::Request> : detail::type< casual::queue::ipc::message::lookup::discard::Reply> {};
+      template<>
+      struct type_traits< casual::queue::ipc::message::lookup::discard::Request> : detail::type< casual::queue::ipc::message::lookup::discard::Reply> {};
 
 
-            template<>
-            struct type_traits< casual::queue::ipc::message::group::configuration::update::Request> : detail::type< casual::queue::ipc::message::group::configuration::update::Reply> {};
+      template<>
+      struct type_traits< casual::queue::ipc::message::group::configuration::update::Request> : detail::type< casual::queue::ipc::message::group::configuration::update::Reply> {};
 
-            template<>
-            struct type_traits< casual::queue::ipc::message::group::state::Request> : detail::type< casual::queue::ipc::message::group::state::Reply> {};
+      template<>
+      struct type_traits< casual::queue::ipc::message::group::state::Request> : detail::type< casual::queue::ipc::message::group::state::Reply> {};
 
-            template<>
-            struct type_traits< casual::queue::ipc::message::group::message::meta::Request> : detail::type< casual::queue::ipc::message::group::message::meta::Reply> {};
+      template<>
+      struct type_traits< casual::queue::ipc::message::group::message::meta::Request> : detail::type< casual::queue::ipc::message::group::message::meta::Reply> {};
 
-            template<>
-            struct type_traits< casual::queue::ipc::message::group::message::meta::peek::Request> : detail::type< casual::queue::ipc::message::group::message::meta::peek::Reply> {};
+      template<>
+      struct type_traits< casual::queue::ipc::message::group::message::meta::peek::Request> : detail::type< casual::queue::ipc::message::group::message::meta::peek::Reply> {};
 
-            template<>
-            struct type_traits< casual::queue::ipc::message::group::message::peek::Request> : detail::type< casual::queue::ipc::message::group::message::peek::Reply> {};
+      template<>
+      struct type_traits< casual::queue::ipc::message::group::message::peek::Request> : detail::type< casual::queue::ipc::message::group::message::peek::Reply> {};
 
-            template<>
-            struct type_traits< casual::queue::ipc::message::group::message::remove::Request> : detail::type< casual::queue::ipc::message::group::message::remove::Reply> {};
+      template<>
+      struct type_traits< casual::queue::ipc::message::group::message::browse::Request> : detail::type< casual::queue::ipc::message::group::message::browse::Reply> {};
 
-            template<>
-            struct type_traits< casual::queue::ipc::message::group::message::recovery::Request> : detail::type< casual::queue::ipc::message::group::message::recovery::Reply> {};
+      template<>
+      struct type_traits< casual::queue::ipc::message::group::message::remove::Request> : detail::type< casual::queue::ipc::message::group::message::remove::Reply> {};
 
-            template<>
-            struct type_traits< casual::queue::ipc::message::group::enqueue::Request> : detail::type< casual::queue::ipc::message::group::enqueue::Reply> {};
+      template<>
+      struct type_traits< casual::queue::ipc::message::group::message::recovery::Request> : detail::type< casual::queue::ipc::message::group::message::recovery::Reply> {};
 
-            template<>
-            struct type_traits< casual::queue::ipc::message::group::dequeue::Request> : detail::type< casual::queue::ipc::message::group::dequeue::Reply> {};
+      template<>
+      struct type_traits< casual::queue::ipc::message::group::enqueue::Request> : detail::type< casual::queue::ipc::message::group::enqueue::Reply> {};
 
-            template<>
-            struct type_traits< casual::queue::ipc::message::group::dequeue::forget::Request> : detail::type< casual::queue::ipc::message::group::dequeue::forget::Reply> {};
+      template<>
+      struct type_traits< casual::queue::ipc::message::group::dequeue::Request> : detail::type< casual::queue::ipc::message::group::dequeue::Reply> {};
 
-
-            template<>
-            struct type_traits< casual::queue::ipc::message::group::queue::restore::Request> : detail::type< casual::queue::ipc::message::group::queue::restore::Reply> {};
-
-            template<>
-            struct type_traits< casual::queue::ipc::message::group::queue::clear::Request> : detail::type< casual::queue::ipc::message::group::queue::clear::Reply> {};
-
-            template<>
-            struct type_traits< casual::queue::ipc::message::group::metric::reset::Request> : detail::type< casual::queue::ipc::message::group::metric::reset::Reply> {};
+      template<>
+      struct type_traits< casual::queue::ipc::message::group::dequeue::forget::Request> : detail::type< casual::queue::ipc::message::group::dequeue::forget::Reply> {};
 
 
-            template<>
-            struct type_traits< casual::queue::ipc::message::forward::group::configuration::update::Request> : detail::type< casual::queue::ipc::message::forward::group::configuration::update::Reply> {};
+      template<>
+      struct type_traits< casual::queue::ipc::message::group::queue::restore::Request> : detail::type< casual::queue::ipc::message::group::queue::restore::Reply> {};
 
-            template<>
-            struct type_traits< casual::queue::ipc::message::forward::group::state::Request> : detail::type< casual::queue::ipc::message::forward::group::state::Reply> {};
-         
+      template<>
+      struct type_traits< casual::queue::ipc::message::group::queue::clear::Request> : detail::type< casual::queue::ipc::message::group::queue::clear::Reply> {};
 
-         } // reverse
+      template<>
+      struct type_traits< casual::queue::ipc::message::group::metric::reset::Request> : detail::type< casual::queue::ipc::message::group::metric::reset::Reply> {};
 
-      } // message
-   } // common
+
+      template<>
+      struct type_traits< casual::queue::ipc::message::forward::group::configuration::update::Request> : detail::type< casual::queue::ipc::message::forward::group::configuration::update::Reply> {};
+
+      template<>
+      struct type_traits< casual::queue::ipc::message::forward::group::state::Request> : detail::type< casual::queue::ipc::message::forward::group::state::Reply> {};
+   
+   } // common::message::reverse
 } // casual

--- a/middleware/queue/include/queue/group/queuebase.h
+++ b/middleware/queue/include/queue/group/queuebase.h
@@ -133,16 +133,21 @@ namespace casual
          std::optional< queuebase::Queue> queue( common::strong::queue::id id);
          //! @}
 
-         queue::ipc::message::group::enqueue::Reply enqueue( const queue::ipc::message::group::enqueue::Request& message);
+         queue::ipc::message::group::enqueue::Reply enqueue( const queue::ipc::message::group::enqueue::Request& request);
          
          queue::ipc::message::group::dequeue::Reply dequeue( 
-            const queue::ipc::message::group::dequeue::Request& message, 
+            const queue::ipc::message::group::dequeue::Request& request, 
             const platform::time::point::type& now);
 
          //! 'meta peek' to get information about messages
          queue::ipc::message::group::message::meta::peek::Reply peek( const queue::ipc::message::group::message::meta::peek::Request& request);
          //! actual peek of messages
          queue::ipc::message::group::message::peek::Reply peek( const queue::ipc::message::group::message::peek::Request& request);
+
+         //! browse the next message
+         queue::ipc::message::group::message::browse::Reply browse( 
+            const queue::ipc::message::group::message::browse::Request& request,
+            const platform::time::point::type& now);
 
          //! @returns all queues that is found in `queues` and has messages potentially available for dequeue
          std::vector< queuebase::message::Available> available( std::vector< common::strong::queue::id> queues) const;

--- a/middleware/queue/include/queue/group/queuebase/statement.h
+++ b/middleware/queue/include/queue/group/queuebase/statement.h
@@ -63,6 +63,12 @@ namespace casual
             sql::database::Statement one_message;
          } peek;
 
+         struct
+         {
+            sql::database::Statement first;
+         } browse;
+
+         
          sql::database::Statement restore;
          sql::database::Statement clear;
 

--- a/middleware/queue/source/group/handle.cpp
+++ b/middleware/queue/source/group/handle.cpp
@@ -322,7 +322,7 @@ namespace casual
                   {
                      auto request( State& state)
                      {
-                        return [&state]( const queue::ipc::message::group::message::meta::peek::Request& message)
+                        return [ &state]( const queue::ipc::message::group::message::meta::peek::Request& message)
                         {
                            Trace trace{ "queue::handle::local::peek::information::Request"};
 
@@ -336,9 +336,9 @@ namespace casual
                   {
                      auto request( State& state)
                      {
-                        return [&state]( const queue::ipc::message::group::message::peek::Request& message)
+                        return [ &state]( const queue::ipc::message::group::message::peek::Request& message)
                         {
-                           Trace trace{ "queue::handle::local::peek::information::Request"};
+                           Trace trace{ "queue::handle::local::peek::messages::Request"};
 
                            state.multiplex.send( message.process.ipc, state.queuebase.peek( message));
                         };
@@ -346,6 +346,19 @@ namespace casual
                   } // messages
 
                } // peek
+
+               namespace browse
+               {
+                  auto request( State& state)
+                  {
+                     return [ &state]( const queue::ipc::message::group::message::browse::Request& message)
+                     {
+                        Trace trace{ "queue::handle::local::browse::Request"};
+
+                        state.multiplex.send( message.process.ipc, state.queuebase.browse( message, platform::time::clock::type::now()));
+                     };
+                  }
+               } // browse
 
                namespace transaction
                {
@@ -865,6 +878,7 @@ namespace casual
             handle::local::state::request( state),
             handle::local::peek::information::request( state),
             handle::local::peek::messages::request( state),
+            handle::local::browse::request( state),
             handle::local::restore::request( state),
             handle::local::clear::request( state),
             handle::local::message::meta::request( state),

--- a/middleware/queue/source/group/queuebase/statement.cpp
+++ b/middleware/queue/source/group/queuebase/statement.cpp
@@ -44,26 +44,27 @@ namespace casual
          {
             Trace trace{ "queue::group::Database::Database precompile statements dequeue"};
 
-            result.dequeue.first = connection.precompile( 
-                  "SELECT"
-                     " ROWID, id, properties, reply, redelivered, type, available, timestamp, payload"
-                  " FROM"
-                     " message"
-                  " WHERE queue = :queue AND state = 2 AND available < :available ORDER BY timestamp ASC, available ASC LIMIT 1;");
+            result.dequeue.first = connection.precompile( R"(
+SELECT
+   ROWID, id, properties, reply, redelivered, type, available, timestamp, payload
+FROM
+   message
+WHERE queue = :queue AND state = 2 AND available < :available ORDER BY timestamp ASC, available ASC LIMIT 1; )");
 
-            result.dequeue.first_id = connection.precompile(  
-                  "SELECT"
-                     " ROWID, id, properties, reply, redelivered, type, available, timestamp, payload"
-                  " FROM "
-                     " message"
-                  " WHERE id = :id AND queue = :queue AND state = 2 AND available < :available;");
+            result.dequeue.first_id = connection.precompile( R"(
+SELECT
+   ROWID, id, properties, reply, redelivered, type, available, timestamp, payload
+FROM 
+   message
+WHERE id = :id AND queue = :queue AND state = 2 AND available < :available; )");
 
-            result.dequeue.first_match = connection.precompile(
-                  "SELECT"
-                     " ROWID, id, properties, reply, redelivered, type, available, MIN( timestamp), payload"
-                  " FROM"
-                     " message"
-                  " WHERE queue = :queue AND state = 2 AND properties = :properties AND available < :available;");
+            result.dequeue.first_match = connection.precompile( R"(
+SELECT
+   ROWID, id, properties, reply, redelivered, type, available, MIN( timestamp), payload
+FROM
+   message
+WHERE queue = :queue AND state = 2 AND properties = :properties AND available < :available; )");
+
          }
 
 
@@ -204,6 +205,8 @@ WHERE
 
          }
 
+
+         // peek
          {
             Trace trace{ "queue::group::Database::Database precompile statements peek"};
 
@@ -242,6 +245,22 @@ FROM
 WHERE id = :id; )");
 
          }
+
+
+         // browse
+         {
+            Trace trace{ "queue::group::Database::Database precompile statements browse"};
+
+            result.browse.first = connection.precompile( R"(
+SELECT
+   ROWID, id, properties, reply, redelivered, type, available, timestamp, payload
+FROM
+   message
+WHERE queue = :queue AND state = 2 AND timestamp > :timestamp AND available < :available ORDER BY timestamp ASC, available ASC LIMIT 1; )");
+
+
+         }
+
 
          result.restore = connection.precompile(R"( 
             UPDATE message 


### PR DESCRIPTION
Add _browsing_ functionality to the queue api. User provided callback gets invoked with a message until the queue is empty or the callback returns false.

Corresponding C-api added as well.

We could expand on this in the future and have the same semantics for browse-dequeue. It might be a better api for the user.