### PR TITLE
common: add hash correlation lookup for coordinate::fan::Out

### DIFF
--- a/middleware/common/source/uuid.cpp
+++ b/middleware/common/source/uuid.cpp
@@ -81,32 +81,6 @@ namespace casual
          return ! empty();
       }
 
-
-      bool operator < ( const Uuid& lhs, const Uuid& rhs)
-      {
-         return uuid_compare( lhs.m_uuid, rhs.m_uuid) < 0;
-      }
-
-      bool operator == ( const Uuid& lhs, const Uuid& rhs)
-      {
-         return uuid_compare( lhs.m_uuid, rhs.m_uuid) == 0;
-      }
-
-      bool operator != ( const Uuid& lhs, const Uuid& rhs)
-      {
-         return ! ( lhs == rhs);
-      }
-
-      bool operator == ( const Uuid& lhs, const Uuid::uuid_type& rhs)
-      {
-         return uuid_compare( lhs.get(), rhs) == 0;
-      }
-
-      bool operator == ( const Uuid::uuid_type& lhs, const Uuid& rhs)
-      {
-         return uuid_compare( lhs, rhs.get()) == 0;
-      }
-
       std::ostream& operator << ( std::ostream& out, const Uuid& uuid)
       {
          if( uuid.empty())


### PR DESCRIPTION
This patch adds hash lookup for coordinate::fan::Out to increase performance when there are lots of pending entries. Profiling showed that when the state gets "to big" almost all time is consumed by correlation (uuid) compares.

resolves #141