### PR TITLE
build - publish logfile on error

### DIFF
--- a/.github/workflows/casual-build-alpha.yaml
+++ b/.github/workflows/casual-build-alpha.yaml
@@ -109,7 +109,7 @@ jobs:
   
   build-centos:
     runs-on: self-hosted
-    if: success()
+    if: ${{ success() }}
     needs: [calculate-version,build-frontend]
     env:
       DISTRIBUTION: 'centos'
@@ -149,6 +149,9 @@ jobs:
           source /git/casual/casual/pipeline/script/pipeline.env
 
           bash /git/casual/casual/pipeline/script/pre/cleanup
+          
+          touch /git/casual/casual.log
+          chmod 777 /git/casual/casual.log
 
           bash /git/casual/casual/pipeline/script/backend/$DISTRIBUTION/build ${{ needs.calculate-version.outputs.build_version }}
           bash /git/casual/casual/pipeline/script/package ${{ needs.calculate-version.outputs.casual_version }} ${{ needs.calculate-version.outputs.casual_release }} $DISTRIBUTION
@@ -159,14 +162,18 @@ jobs:
 
           chmod +x builder.sh
 
-
       - name: Build
         run: |
           docker run --rm -v ${{ github.workspace }}:/git/casual:Z -i ${{ env.centos_image}}:${{ needs.calculate-version.outputs.major_minor }}
 
+      - name: Logpublisher
+        if: ${{ failure() || cancelled() }}
+        run: |
+          ${{ github.workspace }}/casual/pipeline/script/post/logpublisher ${{ github.workspace }}/casual.log ${DISTRIBUTION}-${{ needs.calculate-version.outputs.build_version }}
+
       - name: Test Report
         uses: dorny/test-reporter@v1
-        if: success() || failure()    # run this step even if previous step failed
+        if: ${{ success() || failure() }}    # run this step even if previous step failed
         with:
           name: Google Tests - Centos # Name of the check run which will be created
           path: ./**/report.xml       # Path to test results
@@ -181,7 +188,7 @@ jobs:
 
   build-suse:
     runs-on: self-hosted
-    if: success()
+    if: ${{ success() }}
     needs: [calculate-version,build-frontend]
     env:
       DISTRIBUTION: 'suse'
@@ -221,6 +228,9 @@ jobs:
           source /git/casual/casual/pipeline/script/pipeline.env
 
           bash /git/casual/casual/pipeline/script/pre/cleanup
+          
+          touch /git/casual/casual.log
+          chmod 777 /git/casual/casual.log
 
           bash /git/casual/casual/pipeline/script/backend/$DISTRIBUTION/build ${{ needs.calculate-version.outputs.build_version }}
           bash /git/casual/casual/pipeline/script/package ${{ needs.calculate-version.outputs.casual_version }} ${{ needs.calculate-version.outputs.casual_release }} $DISTRIBUTION
@@ -231,14 +241,18 @@ jobs:
 
           chmod +x builder.sh
 
-
       - name: Build
         run: |
           docker run --rm -v ${{ github.workspace }}:/git/casual:Z -i ${{ env.suse_image}}:${{ needs.calculate-version.outputs.major_minor }}
 
+      - name: Logpublisher
+        if: ${{ failure() || cancelled() }}
+        run: |
+          ${{ github.workspace }}/casual/pipeline/script/post/logpublisher ${{ github.workspace }}/casual.log ${DISTRIBUTION}-${{ needs.calculate-version.outputs.build_version }}
+
       - name: Test Report
         uses: dorny/test-reporter@v1
-        if: success() || failure()   # run this step even if previous step failed
+        if: ${{ success() || failure() }}  # run this step even if previous step failed
         with:
           name: Google Tests - Suse  # Name of the check run which will be created
           path: ./**/report.xml      # Path to test results
@@ -254,7 +268,7 @@ jobs:
   notification-end:
     runs-on: ubuntu-latest
     needs: [build-centos,build-suse]
-    if: always()
+    if: ${{ always() }}
     steps: 
       - uses: martialonline/workflow-status@v2
         id: check

--- a/.github/workflows/casual-build-beta.yaml
+++ b/.github/workflows/casual-build-beta.yaml
@@ -108,7 +108,7 @@ jobs:
   
   build-centos:
     runs-on: self-hosted
-    if: success()
+    if: ${{ success() }}
     needs: [calculate-version,build-frontend]
     env:
       DISTRIBUTION: 'centos'
@@ -148,6 +148,9 @@ jobs:
           source /git/casual/casual/pipeline/script/pipeline.env
 
           bash /git/casual/casual/pipeline/script/pre/cleanup
