### PR TITLE
discovery: improve performance by aggregating updates within a duration

### DIFF
--- a/middleware/common/include/casual/platform.h
+++ b/middleware/common/include/casual/platform.h
@@ -164,10 +164,10 @@ namespace casual
                constexpr size::type next = batch::message::pump::next;
             } // message::pump
 
-            namespace topology
+            namespace accumulate
             {
-               constexpr size::type updates = 100;
-            } // topology
+               constexpr auto timeout = std::chrono::seconds{ 1};
+            } // accumulate
             
          } // discovery
 
@@ -243,8 +243,11 @@ namespace casual
 
          namespace connect::attempts
          {
-            //! threshhold when to start wating a longer time before next connect attempt
-            constexpr size::type threshhold = 100;
+            //! threshold when to start waiting a longer time before next connect attempt
+            constexpr size::type threshold = 100;
+
+            //! delay until attempt to connect again.
+            constexpr std::chrono::seconds delay = std::chrono::seconds{ 3};
 
          } // connect::attempts
 

--- a/middleware/common/include/common/domain.h
+++ b/middleware/common/include/common/domain.h
@@ -39,6 +39,7 @@ namespace casual
          inline explicit operator bool() const noexcept { return predicate::boolean( id);}
 
          inline friend bool operator == ( const Identity& lhs, std::string_view rhs) { return lhs.name == rhs;}
+         inline friend bool operator == ( const Identity& lhs, const strong::domain::id& rhs) { return lhs.id == rhs;}
 
          inline auto tie() const noexcept { return std::tie( id);}
 

--- a/middleware/common/include/common/message/type.h
+++ b/middleware/common/include/common/message/type.h
@@ -81,9 +81,6 @@ namespace casual
          // domain_discovery_request,
          // domain_discovery_reply,
 
-         domain_discovery_needs_request,
-         domain_discovery_needs_reply,
-
          domain_discovery_known_request,
          domain_discovery_known_reply,
 

--- a/middleware/common/include/common/signal/timer.h
+++ b/middleware/common/include/common/signal/timer.h
@@ -59,10 +59,8 @@ namespace casual
 
       //! Sets a scoped timout.
       //! dtor will 'reset' previous timeout, if any. Hence enable nested timeouts.
-      class Scoped
+      struct Scoped
       {
-      public:
-
          Scoped( unit::type timeout);
          Scoped( unit::type timeout, platform::time::point::type now);
 
@@ -88,11 +86,10 @@ namespace casual
 
       //! Sets a scoped Deadline.
       //! dtor will 'unset' timeout regardless
-      class Deadline
+      struct Deadline
       {
-      public:
-
          Deadline( point::type deadline, platform::time::point::type now);
+         Deadline( platform::time::unit duration);
          ~Deadline();
 
          Deadline( Deadline&&) noexcept;

--- a/middleware/common/source/message/type.cpp
+++ b/middleware/common/source/message/type.cpp
@@ -48,8 +48,6 @@ namespace casual
             case Type::domain_discovery_api_reply: return "domain_discovery_api_reply";
             case Type::domain_discovery_api_rediscovery_request: return "domain_discovery_api_rediscovery_request";
             case Type::domain_discovery_api_rediscovery_reply: return "domain_discovery_api_rediscovery_reply";
-            case Type::domain_discovery_needs_request: return "domain_discovery_needs_request";
-            case Type::domain_discovery_needs_reply: return "domain_discovery_needs_reply";
             case Type::domain_discovery_known_request: return "domain_discovery_known_request";
             case Type::domain_discovery_known_reply: return "domain_discovery_known_reply";
             case Type::server_connect_request: return "server_connect_request";

--- a/middleware/common/source/signal/timer.cpp
+++ b/middleware/common/source/signal/timer.cpp
@@ -144,6 +144,11 @@ namespace casual
             timer::unset();
       }
 
+      Deadline::Deadline( platform::time::unit duration)
+      {
+         timer::set( duration);
+      }
+
       Deadline::~Deadline()
       {
          if( m_active)

--- a/middleware/domain/include/domain/discovery/handle.h
+++ b/middleware/domain/include/domain/discovery/handle.h
@@ -16,9 +16,6 @@ namespace casual
    namespace domain::discovery::handle
    {
       using dispatch_type = decltype( common::message::dispatch::handler( common::communication::ipc::inbound::device()));
-
-      void idle( State& state);
-
       dispatch_type create( State& state);
 
    } // domain::discovery::handle

--- a/middleware/domain/source/discovery/admin/cli.cpp
+++ b/middleware/domain/source/discovery/admin/cli.cpp
@@ -202,8 +202,7 @@ Will try to find provided queues in other domains.
                   return std::vector< Row>{
                      create_row( "external-discovery", common::message::Type::domain_discovery_request, common::message::Type::domain_discovery_reply),
                      create_row( "internal-discovery", common::message::Type::domain_discovery_internal_request, common::message::Type::domain_discovery_internal_reply),
-                     create_row( "local-known-request", common::message::Type::domain_discovery_known_request, common::message::Type::domain_discovery_known_reply),
-                     create_row( "local-needs-request", common::message::Type::domain_discovery_needs_request, common::message::Type::domain_discovery_needs_reply),
+                     create_row( "known-gather", common::message::Type::domain_discovery_known_request, common::message::Type::domain_discovery_known_reply),
                   };
                }
 

--- a/middleware/domain/source/discovery/admin/transform.cpp
+++ b/middleware/domain/source/discovery/admin/transform.cpp
@@ -71,7 +71,6 @@ namespace casual
 
                   result.message.count.receive = state::metric::message::count::received( create_count, 
                      message::discovery::api::rediscovery::Request{},
-                     message::discovery::needs::Reply{},
                      message::discovery::known::Reply{},
                      message::discovery::Request{},
                      message::discovery::Reply{},
@@ -85,7 +84,6 @@ namespace casual
                      message::discovery::Request{},
                      message::discovery::Reply{},
                      message::discovery::internal::Request{},
-                     message::discovery::needs::Request{},
                      message::discovery::known::Request{},
                      message::discovery::api::Reply{},
                      message::discovery::api::rediscovery::Reply{},

--- a/middleware/domain/source/manager/state.cpp
+++ b/middleware/domain/source/manager/state.cpp
@@ -321,7 +321,6 @@ namespace casual
 
             if( found->restart && runlevel == decltype( runlevel())::running)
                return result_type{ found, nullptr};
-
          }
 
          // Find and remove from executable
@@ -341,6 +340,7 @@ namespace casual
             grandchildren.erase( std::begin( found));
          }
 
