### PR TITLE
scan-code: fix analyze bugs

### DIFF
--- a/middleware/binding/cobol/source/xatmi.cpp
+++ b/middleware/binding/cobol/source/xatmi.cpp
@@ -123,7 +123,6 @@ extern "C" void TPCALL(struct TPSVCDEF_REC_s *TPSVCDEF_REC,
    char *idata_rec;
    char *odata_rec;
    long olen;
-   int rv;
    long flags;
 
    /* Copy COBOL string to C string and null terminate C string */
@@ -164,12 +163,12 @@ extern "C" void TPCALL(struct TPSVCDEF_REC_s *TPSVCDEF_REC,
    if (TPSVCDEF_REC->TPSIGRSTRT_FLAG)
       flags = flags | TPSIGRSTRT;
 
-   if ((rv = tpcall(service_name,
+   if ( tpcall(service_name,
                     idata_rec,
                     ITPTYPE_REC->LEN,
                     &odata_rec,
                     &olen,
-                    flags)) == -1) {
+                    flags) == -1) {
       TPSTATUS_REC->TP_STATUS = (int32_t)tperrno;
       /* printf("error TPCALL --> tpcall: %d\n", tperrno); */
       tpfree(odata_rec);
@@ -203,9 +202,7 @@ extern "C" void TPCALL(struct TPSVCDEF_REC_s *TPSVCDEF_REC,
 extern "C" void TPCANCEL(struct TPSVCDEF_REC_s *TPSVCDEF_REC,
                          struct TPSTATUS_REC_s *TPSTATUS_REC) {
 
-   int rv;
-
-   if ((rv = tpcancel(TPSVCDEF_REC->COMM_HANDLE)) == -1) {
+   if ( tpcancel(TPSVCDEF_REC->COMM_HANDLE) == -1) {
       TPSTATUS_REC->TP_STATUS = (int32_t)tperrno;
       /* printf("error TPCANCEL --> tpcancel: %d\n", tperrno); */
    } else {
@@ -289,9 +286,7 @@ extern "C" void TPCONNECT(struct TPSVCDEF_REC_s *TPSVCDEF_REC,
 extern "C" void TPDISCON(struct TPSVCDEF_REC_s *TPSVCDEF_REC,
                          struct TPSTATUS_REC_s *TPSTATUS_REC) {
 
-   int rv;
-
-   if ((rv = tpdiscon(TPSVCDEF_REC->COMM_HANDLE)) == -1) {
+   if ( tpdiscon(TPSVCDEF_REC->COMM_HANDLE) == -1) {
       TPSTATUS_REC->TP_STATUS = (int32_t)tperrno;
       /* printf("error TPDISCON --> tpdiscon: %d\n", tperrno); */
    } else {
@@ -313,7 +308,6 @@ extern "C" void TPGETRPLY(struct TPSVCDEF_REC_s *TPSVCDEF_REC,
    char rec_type[REC_TYPE_LEN + 1];
    char sub_type[SUB_TYPE_LEN + 1];
    char *data_rec;
-   int rv;
    long flags;
    long len;
 
@@ -344,10 +338,10 @@ extern "C" void TPGETRPLY(struct TPSVCDEF_REC_s *TPSVCDEF_REC,
    if (TPSVCDEF_REC->TPSIGRSTRT_FLAG)
       flags = flags | TPSIGRSTRT;
 
-   if ((rv = tpgetrply(&TPSVCDEF_REC->COMM_HANDLE,
+   if ( tpgetrply(&TPSVCDEF_REC->COMM_HANDLE,
                        &data_rec,
                        &len,
-                       flags)) == -1) {
+                       flags) == -1) {
       TPSTATUS_REC->TP_STATUS = (int32_t)tperrno;
       /* printf("error TPGETRPLY --> tpgetrply: %d\n", tperrno); */
    } else {
@@ -679,13 +673,12 @@ long flags=0;
    long data_length = TPTYPE_REC->LEN;
    memcpy(data_rec, DATA_REC, data_length);
 
-   int rv;
-   long revent;
-   if ((rv = tpsend(TPSVCDEF_REC->COMM_HANDLE,
+   long revent{};
+   if ( tpsend(TPSVCDEF_REC->COMM_HANDLE,
                   data_rec,
                   data_length,
                   flags,
-                  &revent)) == -1) {
+                  &revent) == -1) {
          TPSTATUS_REC->TP_STATUS = (int32_t)tperrno;
          /* printf("error TPSEND --> tpsend: %d\n", tperrno); */
    } else {

--- a/middleware/common/include/common/algorithm/container.h
+++ b/middleware/common/include/common/algorithm/container.h
@@ -23,7 +23,7 @@ namespace casual
             template< typename C, typename T, typename... Ts> 
             C& back( C& container, T&& t, Ts&&... ts)
             {
-               container.push_back( std::move( t)); 
+               container.push_back( std::forward< T>( t)); 
                return back( container, std::forward< Ts>( ts)...);
             }
          } // detail

--- a/middleware/common/include/common/communication/device.h
+++ b/middleware/common/include/common/communication/device.h
@@ -274,7 +274,7 @@ namespace casual
 
          //! push a message (or complete) to the cache
          template< typename M>
-         correlation_type push( M&& message)
+         auto push( M&& message) -> std::enable_if_t< std::is_rvalue_reference_v< decltype( message)>, correlation_type>
          {
             // Make sure we consume up to one messages from the real device first.
             // So progress can be made.
@@ -283,7 +283,7 @@ namespace casual
             if constexpr( std::is_same_v< std::decay_t< M>, complete_type>)
             {
                static_assert( std::is_rvalue_reference_v< M>, "complete_type needs to be a rvalue");
-               m_cache.push_back( std::move( message));
+               m_cache.push_back( std::forward< M>( message));
             }
             else
                m_cache.push_back( serialize::native::complete< complete_type>( std::forward< M>( message)));

--- a/middleware/common/include/common/serialize/archive/consume.h
+++ b/middleware/common/include/common/serialize/archive/consume.h
@@ -27,9 +27,9 @@ namespace casual
                   {
                      template< typename S, typename D>
                      auto value( S&& source, D& destination, common::traits::priority::tag< 2>)
-                        -> decltype( destination = std::move( source), void())
+                        -> decltype( destination = std::forward< S>( source), void())
                      {
-                        destination = std::move( source);
+                        destination = std::forward< S>( source);
                      }
 
                      template< typename S, typename D>

--- a/middleware/common/include/common/sink.h
+++ b/middleware/common/include/common/sink.h
@@ -6,14 +6,16 @@
 
 #pragma once
 
+#include <type_traits>
+
 namespace casual
 {
    namespace common
    {
       template< typename T>
-      void sink( T&& value)
+      auto sink( T&& value) -> std::enable_if_t< std::is_rvalue_reference_v< decltype( value)>>
       {
-         [[maybe_unused]] auto sinked = std::move( value);
+         [[maybe_unused]] auto sinked = std::forward< T>( value);
       }
    } // common
 } // casual

--- a/middleware/common/include/common/terminal.h
+++ b/middleware/common/include/common/terminal.h
@@ -450,7 +450,7 @@ namespace casual
             template< typename C>
             auto column( std::string name, C&& column)
             {
-               return name_column< C>( std::move( name), std::move( column));
+               return name_column< C>( std::move( name), std::forward< C>( column));
             }
          } // custom
 

--- a/middleware/common/include/common/unittest.h
+++ b/middleware/common/include/common/unittest.h
@@ -25,13 +25,6 @@ namespace casual
 {
    namespace common::unittest
    {
-
-      template< typename T>
-      void sink( T&& value)
-      {
-         auto sinked = std::move( value);
-      }
-
       using base_message = common::message::basic_message< common::message::Type::unittest_message>;
       struct Message : base_message, Compare< Message>
       {

--- a/middleware/common/source/log/stream.cpp
+++ b/middleware/common/source/log/stream.cpp
@@ -271,7 +271,7 @@ namespace casual
                auto deactivate() noexcept { return []( auto& stream) noexcept { stream.deactivate();};}
                
                template< typename P>
-               auto toggle( P&& predicate) noexcept
+               auto toggle( P predicate) noexcept
                {
                   return [ predicate = std::move( predicate)]( auto& stream) noexcept { stream.toggle( predicate);};
                }

--- a/middleware/common/source/serialize/ini.cpp
+++ b/middleware/common/source/serialize/ini.cpp
@@ -149,14 +149,12 @@ namespace casual
                                  std::string name;
                                  while( std::getline( stream, name, '.'))
                                  {
-                                    auto candidate = trim( std::move( name) );
+                                    auto candidate = trim( std::exchange( name, {}));
 
                                     if( candidate.empty())
                                        code::raise::error( code::casual::invalid_document, "invalid name");
                                     else
-                                    {
                                        result.push_back( std::move( candidate));
-                                    }
                                  }
 
                                  if( result.empty())

--- a/middleware/common/source/server/start.cpp
+++ b/middleware/common/source/server/start.cpp
@@ -52,7 +52,7 @@ namespace casual
 
                      template< typename S>
                      common::server::Arguments arguments(
-                           S&& services,
+                           S services,
                            std::vector< argument::transaction::Resource> resources)
                      {
                         common::server::Arguments result;
@@ -65,7 +65,7 @@ namespace casual
                   } // transform
 
                   template< typename S>
-                  void start( S&& services, std::vector< argument::transaction::Resource> resources, common::function<void()const> initialize)
+                  void start( S services, std::vector< argument::transaction::Resource> resources, common::function<void()const> initialize)
                   {
                      Trace trace{ "common::server::start"};
                      log::line( verbose::log, "services: ", services);

--- a/middleware/common/source/transaction/context.cpp
+++ b/middleware/common/source/transaction/context.cpp
@@ -155,7 +155,7 @@ namespace casual
 
             auto configuration = local::resource::configuration( algorithm::transform( named, transform_name));
 
-            auto transform_resource = [ &configuration]( auto&& predicate)
+            auto transform_resource = [ &configuration]( auto predicate)
             {
                return [ &configuration, predicate = std::move( predicate)]( auto& resource)
                {  

--- a/middleware/common/unittest/source/serialize/named/test_value.cpp
+++ b/middleware/common/unittest/source/serialize/named/test_value.cpp
@@ -19,7 +19,7 @@ namespace casual
             const int value = 42;
             auto named = CASUAL_NAMED_VALUE( value);
 
-            EXPECT_TRUE(( std::is_same< decltype( named), named::Value< const int, named::reference::lvalue>>::value ));
+            EXPECT_TRUE(( std::is_same< decltype( named), named::Value< const int, named::reference::lvalue>>::value )) << CASUAL_NAMED_VALUE( named);
          }
 
          TEST( serialize_named_value, lvalue)
@@ -27,7 +27,7 @@ namespace casual
             int value = 42;
             auto named = CASUAL_NAMED_VALUE( value);
 
-            EXPECT_TRUE(( std::is_same< decltype( named), named::Value< int, named::reference::lvalue>>::value ));
+            EXPECT_TRUE(( std::is_same< decltype( named), named::Value< int, named::reference::lvalue>>::value )) << CASUAL_NAMED_VALUE( named);
          }
 
          TEST( serialize_named_value, rvalue)
@@ -35,7 +35,7 @@ namespace casual
             int value = 42;
             auto named = CASUAL_NAMED_VALUE( std::move( value));
 
-            EXPECT_TRUE(( std::is_same< decltype( named), named::Value< int, named::reference::rvalue>>::value ));
+            EXPECT_TRUE(( std::is_same< decltype( named), named::Value< int, named::reference::rvalue>>::value )) << CASUAL_NAMED_VALUE( named);
          }
 
          TEST( serialize_named_value, instantiation)

--- a/middleware/common/unittest/source/transaction/test_id.cpp
+++ b/middleware/common/unittest/source/transaction/test_id.cpp
@@ -83,6 +83,7 @@ namespace casual
 
          transaction::ID moved{ std::move( id)};
 
+         // this will trigger use-after-move
          EXPECT_TRUE( id.null()); // NOLINT
          EXPECT_TRUE( ! moved.null());
       }

--- a/middleware/domain/source/discovery/handle.cpp
+++ b/middleware/domain/source/discovery/handle.cpp
@@ -387,7 +387,7 @@ namespace casual
 
                      // we need to forward the discovery and try to find the absent..
 
-                     auto send_requests = [ &state]( auto&& absent)
+                     auto send_requests = [ &state]( auto absent)
                      {
                         message::discovery::Request request{ process::handle()};
                         request.domain = common::domain::identity();

--- a/middleware/domain/source/manager/handle.cpp
+++ b/middleware/domain/source/manager/handle.cpp
@@ -108,7 +108,7 @@ namespace casual
                      []( auto& instance){ return common::process::id( instance.handle);},
                      []( auto& instance){ return instance.state != decltype( instance.state)::error;});
 
-                     communication::ipc::inbound::device().push( message);
+                     communication::ipc::inbound::device().push( std::move( message));
                   }
 
                   log::line( verbose::log, "entity: ", entity);

--- a/middleware/event/source/service/log/main.cpp
+++ b/middleware/event/source/service/log/main.cpp
@@ -87,7 +87,7 @@ namespace casual
             {
 
                template< typename F> 
-               void pump( state::Log& log, F&& filter)
+               void pump( state::Log& log, F filter)
                {
                   bool done = false;
 

--- a/middleware/gateway/source/group/outbound/handle.cpp
+++ b/middleware/gateway/source/group/outbound/handle.cpp
@@ -51,7 +51,7 @@ namespace casual
 
                         // we 'lost' the connection in some way - we put a connection::Lost on our own ipc-device, and handle it
                         // later (and differently depending on if we're 'regular' or 'reversed')
-                        communication::ipc::inbound::device().push( lost);
+                        communication::ipc::inbound::device().push( std::move( lost));
                      }
                   }
                   else
@@ -179,7 +179,7 @@ namespace casual
                         auto ipc( const V& value) -> decltype( ( value.ipc)) { return value.ipc;}
 
                         template< typename M, typename P>
-                        void reply( State& state, M&& destination, P&& pending, const common::transaction::ID& trid, code::xatmi code)
+                        void reply( State& state, M&& destination, P pending, const common::transaction::ID& trid, code::xatmi code)
                         {
                            common::message::service::call::Reply reply;
                            reply.correlation = destination.correlation;

--- a/middleware/gateway/unittest/source/test_manager.cpp
+++ b/middleware/gateway/unittest/source/test_manager.cpp
@@ -24,6 +24,7 @@
 #include "common/message/domain.h"
 #include "common/algorithm/is.h"
 #include "common/result.h"
+#include "common/sink.h"
 
 #include "serviceframework/service/protocol/call.h"
 
@@ -1331,7 +1332,7 @@ domain:
 
          // b shuts down
          {
-            unittest::sink( b);
+            common::sink( std::move( b));
             unittest::fetch::until( unittest::fetch::predicate::outbound::connected( 0));
          }
 

--- a/middleware/serviceframework/include/serviceframework/service/protocol.h
+++ b/middleware/serviceframework/include/serviceframework/service/protocol.h
@@ -56,7 +56,7 @@ namespace casual
 
             template< typename P>
             Protocol( P&& protocol)
-               : Protocol{ std::make_unique< model< P>>( std::move( protocol))}
+               : Protocol{ std::make_unique< model< P>>( std::forward< P>( protocol))}
             {}
 
             ~Protocol();

--- a/middleware/tools/source/build/generate.cpp
+++ b/middleware/tools/source/build/generate.cpp
@@ -120,10 +120,9 @@ namespace casual
                      };
                   }
 
-                  template< typename T>
-                  auto text( T&& text)
+                  auto text( std::string_view text)
                   {
-                     return [text = std::move( text)]( std::ostream& out)
+                     return [ text]( std::ostream& out)
                      {
                         out << text;
                      };

--- a/middleware/tools/source/service/call/cli.cpp
+++ b/middleware/tools/source/service/call/cli.cpp
@@ -355,7 +355,7 @@ namespace casual
                   else if( state.machine == State::Flag::multiplexing)
                   {
                      communication::select::Directive directive;
-                     auto create_select_handler = [&directive]( auto fd, auto&& handler, auto& device)
+                     auto create_select_handler = [ &directive]( auto fd, auto handler, auto& device)
                      {
                         directive.read.add( fd);
                         return [fd, handler = std::move( handler), &device]( auto descriptor, communication::select::tag::read) mutable

--- a/middleware/transaction/source/manager/admin/cli.cpp
+++ b/middleware/transaction/source/manager/admin/cli.cpp
@@ -769,9 +769,9 @@ namespace casual
                      } // handle
 
                      template< typename A>
-                     auto invoke( A&& associate)
+                     auto invoke( A associate)
                      {
-                        return [associate = std::move( associate)]() mutable
+                        return [ associate = std::move( associate)]() mutable
                         {
                            Trace trace{ "transaction::manager::admin::local::begin::invoke"};
 

--- a/test/unittest/source/gateway/test_discovery.cpp
+++ b/test/unittest/source/gateway/test_discovery.cpp
@@ -12,6 +12,7 @@
 #include "domain/discovery/api.h"
 
 #include "common/communication/instance.h"
+#include "common/sink.h"
 
 #include "queue/api/queue.h"
 #include "queue/code.h"
@@ -575,7 +576,7 @@ domain:
 
          // reboot B, expect discovery of known services in our case casual/example/domain/echo/B
          {
-            unittest::sink( std::move( b));
+            common::sink( std::move( b));
             b = create_b();
 
             gw.activate();

--- a/test/unittest/source/test_queue.cpp
+++ b/test/unittest/source/test_queue.cpp
@@ -16,6 +16,7 @@
 #include "common/communication/instance.h"
 #include "common/transaction/context.h"
 #include "common/execute.h"
+#include "common/sink.h"
 
 namespace casual
 {
@@ -227,7 +228,7 @@ domain:
          EXPECT_TRUE( ! queue::dequeue( "b1").empty());
          
          // shutdown b
-         unittest::sink( std::move( b));
+         common::sink( std::move( b));
 
          // wait until we've lost the connection
          gateway::unittest::fetch::until( gateway::unittest::fetch::predicate::outbound::connected( 0));


### PR DESCRIPTION
A few false positives was also suppressed where `scan-code` warns that it could be a lvalue that is moved, when (from context) it can't. Changed these to forward< T>(..) to suppress, and we know it's an rvalue -> it's going to be a move.