### PR TITLE
c++23 - remove deprecated function is_pod

### DIFF
--- a/.github/workflows/casual-build-alpha.yaml
+++ b/.github/workflows/casual-build-alpha.yaml
@@ -131,7 +131,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: 'casualcore/casual-make'
-          ref: 'master'
+          ref: ${{ needs.calculate-version.outputs.major_minor }}
           path: 'casual-make'
 
       - name: download frontend
@@ -210,7 +210,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: 'casualcore/casual-make'
-          ref: 'master'
+          ref: ${{ needs.calculate-version.outputs.major_minor }}
           path: 'casual-make'
 
       - name: download frontend

--- a/.github/workflows/casual-build-beta.yaml
+++ b/.github/workflows/casual-build-beta.yaml
@@ -130,7 +130,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: 'casualcore/casual-make'
-          ref: 'master'
+          ref: ${{ needs.calculate-version.outputs.major_minor }}
           path: 'casual-make'
 
       - name: download frontend
@@ -210,7 +210,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: 'casualcore/casual-make'
-          ref: 'master'
+          ref: ${{ needs.calculate-version.outputs.major_minor }}
           path: 'casual-make'
 
       - name: download frontend

--- a/.github/workflows/casual-build-release.yaml
+++ b/.github/workflows/casual-build-release.yaml
@@ -129,7 +129,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: 'casualcore/casual-make'
-          ref: 'master'
+          ref: ${{ needs.calculate-version.outputs.major_minor }}
           path: 'casual-make'
 
       - name: download frontend
@@ -209,7 +209,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: 'casualcore/casual-make'
-          ref: 'master'
+          ref: ${{ needs.calculate-version.outputs.major_minor }}
           path: 'casual-make'
 
       - name: download frontend

--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ We've done some field tests
 ### Release notes
 [Changelog](documentation/changelog.md)
 
+### Build status
+|Branch |Status|
+|:-------|:------|
+|release/1.6|![release/1.6](https://github.com/casualcore/casual/actions/workflows/casual-build-release.yaml/badge.svg?branch=release/1.6)|
+|feature/1.7/main|![feature/1.7/main](https://github.com/casualcore/casual/actions/workflows/casual-build-beta.yaml/badge.svg?branch=feature/1.7/main)|
+|release/1.7|![release/1.7](https://github.com/casualcore/casual/actions/workflows/casual-build-release.yaml/badge.svg?branch=release/1.7)|
+
 ### Downloads
 [Official site](http://casual.laz.se/release/)
 

--- a/middleware/common/include/common/serialize/traits.h
+++ b/middleware/common/include/common/serialize/traits.h
@@ -106,7 +106,7 @@ namespace casual
       {
          //! all "pods" that can be serialized directly
          template< typename T>
-         inline constexpr bool pod_v = ( std::is_pod_v< T> && ! std::is_class_v< T> && ! std::is_enum_v< T>) // normal pods
+         inline constexpr bool pod_v = ( std::is_standard_layout_v< T> && ! std::is_class_v< T> && ! std::is_enum_v< T>) // normal pods
             || common::traits::is::any_v< T, std::string, platform::binary::type>;
 
          namespace archive

--- a/pipeline/script/backend/centos/build
+++ b/pipeline/script/backend/centos/build
@@ -10,6 +10,6 @@ CURRENT_DIRECTORY=$( cd "$(dirname "$0")" ; pwd -P )
 
 export CASUAL_MAKE_BUILD_VERSION=$1
 
-source scl_source enable devtoolset-9
+source scl_source enable devtoolset-11
 
 bash ${CURRENT_DIRECTORY}/../common/build


### PR DESCRIPTION
* The is_pod function is removed and replaced by std::is_standard_layout
* Changed pipeline to use correct version of casual-make
* Changed to devtoolset-11
* Added build status on central branches