### PR TITLE
gateway - handle routing problems (#197)

### DIFF
--- a/middleware/gateway/source/group/outbound/handle.cpp
+++ b/middleware/gateway/source/group/outbound/handle.cpp
@@ -990,7 +990,7 @@ namespace casual
             handle::unadvertise( state, state.lookup.remove( descriptor));
 
             // take care of aggregated replies, if any.
-            state.coordinate.discovery.failed( descriptor);
+            state.coordinate.discovery.purge( descriptor);
 
             auto error_reply = []( auto& point){ point.error();};
 

--- a/middleware/gateway/unittest/source/test_manager.cpp
+++ b/middleware/gateway/unittest/source/test_manager.cpp
@@ -618,7 +618,7 @@ domain:
 
          // because of some unknown factor, the queue-manager needs some time to get ready
          // to handle calls. Strange but is a separate issue.
-         process::sleep( std::chrono::milliseconds{ 10});
+         process::sleep( std::chrono::milliseconds{ 500});
 
          // enqueue
          {


### PR DESCRIPTION
Before:
When discovery requests still beeing in-flight and only some of the destinations had replied and a connection lost was received on a connection that already had replied, that reply still were wrongly considerd as a valid provider of the requested service. That caused faulty entries in the service lookup list.

After:
When a connection lost is received all replies in an ongoing discovery from that connection/descriptor are considered failed.