### PR TITLE
queue - prevent forward causing service-manager coredump

### DIFF
--- a/middleware/queue/include/queue/forward/state.h
+++ b/middleware/queue/include/queue/forward/state.h
@@ -265,6 +265,15 @@ namespace casual
                   )
                };
 
+               namespace lookup
+               {
+                  struct Discard : transaction_base
+                  {
+                     Discard() = default;
+                     Discard( transaction_base&& other) : transaction_base{ std::move( other)} {}
+                  };
+               }
+
                struct Call : transaction_base
                {
                   Call() = default;
@@ -278,7 +287,7 @@ namespace casual
                      CASUAL_SERIALIZE( pid);
                   )
                };
-               
+
             } // service
 
             namespace transaction
@@ -335,10 +344,12 @@ namespace casual
             struct
             {
                std::vector< state::pending::service::Lookup> lookups;
+               std::vector< state::pending::service::lookup::Discard> lookup_discards;
                std::vector< state::pending::service::Call> calls;
 
                CASUAL_LOG_SERIALIZE(
                   CASUAL_SERIALIZE( lookups);
+                  CASUAL_SERIALIZE( lookup_discards);
                   CASUAL_SERIALIZE( calls);
                )
 


### PR DESCRIPTION
Before: Occasionally, the forward would request a discard of a service lookup but still call the service, depending on the order of the replies. This would trigger a core in the service-manager when the service ACK:ed the call.

Now: We handle pending service discard requests separately so that no service call occurs irrespective of the order of replies.

Fixes #182