### PR TITLE
gateway: outbound order of connection for a service gets too "orderly"

### DIFF
--- a/middleware/common/include/common/algorithm/random.h
+++ b/middleware/common/include/common/algorithm/random.h
@@ -1,0 +1,29 @@
+//!
+//! Copyright (c) 2023, The casual project
+//!
+//! This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+//!
+
+#pragma once
+
+#include <random>
+
+namespace casual
+{
+   namespace common::algorithm::random
+   {
+      std::mt19937& generator() noexcept;
+
+      //! inserts `value` at a random position in `container`
+      template< typename C, typename V>
+      C& insert( C& container, V&& value)
+      {
+         std::uniform_int_distribution< decltype( container.size())> distribution{ 0, container.size()};
+
+         container.insert( std::begin( container) + distribution( random::generator()), std::forward< V>( value));
+
+         return container;
+      }
+      
+   } // common::algorithm::random
+} // casual

--- a/middleware/common/makefile.cmk
+++ b/middleware/common/makefile.cmk
@@ -50,6 +50,7 @@ install_headers = []
 casual_common_objectfiles = [
 
     make.Compile( 'source/assert.cpp'),
+    make.Compile( 'source/algorithm/random.cpp'),
 
     make.Compile( 'source/strong/id.cpp'),
     make.Compile( 'source/flag/xa.cpp'),

--- a/middleware/common/source/algorithm/random.cpp
+++ b/middleware/common/source/algorithm/random.cpp
@@ -1,0 +1,21 @@
+//!
+//! Copyright (c) 2023, The casual project
+//!
+//! This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+//!
+
+
+#include "common/algorithm/random.h"
+
+namespace casual
+{
+   namespace common::algorithm::random
+   {
+      std::mt19937& generator() noexcept
+      {
+         static std::mt19937 singleton{ std::random_device{}()};
+         return singleton;
+      }
+      
+   } // common::algorithm::random
+} // casual

--- a/middleware/gateway/source/group/outbound/state.cpp
+++ b/middleware/gateway/source/group/outbound/state.cpp
@@ -8,6 +8,7 @@
 
 #include "common/predicate.h"
 #include "common/algorithm/sorted.h"
+#include "common/algorithm/random.h"
 
 namespace casual
 {
@@ -118,7 +119,7 @@ namespace casual
                      }
                      else
                      {
-                        connections.push_back( state::lookup::resource::Connection{ descriptor, add.hops});
+                        algorithm::random::insert( connections, state::lookup::resource::Connection{ descriptor, add.hops});
                      }
 
                      auto hops_less = []( auto& l, auto& r){ return l.hops < r.hops;};

--- a/middleware/gateway/unittest/source/group/outbound/test_state.cpp
+++ b/middleware/gateway/unittest/source/group/outbound/test_state.cpp
@@ -41,6 +41,11 @@ namespace casual
                return lookup;
             }
 