+          
+          touch /git/casual/casual.log
+          chmod 777 /git/casual/casual.log          
 
           bash /git/casual/casual/pipeline/script/backend/$DISTRIBUTION/build ${{ needs.calculate-version.outputs.build_version }}
           bash /git/casual/casual/pipeline/script/package ${{ needs.calculate-version.outputs.casual_version }} ${{ needs.calculate-version.outputs.casual_release }} $DISTRIBUTION
@@ -163,9 +166,14 @@ jobs:
         run: |
           docker run --rm -v ${{ github.workspace }}:/git/casual:Z -i ${{ env.centos_image}}:${{ needs.calculate-version.outputs.major_minor }}
 
+      - name: Logpublisher
+        if: ${{ failure() || cancelled() }}
+        run: |
+          ${{ github.workspace }}/casual/pipeline/script/post/logpublisher ${{ github.workspace }}/casual.log ${DISTRIBUTION}-${{ needs.calculate-version.outputs.build_version }}
+
       - name: Test Report
         uses: dorny/test-reporter@v1
-        if: success() || failure()    # run this step even if previous step failed
+        if: ${{ success() || failure() }}   # run this step even if previous step failed
         with:
           name: Google Tests - Centos # Name of the check run which will be created
           path: ./**/report.xml       # Path to test results
@@ -180,7 +188,7 @@ jobs:
 
   build-suse:
     runs-on: self-hosted
-    if: success()
+    if: ${{ success() }}
     needs: [calculate-version,build-frontend]
     env:
       DISTRIBUTION: 'suse'
@@ -220,6 +228,9 @@ jobs:
           source /git/casual/casual/pipeline/script/pipeline.env
 
           bash /git/casual/casual/pipeline/script/pre/cleanup
+          
+          touch /git/casual/casual.log
+          chmod 777 /git/casual/casual.log
 
           bash /git/casual/casual/pipeline/script/backend/$DISTRIBUTION/build ${{ needs.calculate-version.outputs.build_version }}
           bash /git/casual/casual/pipeline/script/package ${{ needs.calculate-version.outputs.casual_version }} ${{ needs.calculate-version.outputs.casual_release }} $DISTRIBUTION
@@ -235,9 +246,14 @@ jobs:
         run: |
           docker run --rm -v ${{ github.workspace }}:/git/casual:Z -i ${{ env.suse_image}}:${{ needs.calculate-version.outputs.major_minor }}
 
+      - name: Logpublisher
+        if: ${{ failure() || cancelled() }}
+        run: |
+          ${{ github.workspace }}/casual/pipeline/script/post/logpublisher ${{ github.workspace }}/casual.log ${DISTRIBUTION}-${{ needs.calculate-version.outputs.build_version }}
+
       - name: Test Report
         uses: dorny/test-reporter@v1
-        if: success() || failure()   # run this step even if previous step failed
+        if: ${{ success() || failure() }}  # run this step even if previous step failed
         with:
           name: Google Tests - Suse  # Name of the check run which will be created
           path: ./**/report.xml      # Path to test results
@@ -252,7 +268,7 @@ jobs:
 
   tag-repo:
     runs-on: ubuntu-latest
-    if: success()
+    if: ${{ success() }}
     needs: [calculate-version,build-centos,build-suse]
     steps:
       - uses: actions/checkout@v2
@@ -267,7 +283,7 @@ jobs:
   publish-version:
     runs-on: self-hosted
     needs: [build-centos,build-suse,tag-repo]
-    if: success()
+    if: ${{ success() }}
     steps:
       - name: Publish suse
         uses: actions/download-artifact@v3
@@ -287,7 +303,7 @@ jobs:
   notification-end:
     runs-on: ubuntu-latest
     needs: [build-centos,build-suse,tag-repo]
-    if: always()
+    if: ${{ always() }}
     steps: 
       - uses: martialonline/workflow-status@v4
         id: check

--- a/.github/workflows/casual-build-release.yaml
+++ b/.github/workflows/casual-build-release.yaml
@@ -107,7 +107,7 @@ jobs:
   
   build-centos:
     runs-on: self-hosted
-    if: success()
+    if: ${{ success() }}
     needs: [calculate-version,build-frontend]
     env:
       DISTRIBUTION: 'centos'
@@ -148,6 +148,9 @@ jobs:
 
           bash /git/casual/casual/pipeline/script/pre/cleanup
 
+          touch /git/casual/casual.log
+          chmod 777 /git/casual/casual.log
+
           bash /git/casual/casual/pipeline/script/backend/$DISTRIBUTION/build ${{ needs.calculate-version.outputs.build_version }}
           bash /git/casual/casual/pipeline/script/package ${{ needs.calculate-version.outputs.casual_version }} ${{ needs.calculate-version.outputs.casual_release }} $DISTRIBUTION
 
