### PR TITLE
event: add service sequential/concurrent order to event-service-log

### DIFF
--- a/middleware/event/documentation/service.log.md
+++ b/middleware/event/documentation/service.log.md
@@ -32,15 +32,24 @@ domain:
 
 Columns are separated by the provided `delimiter` option (default `|`)
 
-column    | format  | description
-----------|---------|------------------------
-service   | string  | name of the invoked service
-parent    | string  | name of the parent service, if any.
-pid       | integer | process id of the invoked instance 
-execution | uuid    | unique _execution id_, like _breadcrumbs_ 
-trid      | xid     | transaction id
-start     | integer | when the service was invoked, `us` since epoch.
-end       | integer | when the service was done, `us` since epoch
-code      | string  | outcome of the service call. `OK` if ok, otherwise the reported error from the service
+column    | format    | description
+----------|-----------|------------------------
+service   | string    | name of the invoked service
+parent    | string    | name of the parent service, if any.
+pid       | integer   | process id of the invoked instance 
+execution | uuid      | unique _execution id_, like _breadcrumbs_ 
+trid      | xid       | transaction id
+start     | integer   | when the service was invoked, `us` since epoch.
+end       | integer   | when the service was done, `us` since epoch
+pending   | integer   | how long caller had to wait for a non busy server, in `us`
+code      | string    | outcome of the service call. `OK` if ok, otherwise the reported error from the service
+order     | character | "order" of the service - sequential or concurrent, denoted by `S` or `C`. `S` reserves a process, `C` does not.
+
+### example
+
+```
+some/service|some/parent/service|9585|ff75bcc6ef1b4d1c8ae8d58ee0918f81|3d7519f801e4f65a127d9ac09fa159d:b81a4d8715ad44e8afccb796a02fd77f:42:123|1670372749162496|1670372749162723|0|OK|S
+``` 
+
 
 

--- a/middleware/event/source/service/log/main.cpp
+++ b/middleware/event/source/service/log/main.cpp
@@ -118,6 +118,7 @@ namespace casual
                      }),
                      common::event::condition::done( [&done]() { return done;})
                   );
+                  
 
                   common::event::listen(
                      std::move( conditions),
@@ -127,8 +128,10 @@ namespace casual
                         {
                            if( ! filter( metric))
                               return;
-
+                           
                            common::log::line( event::verbose::log, "metric: ", metric);
+
+                           auto service_category = []( auto type){ return type == decltype( type)::sequential ? 'S' : 'C';};
 
                            log.file << metric.service
                               << log.delimiter << metric.parent
@@ -139,6 +142,7 @@ namespace casual
                               << log.delimiter << std::chrono::duration_cast< std::chrono::microseconds>( metric.end.time_since_epoch()).count()
                               << log.delimiter << std::chrono::duration_cast< std::chrono::microseconds>( metric.pending).count()
                               << log.delimiter << common::code::description( metric.code)
+                              << log.delimiter << service_category( metric.type)
                               << '\n';
                         };
 


### PR DESCRIPTION
This patch adds the 'order' of the service written to the event-service-log. If it's sequential or concurrent.

* Sequential services reserves a process
* Concurrent services does not reserve, and multiplex arbitrary number of services in flight.

This notion could be of interest to the user in a metric context.

`S` or `C` has been added as a new _column_ to the file format.

Fixes: #115