+         log::line( log, "runlevel: ", runlevel);
          return result_type{};
       }
 

--- a/middleware/gateway/include/gateway/group/tcp.h
+++ b/middleware/gateway/include/gateway/group/tcp.h
@@ -87,7 +87,8 @@ namespace casual
             platform::time::point::type created = platform::time::clock::type::now();
 
             inline friend bool operator == ( const Information& lhs, common::strong::file::descriptor::id rhs) { return lhs.descriptor == rhs;} 
-
+            inline friend bool operator == ( const Information& lhs, const common::strong::domain::id& rhs) { return lhs.domain == rhs;} 
+            
             CASUAL_LOG_SERIALIZE( 
                CASUAL_SERIALIZE( descriptor);
                CASUAL_SERIALIZE( domain);
@@ -132,6 +133,13 @@ namespace casual
          const Information* information( common::strong::file::descriptor::id descriptor) const noexcept
          {
             if( auto found = common::algorithm::find( m_information, descriptor))
+               return found.data();
+            return nullptr;
+         }
+
+         const Information* information( const common::strong::domain::id& domain) const noexcept
+         {
+            if( auto found = common::algorithm::find( m_information, domain))
                return found.data();
             return nullptr;
          }

--- a/middleware/gateway/include/gateway/group/tcp/connect.h
+++ b/middleware/gateway/include/gateway/group/tcp/connect.h
@@ -121,11 +121,15 @@ namespace casual
          {
             if( ! connect.prospects.empty())
             {
-               // check if we're in unittest context or not.
-               if( common::environment::variable::exists( common::environment::variable::name::unittest::context))
-                  common::signal::timer::set( std::chrono::milliseconds{ 10});
-               else
-                  common::signal::timer::set( std::chrono::seconds{ 3});
+               static const auto duration = []() -> platform::time::unit
+               {
+                  // check if we're in unittest context or not.
+                  if( common::environment::variable::exists( common::environment::variable::name::unittest::context))
+                     return std::chrono::milliseconds{ 10};
+                  return platform::tcp::connect::attempts::delay;
+               }();
+
+               common::signal::timer::set( duration);
             }
          }
       } // retry

--- a/middleware/queue/source/manager/handle.cpp
+++ b/middleware/queue/source/manager/handle.cpp
@@ -483,33 +483,6 @@ namespace casual
 
                } // api
 
