### PR TITLE
service - always send timeout duration in lookup reply

### DIFF
--- a/middleware/common/include/common/message/service.h
+++ b/middleware/common/include/common/message/service.h
@@ -115,7 +115,7 @@ namespace casual
                inline auto logical_name() const noexcept { return requested.value_or( name); }
 
                CASUAL_CONST_CORRECT_SERIALIZE(
-                  service::Base::serialize( archive);
+                  message::Service::serialize( archive);
                   CASUAL_SERIALIZE( requested);
                )
             };

--- a/middleware/service/source/manager/handle.cpp
+++ b/middleware/service/source/manager/handle.cpp
@@ -386,6 +386,7 @@ namespace casual
 
                         auto reply = common::message::reverse::type( message);
                         reply.service = service.information;
+                        reply.service.timeout.duration = service.timeout.duration.value_or( platform::time::unit::zero());
                         reply.state = decltype( reply.state)::idle;
                         reply.process = destination;
                         reply.pending = pending;
@@ -396,8 +397,6 @@ namespace casual
                         if( service.timeoutable())
                         {
                            auto now = platform::time::clock::type::now();
-
-                           reply.service.timeout.duration = service.timeout.duration.value();
 
                            auto next = state.pending.deadline.add( {
                               now + reply.service.timeout.duration,


### PR DESCRIPTION
The service manager now always includes the configured timeout duration in lookup replies even if the service is not timoutable.