### PR TITLE
common: fix failing test_ipc

### DIFF
--- a/middleware/common/unittest/source/communication/test_ipc.cpp
+++ b/middleware/common/unittest/source/communication/test_ipc.cpp
@@ -379,7 +379,7 @@ namespace casual
          const auto message = unittest::Message{ platform::ipc::transport::size * 16};
          platform::size::type errors{};
 
-         algorithm::for_n< 10>( [&]()
+         algorithm::for_n< 31>( [&]()
          {
             for( auto& destination : destinations)
             {


### PR DESCRIPTION
This is for the test case
common_communication_ipc.
send_multiplex_to_inbound__fill_the_ipc__and_cache_the_rest __sink_the_inbounds__expect_callback_invocation__and_empty_state_when_done

(wrapped for line length!)
This is one of  several test cases mentioned in issue #15 (Unittest robustness).  

In the Bolagsverket Suse environment this test has always failed. I have disabled it with GTEST_FILTER. It seems as if it was the "fill_the_ipc__and_cache_the_rest" part of the test that failed. The test had a loop that did 10 "send" to each destination ipc. Increasing this to 31 sends to each made the test succeed in my environment. A value of 30 or less always fail to fill the ipc(s). Possibly Suse (or the Bolagsverket installation) has different defaults for how much data is buffered by an ipc.

I have not tried to add code to read the socket (buffering) options in effect.