-               namespace needs
-               { 
-                  auto request( State& state)
-                  {
-                     return [&state]( casual::domain::message::discovery::needs::Request& message)
-                     {
-                        Trace trace{ "queue::manager::handle::local::domain::discover::needs::request"};
-                        common::log::line( verbose::log, "message: ", message);
-
-                        auto reply = common::message::reverse::type( message);
-
-                        // add the pending _wait for ever_ requests
-                        for( auto& pending : state.pending.lookups)
-                           if( pending.context.semantic == decltype( pending.context.semantic)::wait)
-                              reply.content.queues.push_back( pending.name);
-
-                        // make sure we respect invariants
-                        algorithm::container::sort::unique( reply.content.queues);
-
-                        common::log::line( verbose::log, "reply: ", reply);
-
-                        state.multiplex.send( message.process.ipc, reply);
-                        
-                     };
-                  }
-               } // needs
-
                namespace known
                {
                   auto request( State& state)
@@ -670,7 +643,6 @@ namespace casual
             
             handle::local::domain::discover::internal::request( state),
             handle::local::domain::discover::api::reply( state),
-            handle::local::domain::discover::needs::request( state),
             handle::local::domain::discover::known::request( state),
 
             handle::local::shutdown::request( state),

--- a/middleware/queue/source/manager/main.cpp
+++ b/middleware/queue/source/manager/main.cpp
@@ -72,7 +72,7 @@ namespace casual
 
                // register that we can answer discovery questions.
                using Ability = casual::domain::discovery::provider::Ability;
-               casual::domain::discovery::provider::registration( flags::compose( Ability::discover_internal, Ability::needs, Ability::known));
+               casual::domain::discovery::provider::registration( flags::compose( Ability::discover_internal, Ability::known));
 
                // we can supply configuration
                casual::domain::configuration::supplier::registration();

--- a/middleware/service/source/manager/handle.cpp
+++ b/middleware/service/source/manager/handle.cpp
@@ -849,32 +849,6 @@ namespace casual
                   }
                } // api
 
-               namespace needs
-               {
-                  //! reply with all known external and what we're waiting for.
-                  auto request( State& state)
-                  {
-                     return [&state]( const casual::domain::message::discovery::needs::Request& message)
-                     {
-                        Trace trace{ "service::manager::handle::domain::discovery::needs::request"};
-                        log::line( verbose::log, "message: ", message);
-
-                        auto reply = common::message::reverse::type( message, common::process::handle());
-
-                        // only 'wait' pending
-                        for( auto& pending : state.pending.lookups)
-                           if( pending.request.context.semantic == decltype( pending.request.context.semantic)::wait)
-                              reply.content.services.push_back( pending.request.requested);
-
-                        // make sure we respect the invariants
-                        algorithm::container::sort::unique( reply.content.services);
-
-                        log::line( verbose::log, "reply: ", reply);
-                        communication::device::blocking::optional::send( message.process.ipc, reply);
-                     };
-                  }
-               } // needs
-
                namespace known
                {
                   //! reply with all "remote" service we know of.
@@ -1111,7 +1085,6 @@ namespace casual
             handle::local::Call{ admin::services( state), state},
             handle::local::domain::discovery::internal::request( state),
             handle::local::domain::discovery::api::reply( state),
-            handle::local::domain::discovery::needs::request( state),
             handle::local::domain::discovery::known::request( state),
             handle::local::configuration::update::request( state),
             handle::local::configuration::request( state),

--- a/middleware/service/source/manager/main.cpp
+++ b/middleware/service/source/manager/main.cpp
@@ -112,7 +112,7 @@ namespace casual
 
                // register that we can answer discovery questions.
                using Ability = casual::domain::discovery::provider::Ability;
-               casual::domain::discovery::provider::registration( flags::compose( Ability::discover_internal, Ability::needs, Ability::known));
+               casual::domain::discovery::provider::registration( flags::compose( Ability::discover_internal, Ability::known));
 
                // Connect to domain
                communication::instance::whitelist::connect( communication::instance::identity::service::manager);

--- a/test/unittest/source/gateway/test_discovery.cpp
+++ b/test/unittest/source/gateway/test_discovery.cpp
@@ -506,9 +506,10 @@ domain:
 
             auto update = fetch_topology_until( []( auto& update)
             {
-               return update.domains.size() == 2;
+               return update.domains.size() >= 2;
             });
-
+            
+            EXPECT_TRUE( update.domains.size() == 2);
             EXPECT_TRUE( algorithm::find( update.domains, "B")) << CASUAL_NAMED_VALUE( update.domains);
             EXPECT_TRUE( algorithm::find( update.domains, "A")) << CASUAL_NAMED_VALUE( update.domains);
          }


### PR DESCRIPTION
This patch
* aggregates topology updates within a specific time duration.
* when the duration has passed:
* gather _known_ services/queues (includes "waiting"/_needs_)
* send topology::Explore to all _external_agents_ (outbounds)
* _external_agent_ sends discover::Request to the intersection between the agents known "remote domains" and topology::Explore.domains

This will greatly reduce the amount of messages that is sent. It also improves the "precision" of where discoveries and topology updates is sent, hence only do work that could matter.