+            auto get_all_connections( const state::Lookup& lookup, const std::string& service)
+            {
+               return lookup.services().at( service);
+            }
+
             template< typename L>
             auto get_connection( L& lookup, const std::string& service)
             {
@@ -97,52 +102,56 @@ namespace casual
       {
          auto lookup = local::lookup();
 
-         auto [ result, involved] = lookup.service( "a", {});
-         EXPECT_TRUE( result.connection == local::fd( 10)) << CASUAL_NAMED_VALUE( result.connection);
-         EXPECT_TRUE( transaction::id::null( result.trid));
-         EXPECT_TRUE( ! involved);
+         auto connections = local::get_all_connections( lookup, "a");
 
-         EXPECT_TRUE( local::get_connection( lookup, "a") == local::fd( 20)) << CASUAL_NAMED_VALUE( lookup);
-         EXPECT_TRUE( local::get_connection( lookup, "a") == local::fd( 30));
-         EXPECT_TRUE( local::get_connection( lookup, "a") == local::fd( 100));
-         EXPECT_TRUE( local::get_connection( lookup, "a") == local::fd( 101));
+         for( auto& expected : connections)
+         {
+            auto [ result, involved] = lookup.service( "a", {});
+            EXPECT_TRUE( result.connection == expected.id) << CASUAL_NAMED_VALUE( result.connection);
+            EXPECT_TRUE( transaction::id::null( result.trid));
+            EXPECT_TRUE( ! involved);
+
+         }
 
          // back to the first one
-         EXPECT_TRUE( local::get_connection( lookup, "a") == local::fd( 10));
+         EXPECT_TRUE( local::get_connection( lookup, "a") == range::front( connections).id);
       }
 
       TEST( gateway_outbound_state, lookup_service_a__some_with_same_xid___expect_round_robin_unless_xid_matches)
       {
          auto lookup = local::lookup();
 
+         auto connections = local::get_all_connections( lookup, "a");
+         auto connections_range = range::make( connections);
+
          const auto trid = transaction::id::create();
 
          auto [ result, involved] = lookup.service( "a", trid);
          EXPECT_TRUE( involved);
-         EXPECT_TRUE( result.connection == local::fd( 10)) << CASUAL_NAMED_VALUE( result.connection);
+         EXPECT_TRUE( result.connection == range::front( connections).id ) << CASUAL_NAMED_VALUE( result.connection);
 
          const auto branched = result.trid;
          EXPECT_TRUE( branched != trid) << CASUAL_NAMED_VALUE( branched);
          // expect same global part of trid
          EXPECT_TRUE( transaction::id::range::global( branched) == transaction::id::range::global( trid));
 
-         // 'consume' two
+         // 'consume' two with no trid
          {
             auto [ result, involved] = lookup.service( "a", {});
-            EXPECT_TRUE( result.connection == local::fd( 20));
+            EXPECT_TRUE( result.connection == range::front( ++connections_range).id);
             EXPECT_TRUE( ! involved);
             std::tie( result, involved) = lookup.service( "a", {});
-            EXPECT_TRUE( result.connection == local::fd( 30));
+            EXPECT_TRUE( result.connection == range::front( ++connections_range).id);
             EXPECT_TRUE( ! involved);
          }
 
          // same xid as before - expect same fd as before
          std::tie( result, involved) = lookup.service( "a", trid);
-         EXPECT_TRUE( result.connection == local::fd( 10));
+         EXPECT_TRUE( result.connection == range::front( connections).id);
          EXPECT_TRUE( result.trid == branched) << CASUAL_NAMED_VALUE( result.trid);
 
          // expect next in the round-robin
-         EXPECT_TRUE( local::get_connection( lookup, "a", {}) == local::fd( 100)) << CASUAL_NAMED_VALUE( lookup);
+         EXPECT_TRUE( local::get_connection( lookup, "a", {}) == range::front( ++connections_range).id ) << CASUAL_NAMED_VALUE( lookup);
       }
 
 
@@ -150,15 +159,18 @@ namespace casual
       {
          auto lookup = local::lookup();
 
+         auto c_connections = local::get_all_connections( lookup, "c");
+         auto a_connections = local::get_all_connections( lookup, "a");
+
          auto xid = transaction::id::create();
 
-         EXPECT_TRUE( local::get_connection( lookup, "c", xid) == local::fd( 100));
+         EXPECT_TRUE( local::get_connection( lookup, "c", xid) == range::front( c_connections).id);
 
          // 'consume' a 
-         EXPECT_TRUE( local::get_connection( lookup, "a") == local::fd( 10));
+         EXPECT_TRUE( local::get_connection( lookup, "a") == range::front( a_connections).id);
 
          // same xid as before - expect same fd as before - hence xid-correlation
-         EXPECT_TRUE( local::get_connection( lookup, "a", xid) == local::fd( 100));
+         EXPECT_TRUE( local::get_connection( lookup, "a", xid) == range::front( c_connections).id);
       }
 
       TEST( gateway_outbound_state, add_calls_to_4_services_times_4_xids__remove_all_external_xids__expect_empty_transactions_mapping)
@@ -186,10 +198,11 @@ namespace casual
       TEST( gateway_outbound_state, remove_x__expect_x_unadvertised)
       {
          auto lookup = local::lookup();
+         auto x_connections = local::get_all_connections( lookup, "x");
 
          auto xid = transaction::id::create();
 
-         EXPECT_TRUE( local::get_connection( lookup, "x", xid) == local::fd( 120));
+         EXPECT_TRUE( local::get_connection( lookup, "x", xid) == range::front( x_connections).id);
          auto removed = lookup.remove( local::fd( 120), { "x"}, {});
 
          ASSERT_TRUE( removed.services.size() == 1) << CASUAL_NAMED_VALUE( lookup);
@@ -201,10 +214,11 @@ namespace casual
       TEST( gateway_outbound_state, remove_a__expect_no_unadvertised)
       {
          auto lookup = local::lookup();
+         auto a_connections = local::get_all_connections( lookup, "a");
 
          auto xid = transaction::id::create();
 
-         EXPECT_TRUE( local::get_connection( lookup, "a", xid) == local::fd( 10));
+         EXPECT_TRUE( local::get_connection( lookup, "a", xid) == range::front( a_connections).id);
          auto removed = lookup.remove( local::fd( 120), { "a"}, {});
 
          EXPECT_TRUE( removed.services.empty()) << CASUAL_NAMED_VALUE( lookup);


### PR DESCRIPTION
Before: The order of connections a given service has (the remote domains that expose the service) is based on the order which the connections connect. In some topologies this could give a bad load balancing.

Now: When we add add a connection to a service we insert it a random position. round-robin is used as before after that.

Resolves #201