### PR TITLE
event: add event-logging for significant stuff that is done

### DIFF
--- a/middleware/common/include/common/log/category.h
+++ b/middleware/common/include/common/log/category.h
@@ -42,6 +42,14 @@ namespace casual
 
       //! Log with category 'casual.buffer'
       extern Stream buffer;
+
+      namespace event
+      {
+         extern Stream service;
+         extern Stream server;
+         extern Stream transaction;
+         
+      } // event
       
    } // common::log::category
 } // casual

--- a/middleware/common/source/log/category.cpp
+++ b/middleware/common/source/log/category.cpp
@@ -28,6 +28,13 @@ namespace casual
       Stream transaction{ "casual.transaction"};
       Stream buffer{ "casual.buffer"};
 
+      namespace event
+      {
+         Stream service{ "casual.event.service"};
+         Stream server{ "casual.event.server"};
+         Stream transaction{ "casual.event.transaction"}; 
+      } // event
+
    } // common::log::category
 } // casual
 

--- a/middleware/common/source/server/handle/policy.cpp
+++ b/middleware/common/source/server/handle/policy.cpp
@@ -39,6 +39,8 @@ namespace casual
                   signal::thread::scope::Mask block{ signal::set::filled( code::signal::terminate, code::signal::interrupt)};
 
                   communication::device::blocking::send( communication::instance::outbound::service::manager::device(), advertise);
+
+                  log::line( log::category::event::server, "advertise");
                }
             }
 
@@ -74,6 +76,8 @@ namespace casual
 
             // Let the service-manager know about our services...
             policy::advertise( std::move( arguments.services));
+
+            log::line( log::category::event::server, "configure");
          }
 
          void Default::reply( strong::ipc::id id, message::service::call::Reply& message)
@@ -82,6 +86,8 @@ namespace casual
             log::line( log::debug, "ipc: ", id, "reply: ", message);
 
             communication::device::blocking::send( id, message);
+
+            log::line( log::category::event::service, "reply");
          }
 
          void Default::reply( strong::ipc::id id, message::conversation::callee::Send& message)
@@ -90,6 +96,8 @@ namespace casual
             log::line( log::debug, "ipc: ", id, "reply: ", message);
 
             communication::device::blocking::send( id, message);
+
+            log::line( log::category::event::service, "reply");
          }
 
          void Default::ack( const message::service::call::ACK& message)
@@ -99,9 +107,11 @@ namespace casual
             log::line( verbose::log, "reply: ", message);
 
             communication::device::blocking::send( communication::instance::outbound::service::manager::device(), message);
+
+            log::line( log::category::event::service, "ack");
          }
 
-         void Default::statistics( strong::ipc::id id,  message::event::service::Call& event)
+         void Default::statistics( strong::ipc::id id, message::event::service::Call& event)
          {
             Trace trace{ "server::handle::policy::Default::statistics"};
 
@@ -115,6 +125,8 @@ namespace casual
             {
                log::line( log::category::error, exception::capture());
             }
+
+            log::line( log::category::event::service, "statistics");
          }
 
          void Default::transaction(

--- a/middleware/common/source/service/call/context.cpp
+++ b/middleware/common/source/service/call/context.cpp
@@ -177,6 +177,7 @@ namespace casual
 
             communication::device::blocking::send( target.process.ipc, prepared.message);
          }
+         log::line( log::category::event::service, "send|", target.service.name, '|', prepared.descriptor);
 
          unreserve.release();
          return prepared.descriptor;
@@ -258,7 +259,7 @@ namespace casual
          reply::Result result;
          auto [ reply, xatmi_descriptor] = get_reply();
 
-         log::line( log::debug, "reply: ", reply);
+         log::line( log::category::event::service , "receive|", xatmi_descriptor, '|', reply.code.result);
 
          result.descriptor = xatmi_descriptor;
          result.user = reply.code.user;

--- a/middleware/queue/include/queue/common/log.h
+++ b/middleware/queue/include/queue/common/log.h
@@ -25,13 +25,18 @@ namespace casual
       namespace trace
       {
          extern common::log::Stream log;  
-      } // verbose
+      } // trace
 
       struct Trace : common::log::Trace
       {
          template< typename T>
          Trace( T&& value) : common::log::Trace( std::forward< T>( value), trace::log) {}
       };
