### PR TITLE
gateway: shutdown doesn't wait for inbounds before outbounds

### DIFF
--- a/middleware/gateway/include/gateway/manager/state.h
+++ b/middleware/gateway/include/gateway/manager/state.h
@@ -19,6 +19,8 @@
 
 #include "configuration/model.h"
 
+#include "casual/task.h"
+
 
 namespace casual
 {
@@ -80,9 +82,7 @@ namespace casual
 
          struct State
          {
-
-            //! @return true if we're done, and ready to exit
-            bool done() const;
+            common::state::Machine< state::Runlevel, state::Runlevel::startup> runlevel;
 
             struct
             {
@@ -97,15 +97,20 @@ namespace casual
                
                CASUAL_LOG_SERIALIZE( CASUAL_SERIALIZE( groups);)
             } outbound;
+
+            //! coordinated tasks, only(?) for shutdown 
+            //! inbound before outbound
+            casual::task::Coordinator tasks;
+
             
-
-            common::state::Machine< state::Runlevel, state::Runlevel::startup> runlevel;
-
-
+            //! @return true if we're done, and ready to exit
+            bool done() const noexcept;
+            
             CASUAL_LOG_SERIALIZE(
+               CASUAL_SERIALIZE( runlevel);
                CASUAL_SERIALIZE( inbound);
                CASUAL_SERIALIZE( outbound);
-               CASUAL_SERIALIZE( runlevel);
+               CASUAL_SERIALIZE( tasks);
             )
 
          };

--- a/middleware/gateway/source/manager/state.cpp
+++ b/middleware/gateway/source/manager/state.cpp
@@ -63,7 +63,7 @@ namespace casual
 
          } // state
 
-         bool State::done() const
+         bool State::done() const noexcept
          {
             using Runlevel = decltype( runlevel());
 


### PR DESCRIPTION
This patch make sure that all inbound groups is shut down before we start to shutdown outbound groups. This enables a clan shutdown regarding transactions.

When TM is handling the last prepare/commit/rollback messages from other domains, all outbound connections is still present -> TM is able to propagate transaction "directives" to other domains as part of distributed transactions.

Resolves #186