### PR TITLE
cli: fix gateway --list-connections to indicate inbound discovery forward

### DIFF
--- a/middleware/administration/makefile.cmk
+++ b/middleware/administration/makefile.cmk
@@ -104,6 +104,7 @@ make.LinkUnittest( 'unittest/bin/test-casual-administration',
       make.Compile( 'unittest/source/cli/test_queue.cpp'),
       make.Compile( 'unittest/source/cli/test_internal.cpp'),
       make.Compile( 'unittest/source/cli/test_transaction.cpp'),
+      make.Compile( 'unittest/source/cli/test_gateway.cpp'),
    ],
    [ 
       unittest_lib,

--- a/middleware/administration/unittest/source/cli/test_gateway.cpp
+++ b/middleware/administration/unittest/source/cli/test_gateway.cpp
@@ -1,0 +1,104 @@
+//!
+//! Copyright (c) 2022, The casual project
+//!
+//! This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+//!
+
+#include "common/unittest.h"
+
+#include "administration/unittest/cli/command.h"
+
+#include "gateway/unittest/utility.h"
+
+#include "domain/unittest/manager.h"
+
+namespace casual
+{
+   using namespace common;
+
+   namespace administration
+   {
+      namespace local
+      {
+         namespace
+         {
+            namespace configuration
+            {
+               constexpr auto base = R"(
+domain:
+   groups: 
+      -  name: base
+      -  name: user
+         dependencies: [ base]
+      -  name: gateway
+         dependencies: [ user]
+   
+   servers:
+      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager"
+        memberships: [ base]
+      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/casual-transaction-manager"
+        memberships: [ base]
+      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/gateway/bin/casual-gateway-manager"
+        memberships: [ gateway]
+)";
+            } // configuration
+
+            template< typename... C>
+            auto domain( C&&... configurations)
+            {
+               return casual::domain::unittest::manager( configuration::base, std::forward< C>( configurations)...);
+            }
+         } // <unnamed>      
+
+      } // local
+
+      TEST( cli_gateway, inbound_discovery_forward__expect_state_with_connection_bound__in_star)
+      {
+         common::unittest::Trace trace;
+         
+         auto b = local::domain( R"(
+domain:
+   name: B
+   gateway:
+      inbound:
+         groups:
+            -  connections:
+                  -  address: 127.0.0.1:7001
+                     discovery:
+                        forward: true
+                  -  address: 127.0.0.1:7002
+                     discovery:
+                        forward: false
+)");
+
+
+         auto a = local::domain( R"(
+domain:
+   name: A
+   gateway:
+      outbound:
+         groups:
+            -  connections:
+                  -  address: 127.0.0.1:7001
+                  -  address: 127.0.0.1:7002
+)");
+
+
+         gateway::unittest::fetch::until( gateway::unittest::fetch::predicate::outbound::connected());
+
+         b.activate();
+
+         // extract only the bounds, and sort it for determinism.
+         auto output = administration::unittest::cli::command::execute( "casual gateway --list-connections --porcelain true | cut -d '|' -f 3 | sort" ).string();
+
+         constexpr auto expected = R"(in
+in*
+)";
+
+         EXPECT_TRUE( output == expected) << "output:  " << output << "expected: " << expected;
+      }
+
+   
+
+   } // administration
+} // casual

--- a/middleware/gateway/include/gateway/manager/admin/model.h
+++ b/middleware/gateway/include/gateway/manager/admin/model.h
@@ -45,6 +45,7 @@ namespace casual
                unknown,
                out,
                in,
+               in_forward,
             };
 
             constexpr std::string_view description( Bound value) noexcept
@@ -53,6 +54,7 @@ namespace casual
                {
                   case Bound::out: return "out";
                   case Bound::in: return "in";
+                  case Bound::in_forward: return "in*";
                   case Bound::unknown: return "unknown";
                }
                return "<unknown>";

--- a/middleware/gateway/source/manager/admin/cli.cpp
+++ b/middleware/gateway/source/manager/admin/cli.cpp
@@ -91,12 +91,12 @@ namespace casual
                   return "-";
                };
 
-               auto group = []( auto& value) -> decltype( value.group)
+               auto group = []( auto& value)
                {
                   return value.group;
                };
 
-               auto alias = []( auto& value) -> decltype( value.alias)
+               auto alias = []( auto& value)
                {
                   return value.alias;
                };
@@ -120,6 +120,7 @@ namespace casual
                      {
                         using Enum = decltype( value.bound);
                         case Enum::in: return "in";
+                        case Enum::in_forward: return "in*";
                         case Enum::out: return "out";
                         case Enum::unknown: return "unknown";
                      }


### PR DESCRIPTION
This patch prints `in*` as bound for inbound with configuration discovery forward = true

resolves #147