### PR TITLE
service: handle multiple busy lookups

### DIFF
--- a/middleware/service/source/forward/main.cpp
+++ b/middleware/service/source/forward/main.cpp
@@ -63,8 +63,6 @@ namespace casual
                Trace trace{ "service::forward::start"};
                log::line( verbose::log, "state: ", state);
 
-               auto handler = handle::create( state);
-
                communication::select::dispatch::pump(
                   local::condition( state),
                   state.directive,

--- a/middleware/service/source/manager/handle.cpp
+++ b/middleware/service/source/manager/handle.cpp
@@ -530,7 +530,7 @@ namespace casual
                                  dispatch::lookup::no_entry( state, message);
                               break;
                            case Enum::internal:
-                                 if( ! dispatch::lookup::external_internal( state, *service, message, pending))
+                              if( ! dispatch::lookup::external_internal( state, *service, message, pending))
                                  discover( state, std::move( message), service->information.name);
                               break;
                         }

--- a/middleware/service/unittest/source/manager/test_manager.cpp
+++ b/middleware/service/unittest/source/manager/test_manager.cpp
@@ -1092,5 +1092,55 @@ domain:
          }
       }
 
+      TEST( service_manager, lookup_reserved_service__SM_receives_process_exit_event__expect_idle_when_reservation_finished)
+      {
+         common::unittest::Trace trace;
+
+         auto domain = local::domain();
+
+         service::unittest::advertise( { "local-service"});
+
+         // we reserve ourselves
+         {
+            auto service = common::service::Lookup{ "local-service"}();
+            EXPECT_TRUE( service.service.name == "local-service");
+            EXPECT_TRUE( service.state == decltype( service.state)::idle);
+         }
+
+         // lookup 'local-service' again
+         common::service::Lookup lookup{ "local-service"};
+
+         // meanwhile, some process dies
+         {
+            common::message::event::process::Exit event;
+            event.state.pid = common::strong::process::id{ 42};
+            event.state.reason = decltype( event.state.reason)::exited;
+            common::communication::device::blocking::send( common::communication::instance::outbound::service::manager::device(), event);
+         }
+
+         // we have ourselves reserved - expect to be busy
+         {
+            auto service = lookup();
+            EXPECT_TRUE( service.service.name == "local-service");
+            EXPECT_TRUE( service.state == decltype( service.state)::busy);
+         }
+
+         {
+            // send ack for our initial "call"
+            {
+               common::message::service::call::ACK message;
+               message.metric.process = common::process::handle();
+
+               common::communication::device::blocking::send( 
+                  common::communication::instance::outbound::service::manager::device(),
+                  message);
+            }
+
+            // we should be idle again
+            auto service = lookup();
+            EXPECT_TRUE( service.state == decltype( service.state)::idle);
+         }
+      }
+
    } // service
 } // casual


### PR DESCRIPTION
Before: we relied on the service manager only sending a single busy lookup reply before sending idle. The SM didnt always uphold this contract which would occasionally cause service calls to fail.

Now: we wait until we receive an idle reply irrespective of how many busy ones are sent beforehand.

Resolves #217