### PR TITLE
queue - send error reply on failed enqueue

### DIFF
--- a/middleware/queue/source/group/handle.cpp
+++ b/middleware/queue/source/group/handle.cpp
@@ -229,6 +229,7 @@ namespace casual
                         catch( ...)
                         {
                            log::line( log::category::error, exception::capture(), " failed with enqueue request to queue: ", message.name);
+                           state.multiplex.send( message.process.ipc, common::message::reverse::type( message));
                         }
                      };
                   }


### PR DESCRIPTION
Send an error reply was sent when enqueues fail, such as when the queuebase runs out of memory

Fixes #173