### PR TITLE
discovery: aggregate external discovery requests for performance

### DIFF
--- a/middleware/common/include/casual/platform.h
+++ b/middleware/common/include/casual/platform.h
@@ -166,7 +166,8 @@ namespace casual
 
             namespace accumulate
             {
-               constexpr auto timeout = std::chrono::seconds{ 1};
+               constexpr size::type requests = 20;
+               constexpr auto timeout = std::chrono::milliseconds{ 4};
             } // accumulate
             
          } // discovery

--- a/middleware/domain/include/domain/discovery/state.h
+++ b/middleware/domain/include/domain/discovery/state.h
@@ -173,7 +173,7 @@ namespace casual
 
          namespace accumulate
          {
-            namespace topology::state
+            namespace topology
             {
                struct Direct
                {
@@ -186,15 +186,21 @@ namespace casual
                   )
                };
 
-               struct Implicit
+               namespace extract
                {
-                  std::vector< common::domain::Identity> domains;
+                  struct Result
+                  {
+                     message::discovery::topology::direct::Explore direct;
+                     std::vector< common::domain::Identity> implicit_domains;
 
-                  CASUAL_LOG_SERIALIZE(
-                     CASUAL_SERIALIZE( domains);
-                  )
-               };
-            } // topology::state
+                     CASUAL_LOG_SERIALIZE(
+                        CASUAL_SERIALIZE( direct);
+                        CASUAL_SERIALIZE( implicit_domains);
+                     )
+                  };
+               } // extract
+
+            } // topology
 
             struct Topology
             {
@@ -202,34 +208,152 @@ namespace casual
                void add( message::discovery::topology::direct::Update&& message);
                void add( message::discovery::topology::implicit::Update&& message);
 
-               using extract_result = std::tuple< message::discovery::topology::direct::Explore, message::discovery::topology::implicit::Update>;
-               extract_result extract() noexcept;
+               std::optional< topology::extract::Result> extract() noexcept;
 
                //! @returns true if something is aggregated, false otherwise
-               inline explicit operator bool() const noexcept { return ! m_direct.domains.empty() || ! m_implicit.domains.empty();}
+               inline bool empty() const noexcept { return m_direct.domains.empty() && m_implicit_domains.empty();}
 
                CASUAL_LOG_SERIALIZE(
                   CASUAL_SERIALIZE_NAME( m_direct, "direct");
-                  CASUAL_SERIALIZE_NAME( m_implicit, "implicit");
+                  CASUAL_SERIALIZE_NAME( m_implicit_domains, "implicit");
                )
                
             private:
-
-               topology::state::Direct m_direct;
-               topology::state::Implicit m_implicit;
-               //! keeps track of the lifetime of our timer.
-               std::optional< common::signal::timer::Deadline> m_timer;
+               topology::Direct m_direct;
+               std::vector< common::domain::Identity> m_implicit_domains;
             };