@@ -162,9 +165,14 @@ jobs:
         run: |
           docker run --rm -v ${{ github.workspace }}:/git/casual:Z -i ${{ env.centos_image}}:${{ needs.calculate-version.outputs.major_minor }}
 
+      - name: Logpublisher
+        if: ${{ failure() || cancelled() }}
+        run: |
+          ${{ github.workspace }}/casual/pipeline/script/post/logpublisher ${{ github.workspace }}/casual.log ${DISTRIBUTION}-${{ needs.calculate-version.outputs.build_version }}
+
       - name: Test Report
         uses: dorny/test-reporter@v1
-        if: success() || failure()    # run this step even if previous step failed
+        if: ${{ success() || failure() }}   # run this step even if previous step failed
         with:
           name: Google Tests - Centos # Name of the check run which will be created
           path: ./**/report.xml       # Path to test results
@@ -179,7 +187,7 @@ jobs:
 
   build-suse:
     runs-on: self-hosted
-    if: success()
+    if: ${{ success() }}
     needs: [calculate-version,build-frontend]
     env:
       DISTRIBUTION: 'suse'
@@ -220,6 +228,9 @@ jobs:
 
           bash /git/casual/casual/pipeline/script/pre/cleanup
 
+          touch /git/casual/casual.log
+          chmod 777 /git/casual/casual.log
+
           bash /git/casual/casual/pipeline/script/backend/$DISTRIBUTION/build ${{ needs.calculate-version.outputs.build_version }}
           bash /git/casual/casual/pipeline/script/package ${{ needs.calculate-version.outputs.casual_version }} ${{ needs.calculate-version.outputs.casual_release }} $DISTRIBUTION
 
@@ -234,9 +245,14 @@ jobs:
         run: |
           docker run --rm -v ${{ github.workspace }}:/git/casual:Z -i ${{ env.suse_image}}:${{ needs.calculate-version.outputs.major_minor }}
 
+      - name: Logpublisher
+        if: ${{ failure() || cancelled() }}
+        run: |
+          ${{ github.workspace }}/casual/pipeline/script/post/logpublisher ${{ github.workspace }}/casual.log ${DISTRIBUTION}-${{ needs.calculate-version.outputs.build_version }}
+
       - name: Test Report
         uses: dorny/test-reporter@v1
-        if: success() || failure()   # run this step even if previous step failed
+        if: ${{ success() || failure() }}  # run this step even if previous step failed
         with:
           name: Google Tests - Suse  # Name of the check run which will be created
           path: ./**/report.xml      # Path to test results
@@ -251,7 +267,7 @@ jobs:
 
   tag-repo:
     runs-on: ubuntu-latest
-    if: success()
+    if: ${{ success() }}
     needs: [calculate-version,build-centos,build-suse]
     steps:
       - uses: actions/checkout@v2
@@ -266,7 +282,7 @@ jobs:
   publish-version:
     runs-on: self-hosted
     needs: [build-centos,build-suse,tag-repo]
-    if: success()
+    if: ${{ success() }}
     steps:
       - name: Publish suse
         uses: actions/download-artifact@v3
@@ -286,7 +302,7 @@ jobs:
   notification-end:
     runs-on: ubuntu-latest
     needs: [build-centos,build-suse,tag-repo]
-    if: always()
+    if: ${{ always() }}
     steps: 
       - uses: martialonline/workflow-status@v2
         id: check

--- a/pipeline/script/post/logpublisher
+++ b/pipeline/script/post/logpublisher
@@ -1,0 +1,28 @@
+#! /bin/bash
+
+if (( $# == 2 ))
+then
+    logfile=$1
+    suffix="-"$2
+elif (( $# == 1 ))
+then
+    logfile=$1
+    suffix=""
+else
+    exit 0
+fi
+
+TIMEPOINT=$( date +%Y-%m-%dT%H%M%S)
+CASUAL_BACKUP_PATH="/var/www/build/logs"
+
+if [[ -f ${logfile} ]]
+then
+    if [[ ! -d ${CASUAL_BACKUP_PATH} ]]
+    then
+        mkdir -p ${CASUAL_BACKUP_PATH}
+    fi
+
+    destination=${CASUAL_BACKUP_PATH}/$( basename ${logfile})${suffix}-${TIMEPOINT}
+
+    mv ${logfile} ${destination} 2> /dev/null
+fi


### PR DESCRIPTION
casual.log are published to webserver on error in order to be able to troubleshoot