### PR TITLE
queue: handle enqueue errors correctly

### DIFF
--- a/middleware/queue/include/queue/common/ipc/message.h
+++ b/middleware/queue/include/queue/common/ipc/message.h
@@ -482,6 +482,7 @@ namespace casual
             {
                using base_reply::base_reply;
 
+               //! A 'nil' id represent that the enqueue failed (for now, assume queue:no_queue)
                common::Uuid id;
 
                CASUAL_CONST_CORRECT_SERIALIZE(

--- a/middleware/queue/include/queue/common/queue.h
+++ b/middleware/queue/include/queue/common/queue.h
@@ -9,6 +9,7 @@
 
 #include "queue/common/ipc/message.h"
 #include "common/strong/type.h"
+#include "common/string.h"
 
 #include <string>
 
@@ -24,7 +25,7 @@ namespace casual
       struct Lookup
       {
          using Semantic = ipc::message::lookup::request::context::Semantic;
-         explicit Lookup( std::string queue, Semantic semantic = Semantic::direct);
+         explicit Lookup( common::string::Argument queue, Semantic semantic = Semantic::direct);
 
          ipc::message::lookup::Reply operator () () const;
 

--- a/middleware/queue/include/queue/forward/state.h
+++ b/middleware/queue/include/queue/forward/state.h
@@ -62,7 +62,12 @@ namespace casual
                std::string queue;
                common::process::Handle process;
 
-               explicit operator bool () const { return id && process;}
+               inline explicit operator bool () const { return id && process;}
+               inline void invalidate() noexcept 
+               {
+                  id = {};
+                  process = {};
+               }
 
                friend inline bool operator == ( const Source& lhs, common::strong::queue::id id) { return lhs.id == id;}
                friend inline bool operator == ( const Source& lhs, common::strong::process::id pid) { return lhs.process.pid == pid;}
@@ -172,7 +177,13 @@ namespace casual
 
                void invalidate() noexcept;
 
-               inline bool valid_queues() const { return source && ( ! reply || reply.value());}
+               inline bool valid_queues() const { return source && ( ! reply || *reply);}
+               inline void invalidate_queues() noexcept
+               { 
+                  source.invalidate();
+                  if( reply)
+                     reply->invalidate();
+               }
 
                inline friend bool operator == ( const Service& lhs, forward::id rhs) { return lhs.id == rhs;}
                inline friend bool operator == ( const Service& lhs, common::strong::process::id rhs) { return lhs.source.process == rhs || lhs.reply == rhs;}
@@ -208,6 +219,11 @@ namespace casual
                Queue& operator--();
 
                void invalidate() noexcept;
+               inline void invalidate_queues() noexcept
+               { 
+                  source.invalidate();
+                  target.invalidate();
+               }
 
                inline bool valid_queues() const { return source && target;}
 

--- a/middleware/queue/source/api/queue.cpp
+++ b/middleware/queue/source/api/queue.cpp
@@ -65,7 +65,6 @@ namespace casual
                   request.message.attributes.properties = message.attributes.properties;
                   request.message.attributes.reply = message.attributes.reply;
                   request.message.attributes.available = message.attributes.available;
-
                   request.name = lookup.name();
 
                   auto group = lookup();
@@ -78,6 +77,11 @@ namespace casual
                   common::log::line( verbose::log, "request: ", request);
 
                   auto id = common::communication::ipc::call( group.process.ipc, request).id;
+
+                  // a 'nil' queue id indicate error...
+                  if( ! id)
+                     common::code::raise::error( queue::code::no_queue, "failed to lookup queue: ", lookup.name());
+
                   common::log::line( queue::event::log, "enqueue|", id);
 
                   return id;

--- a/middleware/queue/source/common/queue.cpp
+++ b/middleware/queue/source/common/queue.cpp
@@ -34,7 +34,7 @@ namespace casual
          } // <unnamed>
       } // local
 
-      Lookup::Lookup( std::string queue, Semantic semantic)
+      Lookup::Lookup( common::string::Argument queue, Semantic semantic)
          : m_name( std::move( queue)), m_correlation{ local::request( m_name, semantic)}
       {}
 


### PR DESCRIPTION
There are no error state in the dequeue::Reply, and the only way to indicate error is to propagate a 'nil' message id (this is not sufficient, and need to change to 1.7).

Before: We did not check this _error indication_ both in the API and in queue-forward. Which could lead to "lost messages".

After:
* Forward: We check this _error indication_ and assumes `queue:no_queue`. Invalidate the queues, and "restart" the forward "flow"
* API: We check this _error indication_ and raise `queue:no_queue` if 'nil'