+
+            namespace request
+            {
+               namespace reply
+               {
+                  enum struct Type : short
+                  {
+                     api,
+                     discovery,
+                  };
+                  constexpr std::string_view description( Type value) noexcept
+                  {
+                     switch( value)
+                     {
+                        case Type::api: return "api";
+                        case Type::discovery: return "discovery";
+                     }
+                     return "<unknown>";
+                  }
+               } // reply
+
+               struct Reply
+               {
+                  reply::Type type;
+                  common::strong::correlation::id correlation;
+                  common::strong::ipc::id ipc;
+
+                  inline friend bool operator == ( const Reply& lhs, reply::Type rhs) noexcept { return lhs.type == rhs;}
+
+                  CASUAL_LOG_SERIALIZE(
+                     CASUAL_SERIALIZE( type);
+                     CASUAL_SERIALIZE( correlation);
+                     CASUAL_SERIALIZE( ipc);
+                  )
+               };
+
+               namespace extract
+               {
+                  struct Result
+                  {
+                     message::discovery::request::Content content;
+                     std::vector< request::Reply> replies;
+
+                     CASUAL_LOG_SERIALIZE(
+                        CASUAL_SERIALIZE( content);
+                        CASUAL_SERIALIZE( replies);
+                     )
+                  };
+                  
+               } // extract
+               
+            } // request
+
+            struct Request
+            {
+               void add( message::discovery::Request message);
+               void add( message::discovery::api::Request message);
+
+               std::optional< request::extract::Result> extract() noexcept;
+
+               inline auto pending() const noexcept { return m_result.replies.size();}
+
+               CASUAL_LOG_SERIALIZE(
+                  CASUAL_SERIALIZE_NAME( m_result, "result");
+               )
+            
+            private:
+               request::extract::Result m_result;
+            };
+
+            namespace extract
+            {
+               struct Result
+               {
+                  std::optional< topology::extract::Result> topology;
+                  std::optional<request::extract::Result> request;
+
+                  CASUAL_LOG_SERIALIZE(
+                     CASUAL_SERIALIZE( topology);
+                     CASUAL_SERIALIZE( request);
+                  )
+               };
+               
+            } // extract
+
+
+            struct Heuristic
+            {
+               std::optional< common::signal::timer::Deadline> deadline;
+
+               static platform::size::type in_flight() noexcept;
+
+               static const platform::size::type in_flight_window;
+               static const platform::time::unit duration;
+
+
+
+               CASUAL_LOG_SERIALIZE(
+                  CASUAL_SERIALIZE_NAME( in_flight(), "in_flight");
+                  CASUAL_SERIALIZE( in_flight_window);
+                  CASUAL_SERIALIZE( duration);
+               )
+            };
+
 
          } // accumulate
 
          struct Accumulate
          {
-            accumulate::Topology topology;
+            Accumulate();
+
+            void add( message::discovery::Request message);
+            void add( message::discovery::api::Request message);
+            void add( message::discovery::topology::direct::Update message);
+            void add( message::discovery::topology::implicit::Update message);
+
+            //! this should only be called when a timeout occur
+            accumulate::extract::Result extract();
+
+            //! @returns true if the accumulate should be bypassed, hence no accumulation based on load.
+            bool bypass() const noexcept;
 
             CASUAL_LOG_SERIALIZE(
-               CASUAL_SERIALIZE( topology);
+               CASUAL_SERIALIZE( m_heuristic);
+               CASUAL_SERIALIZE( m_topology);
+               CASUAL_SERIALIZE( m_request);
             )
+
+         private:
+            accumulate::Heuristic m_heuristic;
+            accumulate::Topology m_topology;
+            accumulate::Request m_request;
          };
 
 


### PR DESCRIPTION
This patch tries to aggregate discovery::Request based on load. The load is measured as _current discovery request in-flight_.

We've got a _load-window_ that defines how many in-flights to trigger the "next level". Every "level" adds a _timeout_ where every external discovery request are accumulated within.

When the _timeout_ kicks in, the aggregated request is sent, and later when the accumulated reply arrives it is _fan out_ to corresponding replies to match the actual original requests (correlation id and such).

"level" semantics:

The first "level" is `0`, hence has no accumulation and no timeout -> every request is sent "as is".

"level" 1 has a timeout with accumulation until send of 1 x _timeout value_.

"level" 2 -> 2 x _timeout value_.

... and so on.

To reach the "next level" the load has to increase with the _load-window_.

Example: Lets say _load-window_ is 2, and _timeout value_ is 10ms. If we have a load of 3, a timeout is set to 10ms, and we start accumulating request. When the timeout kicks in, we send the request, and invalidate the timeout.
A new request is about to be "sent", we check the load and decide if we should accumulate or not. We could have got replies during this time, and the load has gone down.

Note: To reach "level 2", there need to be a load of 5 -> including at least 2 accumulated requests -> at least 2 x 2ms without "any" replies.

This "algorithm" should self tune against heavy loads, at lest to other domains over network.

Temporary "config", will probably be renamed or removed in the future:
* CASUAL_DISCOVERY_ACCUMULATE_REQUESTS = <load window default 20>
* CASUAL_DISCOVERY_ACCUMULATE_TIMEOUT = <timeout default 4ms>