### PR TITLE
service - avoid double busy lookup

### DIFF
--- a/middleware/common/source/service/call/context.cpp
+++ b/middleware/common/source/service/call/context.cpp
@@ -168,6 +168,9 @@ namespace casual
             target = service();
          }
 
+         if( target.state != decltype( target.state)::idle)
+            code::raise::error( code::casual::invalid_semantics, "unable to reserve instance of service '", target.service, "'");
+
          // Call the service
          {
             prepared.message.service = target.service;

--- a/middleware/service/source/manager/handle.cpp
+++ b/middleware/service/source/manager/handle.cpp
@@ -626,7 +626,7 @@ namespace casual
                            // context::wait is not relevant for pending time.
                            if( pending.request.context.semantic == decltype( pending.request.context.semantic)::wait)
                               service::detail::lookup( state, pending.request, {});
-                           else                              
+                           else
                               service::detail::lookup( state, pending.request, platform::time::clock::type::now() - pending.when);
                         };
                         

--- a/middleware/service/source/manager/state.cpp
+++ b/middleware/service/source/manager/state.cpp
@@ -636,10 +636,15 @@ namespace casual
          // remove
          local::remove_services( *this, instance, message.services.remove);
 
-         // find all potentially pending.
+         // find all potentially pending that might be enabled by the new concurrent service(s)
          auto [ keep, remove] = algorithm::stable::partition( pending.lookups, [&]( auto& pending)
          {
-            if( auto found = algorithm::find( services, pending.request.requested))
+            auto is_requested_concurrent_service = [ &]( const auto& service)
+            {
+               return service.second.is_concurrent() && ! service.second.is_sequential() && service.first == pending.request.requested;
+            };
+
+            if( auto found = algorithm::find_if( services, std::move( is_requested_concurrent_service)))
                return found->second.instances.empty(); // false/remove if not empty, hence what we 'want' to return
 
             return true; // keep

--- a/middleware/service/unittest/source/manager/test_manager.cpp
+++ b/middleware/service/unittest/source/manager/test_manager.cpp
@@ -1047,5 +1047,50 @@ domain:
          EXPECT_TRUE( reply.state == decltype( reply.state)::replied) << trace.compose( "reply.state: ", reply.state);
       }
 
+      TEST( service_manager, lookup_reserved_service__SM_receives_concurrent_service_advertisement__expect_idle_when_reservation_finished)
+      {
+         common::unittest::Trace trace;
+
+         auto domain = local::domain();
+
+         service::unittest::advertise( { "local-service"});
+
+         // we reserve ourselves
+         {
+            auto service = common::service::Lookup{ "local-service"}();
+            EXPECT_TRUE( service.service.name == "local-service");
+            EXPECT_TRUE( service.state == decltype( service.state)::idle);
+         }
+
+         // lookup 'local-service' again
+         common::service::Lookup lookup{ "local-service"};
+
+         // some unrelated concurrent services are advertised while our second lookup is pending
+         service::unittest::concurrent::advertise( { "some-remote-service", "some-other-remote-service"});
+
+         // we have ourselves reserved - expect to be busy
+         {
+            auto service = lookup();
+            EXPECT_TRUE( service.service.name == "local-service");
+            EXPECT_TRUE( service.state == decltype( service.state)::busy);
+         }
+
+         {
+            // send ack for our initial "call"
+            {
+               common::message::service::call::ACK message;
+               message.metric.process = common::process::handle();
+
+               common::communication::device::blocking::send( 
+                  common::communication::instance::outbound::service::manager::device(),
+                  message);
+            }
+
+            // we should be idle again
+            auto service = lookup();
+            EXPECT_TRUE( service.state == decltype( service.state)::idle);
+         }
+      }
+
    } // service
 } // casual


### PR DESCRIPTION
Before: When receiving a concurrent::Advertise, the service manager would retry all pending lookups, potentially leading to a situation where a caller would get double 'busy' replies.

Now: On receiving concurrent::Advertise we only retry pending lookups for services that have concurrent instances. Additionally we raise an error in the caller upon receiving multiple busy looup replies.

Addresses #217