### PR TITLE
unittest - improve stability of several tests

### DIFF
--- a/middleware/common/include/common/unittest.h
+++ b/middleware/common/include/common/unittest.h
@@ -75,6 +75,13 @@ namespace casual
          
          // not implemented yet.
          // platform::binary::type receive( const strong::correlation::id& correlation);
+
+         namespace wait::until
+         {
+            //! blocks until `service` has been advertised
+            void advertised( std::string_view service);
+         } // wait::until
+
       } // service
 
 

--- a/middleware/common/source/unittest.cpp
+++ b/middleware/common/source/unittest.cpp
@@ -66,6 +66,24 @@ namespace casual
             return communication::device::blocking::send( lookup.process.ipc, message);
          }
 
+         namespace wait::until
+         {
+            void advertised( std::string_view service)
+            {
+               common::message::service::lookup::Request lookup_request{ process::handle()};
+               lookup_request.requested = service;
+               lookup_request.context.semantic = decltype( lookup_request.context.semantic)::wait;
+               auto correlation = communication::device::blocking::send( communication::instance::outbound::service::manager::device(), lookup_request);
+               communication::ipc::receive< common::message::service::lookup::Reply>( correlation);
+
+               common::message::service::lookup::discard::Request discard_request{ process::handle()};
+               discard_request.correlation = correlation;
+               discard_request.requested = service;
+               discard_request.reply = false;
+               communication::device::blocking::send( communication::instance::outbound::service::manager::device(), discard_request);
+            }
+         } // wait::until
+
       } // service
 
 

--- a/middleware/domain/unittest/source/utility.cpp
+++ b/middleware/domain/unittest/source/utility.cpp
@@ -10,6 +10,8 @@
 
 #include "serviceframework/service/protocol/call.h"
 
+#include "common/unittest.h"
+
 namespace casual
 {
    using namespace common;
@@ -32,6 +34,7 @@ namespace casual
 
       manager::admin::model::State state()
       {
+         common::unittest::service::wait::until::advertised( manager::admin::service::name::state);
          serviceframework::service::protocol::binary::Call call;
          auto reply = call( manager::admin::service::name::state);
          return reply.extract< manager::admin::model::State>();

--- a/middleware/gateway/makefile.cmk
+++ b/middleware/gateway/makefile.cmk
@@ -173,12 +173,6 @@ protocol_objects = [
     make.Compile( 'source/documentation/protocol/example.cpp')
 ]
 
-unittest_archive = make.LinkArchive( 'bin/casual-gateway-unittest',
-    [
-        make.Compile( 'unittest/source/utility.cpp'),
-    ]
-)
-
 # Unittest
 
 unittest_archive = make.LinkArchive( 'bin/casual-gateway-unittest', 

--- a/middleware/gateway/source/group/outbound/handle.cpp
+++ b/middleware/gateway/source/group/outbound/handle.cpp
@@ -240,7 +240,7 @@ namespace casual
                               return [ &state, trid = message.trid]( auto& destination)
                               {
                                  auto pending = state.service.consume( destination.correlation);
-                                 detail::send::error::reply( state, destination, std::move( pending), trid, code::xatmi::system);;
+                                 detail::send::error::reply( state, destination, std::move( pending), trid, code::xatmi::system);
                               };
                            };
 

--- a/middleware/gateway/unittest/source/utility.cpp
+++ b/middleware/gateway/unittest/source/utility.cpp
@@ -9,8 +9,8 @@
 
 #include "serviceframework/service/protocol/call.h"
 
-
 #include "common/communication/ipc.h"
+#include "common/unittest.h"
 
 namespace casual
 {
@@ -19,6 +19,7 @@ namespace casual
    {
       manager::admin::model::State state()
       {
+         common::unittest::service::wait::until::advertised( manager::admin::service::name::state);
          serviceframework::service::protocol::binary::Call call;
          auto reply = call( manager::admin::service::name::state);
          return reply.extract< manager::admin::model::State>();

--- a/middleware/queue/unittest/source/utility.cpp
+++ b/middleware/queue/unittest/source/utility.cpp
@@ -10,12 +10,15 @@
 
 #include "serviceframework/service/protocol/call.h"
 
+#include "common/unittest.h"
+
 namespace casual
 {
    namespace queue::unittest
    {
       manager::admin::model::State state()
       {
+         common::unittest::service::wait::until::advertised( queue::manager::admin::service::name::state);
          return serviceframework::service::protocol::binary::Call{}( queue::manager::admin::service::name::state).extract< manager::admin::model::State>();
       }
 

--- a/middleware/service/unittest/source/utility.cpp
+++ b/middleware/service/unittest/source/utility.cpp
@@ -9,6 +9,7 @@
 
 #include "common/communication/instance.h"
 #include "common/instance.h"
+#include "common/unittest.h"
 
 #include "serviceframework/service/protocol/call.h"
 
@@ -73,6 +74,8 @@ namespace casual
 
       manager::admin::model::State state()
       {
+         common::unittest::service::wait::until::advertised( manager::admin::service::name::state);
+
          serviceframework::service::protocol::binary::Call call;
 
          auto reply = call( manager::admin::service::name::state);

--- a/middleware/transaction/unittest/source/utility.cpp
+++ b/middleware/transaction/unittest/source/utility.cpp
@@ -9,12 +9,15 @@
 
 #include "serviceframework/service/protocol/call.h"
 
+#include "common/unittest.h"
+
 namespace casual
 {
    namespace transaction::unittest
    {
       manager::admin::model::State state()
       {
+         common::unittest::service::wait::until::advertised( manager::admin::service::name::state());
          serviceframework::service::protocol::binary::Call call;
          return call( manager::admin::service::name::state()).extract< manager::admin::model::State>( "result");
       }


### PR DESCRIPTION
* Fixed a unittest in gateway that would occasionally hang due to a timing error.
* Added a utility function to wait for a service to be advertised. Some tests would fail when fetching a manager's state before that service had been advertised.