### PR TITLE
discovery: fix on topology direct to include services with remote == 0

### DIFF
--- a/middleware/service/source/manager/handle.cpp
+++ b/middleware/service/source/manager/handle.cpp
@@ -887,11 +887,11 @@ namespace casual
 
                         auto reply = common::message::reverse::type( message, common::process::handle());
 
-                        // all known "remote" services
+                        // all known "remote" (not "local") services
                         reply.content.services = algorithm::accumulate( state.services, std::move( reply.content.services), []( auto result, auto& pair)
                         {
                            const auto& [ name, service] = pair;
-                           if( service.is_concurrent() && ! service.is_sequential())
+                           if( ! service.is_sequential())
                               result.push_back( name);
 
                            return result;


### PR DESCRIPTION
This patch fixes discovery to includes services that are previously known (but now has instances == 0).
This triggers when a topology-direct event happen, that is, a new direct outbound connection is established.

Resolves issue #124

@ahhud can you review this somewhat small commit?