+
+      namespace event
+      {
+         extern common::log::Stream log;  
+      } // event
 
    } // queue
 } // casual

--- a/middleware/queue/source/api/queue.cpp
+++ b/middleware/queue/source/api/queue.cpp
@@ -78,7 +78,7 @@ namespace casual
                   common::log::line( verbose::log, "request: ", request);
 
                   auto id = common::communication::ipc::call( group.process.ipc, request).id;
-                  common::log::line( verbose::log, "id: ", id);
+                  common::log::line( queue::event::log, "enqueue|", id);
 
                   return id;
                }
@@ -135,19 +135,21 @@ namespace casual
                            group.process.ipc,  
                            dequeue::request( group, selector, transaction.trid, false));
 
-                        if( ! reply.message.empty() && transaction)
+                        if( ! reply.message.empty())
                         {
-                           // Make sure we trigger an interaction with the TM.
-                           // Since the queue-groups act as 'external resources' to
-                           // the TM
-                           transaction.external();
+                           if( transaction)
+                           {
+                              // Make sure we trigger an interaction with the TM.
+                              // Since the queue-groups act as 'external resources' to
+                              // the TM
+                              transaction.external();
+                           }
+                           common::log::line( queue::event::log, "dequeue|", reply.message.front().id);
                         }
 
                         return common::algorithm::transform( reply.message, transform::message());
                      }  
                   } // non
-
-
 
                   auto blocking( const queue::Lookup& lookup, const Selector& selector)
                   {
@@ -178,12 +180,17 @@ namespace casual
                         Trace trace{ "casual::queue::local::dequeue::blocking handler - dequeue::Reply"};
                         common::log::line( verbose::log, "message: ", message);
 
-                        if( ! message.message.empty() && transaction)
+                        if( ! message.message.empty())
                         {
-                           // Make sure we trigger an interaction with the TM.
-                           // Since the queue-groups act as 'external resources' to
-                           // the TM
-                           transaction.external();
+                           if( transaction)
+                           {
+                              // Make sure we trigger an interaction with the TM.
+                              // Since the queue-groups act as 'external resources' to
+                              // the TM
+                              transaction.external();
+                           }
+
+                           common::log::line( queue::event::log, "dequeue|", message.message.front().id);
                         }
 
                         if( message.correlation != correlation)

--- a/middleware/queue/source/common/log.cpp
+++ b/middleware/queue/source/common/log.cpp
@@ -23,7 +23,12 @@ namespace casual
       namespace trace
       {
          common::log::Stream log{ "casual.queue.trace"};  
-      } // verbose
+      } // trace
 
+      namespace event
+      {
+         common::log::Stream log{ "casual.event.queue"};
+      } // event
+      
    } // queue
 } // casual

--- a/middleware/queue/source/group/handle.cpp
+++ b/middleware/queue/source/group/handle.cpp
@@ -601,7 +601,7 @@ namespace casual
                            if( std::filesystem::exists( old))
                            {
                               std::filesystem::rename( old, file);
-                              event::notification::send( "queuebase file moved: ", std::filesystem::relative( old), " -> ", std::filesystem::relative( file));
+                              common::event::notification::send( "queuebase file moved: ", std::filesystem::relative( old), " -> ", std::filesystem::relative( file));
                               log::line( log::category::warning, "queuebase file moved: ", old, " -> ", file);
                            }
                         }
@@ -697,7 +697,7 @@ namespace casual
                         log::line( verbose::log, "remove: ", remove);
 
                         // if something goes wrong we send fatal event
-                        auto queues = event::guard::fatal( [&]()
+                        auto queues = common::event::guard::fatal( [&]()
                         { 
                            return detail::update( state, wanted, remove, state.zombies);
                         });


### PR DESCRIPTION
The ambition is to help "profiling" in a "poor mans way" :) We log events when they are done, and this gives the possibility to deduce delta times, hence give a better understanding where the time is consumed.

4 types of categories, that should be self-explanatory:

* casual.event.server
* casual.event.service
* casual.event.transaction
* casual.event.queue

To enable: use the same semantics as regular casual log.