### PR TITLE
discovery - handle prospect services (#198)

### DIFF
--- a/middleware/domain/include/domain/discovery/state.h
+++ b/middleware/domain/include/domain/discovery/state.h
@@ -236,7 +236,6 @@ namespace casual
 
       } // state
 
-
       struct State
       {
          State();
@@ -274,7 +273,23 @@ namespace casual
             )
          } service_name;
 
-         
+         struct Prospects
+         {
+            using Content = message::discovery::request::Content;
+            std::map< std::string, std::vector< common::strong::correlation::id>> services;
+            std::map< std::string, std::vector< common::strong::correlation::id>> queues;
+
+            void insert( const Content& content, common::strong::correlation::id correlation);
+            // remove all entrys in prospect list added by correlation
+            void remove( common::strong::correlation::id correlation);
+
+            Content content() const;
+
+            CASUAL_LOG_SERIALIZE(
+               CASUAL_SERIALIZE( services);
+               CASUAL_SERIALIZE( queues);
+            )
+         } prospects;
 
          state::Accumulate accumulate;
          
@@ -287,6 +302,7 @@ namespace casual
             CASUAL_SERIALIZE( coordinate);
             CASUAL_SERIALIZE( multiplex);
             CASUAL_SERIALIZE( service_name);
+            CASUAL_SERIALIZE( prospects);
             CASUAL_SERIALIZE( accumulate);
             CASUAL_SERIALIZE( providers);
          )

--- a/middleware/domain/source/discovery/state.cpp
+++ b/middleware/domain/source/discovery/state.cpp
@@ -139,6 +139,40 @@ namespace casual
          return false;
       }
 
-      
+      void State::Prospects::insert( const Content& content, common::strong::correlation::id correlation)
+      {
+         for( auto service : content.services)
+         {
+            services[ service].emplace_back( correlation);
+         }
+         for( auto queue : content.queues)
+         {
+            queues[ queue].emplace_back( correlation);
+         }
+      }
+
+      void State::Prospects::remove( common::strong::correlation::id correlation)
+      {
+         algorithm::container::erase_if( services, [ &correlation]( auto& pair) 
+         {
+            return algorithm::container::erase( pair.second, correlation).empty();
+         });
+
+         algorithm::container::erase_if( queues, [ &correlation]( auto& pair) 
+         {
+            return algorithm::container::erase( pair.second, correlation).empty();
+         });
+      }
+
+      State::Prospects::Content State::Prospects::content() const
+      {
+         State::Prospects::Content content;
+         algorithm::transform( services, content.services, []( auto& pair) { return pair.first;});
+         algorithm::transform( queues, content.queues, []( auto& pair) { return pair.first;});
+         algorithm::container::sort::unique( content.services);
+         algorithm::container::sort::unique( content.queues);
+
+         return content;
+      }
    } // domain::discovery
 } // casual

--- a/middleware/gateway/source/group/outbound/handle.cpp
+++ b/middleware/gateway/source/group/outbound/handle.cpp
@@ -469,7 +469,7 @@ namespace casual
 
                      namespace topology::direct
                      {
-                        
+
                         auto explore( State& state)
                         {
                            //! Sent from _discovery_ when:
@@ -509,7 +509,7 @@ namespace casual
                                  // We don't need to reply. Only advertise the explored services, if any.
                                  detail::advertise::replies( state, replies, outcome);
                               };
-                              
+
                               state.coordinate.discovery( 
                                  send_request( state, message),
                                  std::move( callback));


### PR DESCRIPTION
Before:
In-flight discovery request was not considered upon rediscovery requests and explore resulting in missing services ( and queues) routing to new connections.

After:
Every in-flight discovery request registers it's resources to a prospect list which is considered when doing rediscover and exlpore. After the discovery request is done all prospect claims are removed from the prospect list made by that correlation.