### PR TITLE
service: service timeout could render zombie transactions

### DIFF
--- a/middleware/domain/unittest/source/manager.cpp
+++ b/middleware/domain/unittest/source/manager.cpp
@@ -85,6 +85,7 @@ namespace casual
 
                   // reset service instance, if any.
                   exception::guard( [](){ communication::instance::outbound::service::manager::device().connector().clear();});
+                  exception::guard( [](){ communication::instance::outbound::transaction::manager::device().connector().clear();});
                }
 
             } // instance::devices

--- a/middleware/service/include/service/manager/state.h
+++ b/middleware/service/include/service/manager/state.h
@@ -175,6 +175,7 @@ namespace casual
                   {   
                      platform::time::point::type when;
                      common::strong::correlation::id correlation;
+                     //! The actual instance that the timeout refers to.
                      common::strong::process::id target;
                      state::Service* service = nullptr;
 
@@ -448,12 +449,16 @@ namespace casual
 
          common::Process forward;
 
+         // TODO merge this to a timeout { duration, instances} 
          casual::configuration::model::service::Timeout timeout;
+         std::vector< common::strong::process::id> timeout_instances;
 
          //! holds all the routes, for services that has routes
          std::map< std::string, std::vector< std::string>> routes;
          //! the same as above from the route to actual service.
          std::map< std::string, std::string> reverse_routes;
+
+
 
          //! holds all alias restrictions.
          casual::configuration::model::service::Restriction restriction;

--- a/middleware/service/unittest/source/utility.cpp
+++ b/middleware/service/unittest/source/utility.cpp
@@ -91,6 +91,7 @@ namespace casual
             message.correlation = request.correlation;
             message.metric.pending = request.pending;
             message.metric.service = request.service.name;
+            message.metric.trid = request.trid;
             message.metric.type = ( request.service.type == decltype( request.service.type)::concurrent) ?
                decltype( message.metric.type)::concurrent : decltype( message.metric.type)::sequential;
 

--- a/middleware/transaction/source/manager/admin/transform.cpp
+++ b/middleware/transaction/source/manager/admin/transform.cpp
@@ -6,6 +6,7 @@
 
 
 #include "transaction/manager/admin/transform.h"
+#include "transaction/common.h"
 
 #include "common/algorithm.h"
 #include "common/transcode.h"
@@ -208,6 +209,9 @@ namespace casual
 
       admin::model::State state( const manager::State& state)
       {
+         Trace trace{ "transaction::manager::admin::transform::state"};
+         common::log::line( verbose::log, "state: ", state);
+
          admin::model::State result;
 
          common::algorithm::transform( state.resources, result.resources, &transform::resource::proxy);


### PR DESCRIPTION
Before: When a service trigger a timeout by service-manager, an error reply is sent from SM. caller will then rollback the transaction. The service is till running (if linger) and could trigger resource involvement with the transaction (again).This new transaction (it's new to TM since the TM has forgotten the recently rollbacked transaction) will never be handled, and will most likely be "marked as in-doubt" -> cause a lot of unwanted problems.

Now: When service manager receives an "ACK" from the timouted service it sends a rollback request to TM -> If there are resources that has been involved the rollback will be issued, exactly like a normal rollback.

Note: it feels a bit ugly to let SM actually order a rollback, it might be better if it "just notify TM", and TM decides what to do. Like a "post timeout cleanup rollback" message. The current solution is less intrusive though.