### PR TITLE
xatmi - extend c-api with excecution service name (#140)

### DIFF
--- a/middleware/xatmi/include/casual/xatmi/extended.h
+++ b/middleware/xatmi/include/casual/xatmi/extended.h
@@ -39,6 +39,20 @@ extern void casual_execution_id_set( const uuid_t* id);
 extern const uuid_t* casual_execution_id_get();
 
 /**
+ * @returns the name of current execution service name
+ *
+ * @attention could be empty if called in wrong context
+ */
+extern const char* casual_execution_service_name();
+
+/**
+ * @returns the name of current execution parents service name
+ *
+ * @attention could be empty if called in wrong context
+ */
+extern const char* casual_execution_parent_service_name();
+
+/**
  * @returns the alias of the instance.
  * 
  * @attention could be NULL if the instance is *not* spawn by

--- a/middleware/xatmi/source/xatmi/extended.cpp
+++ b/middleware/xatmi/source/xatmi/extended.cpp
@@ -123,6 +123,16 @@ long casual_instance_index()
    return -1;
 }
 
+const char* casual_execution_service_name()
+{
+   return casual::common::execution::service::name().c_str();
+}
+
+const char* casual_execution_parent_service_name()
+{
+   return casual::common::execution::service::parent::name().c_str();
+}
+
 
 void casual_execution_id_set( const uuid_t* id)
 {


### PR DESCRIPTION
- added casual_execution_service_name()
- added casual_execution_parent_service_name()