### PR TITLE
queue: fix pending data structure slicing

### DIFF
--- a/middleware/queue/include/queue/forward/state.h
+++ b/middleware/queue/include/queue/forward/state.h
@@ -286,7 +286,7 @@ namespace casual
                struct Lookup : transaction_base
                {
                   Lookup() = default;
-                  Lookup( transaction_base&& other) : transaction_base{ std::move( other)} {}
+                  Lookup( const transaction_base& other) : transaction_base{ other} {}
 
                   common::buffer::Payload buffer;
 
@@ -299,8 +299,8 @@ namespace casual
                struct Call : transaction_base
                {
                   Call() = default;
-                  Call( transaction_base&& other, common::strong::process::id pid)
-                     : transaction_base{ std::move( other)}, pid{ pid} {}
+                  Call( const transaction_base& other, common::strong::process::id pid)
+                     : transaction_base{ other}, pid{ pid} {}
 
                   common::strong::process::id pid{};
 
@@ -319,21 +319,20 @@ namespace casual
                struct Rollback : transaction_base
                {
                   Rollback() = default;
-                  Rollback( transaction_base&& other) : transaction_base{ std::move( other)} {} 
+                  Rollback( const transaction_base& other) : transaction_base{ other} {} 
                };
 
                struct Commit : transaction_base
                {
                   Commit() = default;
-                  Commit( transaction_base&& other) : transaction_base{ std::move( other)} {}
+                  Commit( const transaction_base& other) : transaction_base{ other} {}
                };
             } // transaction
 
             struct Enqueue : transaction_base
             {
                Enqueue() = default;
-               Enqueue( transaction_base&& other) : transaction_base{ std::move( other)} {}
-               
+               Enqueue( const transaction_base& other) : transaction_base{ other} {}
             };
 
          } // pending

--- a/middleware/queue/source/forward/state.cpp
+++ b/middleware/queue/source/forward/state.cpp
@@ -14,26 +14,8 @@ namespace casual
    using namespace common;
    namespace queue::forward
    {
-      namespace local
-      {
-         namespace
-         {
-            namespace extract
-            {
-               template< typename P>
-               auto pending( P& pending, state::forward::id id)
-               {
-                  return algorithm::container::extract( pending, 
-                     std::get< 1>( algorithm::partition( pending, predicate::negate( predicate::value::equal( id)))));
-               }
-            } // extract
-            
-         } // <unnamed>
-      } // local
-
       namespace state
       {
-
          std::string_view description( Runlevel value)
          {
             switch( value)


### PR DESCRIPTION
Before: When pending objects where moved within the "state machine" some unexpected and unwanted slicing was produced, which lead to "memory leak" (some destructors was not called).

A bit surprising that neither compilers nor clang-tidy catched this bug.