### PR TITLE
configuration - fix queue configuration default directory

### DIFF
--- a/middleware/configuration/documentation/build/executable.development.md
+++ b/middleware/configuration/documentation/build/executable.development.md
@@ -4,13 +4,13 @@
 
 Defines user configuration when building a casual executable.
 
-## resources
+### resources
 
 Defines which `xa` resources to link and use runtime. A name **has** to be provided for each 
 resource, startup configuration phase will ask for resource configuration for that 
 given name.
 
-## entrypoint
+### entrypoint
 
 Defines the name of the user provided _entry point_. The signature has to be the same as a
 normal main function `int <entrypoint-name>( int argc, char** argv)`.

--- a/middleware/configuration/documentation/build/server.development.md
+++ b/middleware/configuration/documentation/build/server.development.md
@@ -4,7 +4,7 @@
 
 Defines user configuration when building a casual server.
 
-## services
+### services
 
 Defines which services the server has (and advertises on startup). The actual `xatmi` conformant
 function that is bound to the service can have a different name.
@@ -18,7 +18,7 @@ join         | join transaction if present else execute outside transaction
 atomic       | start a new transaction regardless
 none         | execute outside transaction regardless
 
-## resources
+### resources
 
 Defines which `xa` resources to link and use runtime. If a name is provided for a given
 resource, then startup configuration phase will ask for resource configuration for that 

--- a/middleware/configuration/documentation/domain.queue.operation.md
+++ b/middleware/configuration/documentation/domain.queue.operation.md
@@ -55,7 +55,7 @@ domain:
       directory: "${CASUAL_DOMAIN_HOME}/queue/groups"
     groups:
       - alias: "A"
-        note: "will get default queuebase: ${CASUAL_DOMAIN_HOME}/queue/groupA.gb"
+        note: "will get default queuebase: ${CASUAL_DOMAIN_HOME}/queue/groups/A.qb"
         queues:
           - name: "a1"
           - name: "a2"
@@ -129,7 +129,7 @@ domain:
             "groups": [
                 {
                     "alias": "A",
-                    "note": "will get default queuebase: ${CASUAL_DOMAIN_HOME}/queue/groupA.gb",
+                    "note": "will get default queuebase: ${CASUAL_DOMAIN_HOME}/queue/groups/A.qb",
                     "queues": [
                         {
                             "name": "a1"
@@ -301,7 +301,7 @@ service=casual/example/echo
 
 [domain.queue.groups]
 alias=A
-note=will get default queuebase: ${CASUAL_DOMAIN_HOME}/queue/groupA.gb
+note=will get default queuebase: ${CASUAL_DOMAIN_HOME}/queue/groups/A.qb
 
 [domain.queue.groups.queues]
 name=a1
@@ -365,7 +365,7 @@ name=c2
   <groups>
    <element>
     <alias>A</alias>
-    <note>will get default queuebase: ${CASUAL_DOMAIN_HOME}/queue/groupA.gb</note>
+    <note>will get default queuebase: ${CASUAL_DOMAIN_HOME}/queue/groups/A.qb</note>
     <queues>
      <element>
       <name>a1</name>

--- a/middleware/configuration/include/configuration/model.h
+++ b/middleware/configuration/include/configuration/model.h
@@ -621,6 +621,7 @@ namespace casual::configuration
             std::string queuebase;
             std::string note;
             std::vector< Queue> queues;
+            std::string directory;
 
             inline friend bool operator == ( const Group& lhs, const std::string& alias) { return lhs.alias == alias;}
 
@@ -633,6 +634,7 @@ namespace casual::configuration
                CASUAL_SERIALIZE( queuebase);
                CASUAL_SERIALIZE( note);
                CASUAL_SERIALIZE( queues);
+               CASUAL_SERIALIZE( directory);
             )
 
             inline auto tie() const { return std::tie( alias, queuebase, note, queues);}

--- a/middleware/configuration/source/example/model.cpp
+++ b/middleware/configuration/source/example/model.cpp
@@ -231,7 +231,7 @@ domain:
 
       groups:
          -  alias: A
-            note: "will get default queuebase: ${CASUAL_DOMAIN_HOME}/queue/groupA.gb"
+            note: "will get default queuebase: ${CASUAL_DOMAIN_HOME}/queue/groups/A.qb"
             queues:
                -  name: a1
                -  name: a2

--- a/middleware/configuration/source/model/transform.cpp
+++ b/middleware/configuration/source/model/transform.cpp
@@ -398,13 +398,21 @@ namespace casual
 
                   if( source.groups)
                   {
-                     result.groups = common::algorithm::transform( source.groups.value(), []( auto& group)
+                     auto default_directory = [ &source]() -> std::string
+                     {
+                        if( source.defaults && source.defaults->directory)
+                           return *source.defaults->directory;
+                        return {};
+                     }();
+
+                     result.groups = common::algorithm::transform( source.groups.value(), [ &default_directory]( auto& group)
                      {
                         queue::Group result;
 
                         result.alias = group.alias.value_or( "");
                         result.note = group.note.value_or( "");
                         result.queuebase = group.queuebase.value_or( "");
+                        result.directory = default_directory;
 
                         common::algorithm::transform( group.queues, result.queues, []( auto& queue)
                         {

--- a/middleware/queue/source/group/handle.cpp
+++ b/middleware/queue/source/group/handle.cpp
@@ -586,6 +586,9 @@ namespace casual
                      {
                         if( ! message.model.queuebase.empty())
                            return group::Queuebase{ message.model.queuebase};
+
+                        if( ! message.model.directory.empty())
+                           return group::Queuebase{ message.model.directory + "/" + message.model.alias + ".qb"};
                         
                         auto name = message.model.alias + ".qb";
                         auto file = common::environment::directory::queue() / name;


### PR DESCRIPTION
Before:
Configuration domain.queue.default.directory was not being used.

Now:
Uses queuebase if any, else <default.directory>/<group.alias>.qb

Fixes #171