### PR TITLE
configuration: prevent global contract setting being default overridden

### DIFF
--- a/middleware/configuration/include/configuration/model.h
+++ b/middleware/configuration/include/configuration/model.h
@@ -237,7 +237,7 @@ namespace casual::configuration
             using Contract = common::service::execution::timeout::contract::Type;
             
             std::optional< platform::time::unit> duration;
-            Contract contract = Contract::linger;
+            std::optional< Contract> contract;
 
             Timeout set_union( Timeout lhs, Timeout rhs);
 

--- a/middleware/configuration/source/model.cpp
+++ b/middleware/configuration/source/model.cpp
@@ -256,7 +256,8 @@ namespace casual
                if( rhs.duration)
                   lhs.duration = std::move( rhs.duration);
 
-               lhs.contract = rhs.contract;
+               if( rhs.contract)
+                  lhs.contract = rhs.contract;
                return lhs;
             }
 

--- a/middleware/configuration/source/model/transform.cpp
+++ b/middleware/configuration/source/model/transform.cpp
@@ -578,7 +578,8 @@ namespace casual
                      if( model.duration)
                         timeout.duration = chronology::to::string( model.duration.value());
 
-                     timeout.contract = common::service::execution::timeout::contract::transform( model.contract);
+                     if( model.contract)
+                        timeout.contract = common::service::execution::timeout::contract::transform( *model.contract);
 
                      std::optional<configuration::user::domain::service::Execution> result;
                      if( timeout.duration || timeout.contract)
@@ -624,7 +625,8 @@ namespace casual
 
                      auto& timeout = result.global.emplace().service.emplace().execution.emplace().timeout.emplace();
 
-                     timeout.contract = common::service::execution::timeout::contract::transform( model.service.global.timeout.contract);
+                     if( model.service.global.timeout.contract)
+                        timeout.contract = common::service::execution::timeout::contract::transform( *model.service.global.timeout.contract);
 
                      if( model.service.global.timeout.duration)
                         timeout.duration = chronology::to::string( *model.service.global.timeout.duration);

--- a/middleware/configuration/unittest/source/test_model.cpp
+++ b/middleware/configuration/unittest/source/test_model.cpp
@@ -685,6 +685,65 @@ domain:
          EXPECT_TRUE( A == result) << CASUAL_NAMED_VALUE( A) << "\n" << CASUAL_NAMED_VALUE( result);
       }
 
+
+      TEST( configuration_model_set_operations, A_union_B__partial_override_of_A_in_B)
+      {
+         common::unittest::Trace trace;
+
+         constexpr auto configuration = R"(
+domain:
+   name: A
+   global:
+      service:
+         execution:
+            timeout:
+               duration: 90
+               contract: terminate
+   servers:
+      - alias: a
+        path: a
+)";
+
+         // note: we do not override contract
+         constexpr auto add = R"(
+domain:
+   name: B
+   global:
+      service:
+         execution:
+            timeout:
+               duration: 45
+   servers:
+      - alias: b
+        path: b
+)";
+
+         // expect contract from A to carry over, but duration to be overridden
+         constexpr auto expected = R"(
+domain:
+   name: B
+   global:
+      service:
+         execution:
+            timeout:
+               duration: 45
+               contract: terminate
+   servers:
+      - alias: a
+        path: a
+      - alias: b
+        path: b
+)";
+
+         auto A = local::configuration( configuration);
+         auto B = local::configuration( add);
+         auto result = local::configuration( expected);
+
+         A = set_union( A, std::move( B));
+
+         EXPECT_TRUE( A == result) << CASUAL_NAMED_VALUE( A) << "\n" << CASUAL_NAMED_VALUE( result);
+      }
+
    } // configuration
 
 } // casual

--- a/middleware/service/source/manager/handle.cpp
+++ b/middleware/service/source/manager/handle.cpp
@@ -17,12 +17,14 @@
 #include "common/environment/normalize.h"
 #include "common/algorithm.h"
 #include "common/algorithm/is.h"
+#include "common/algorithm/coalesce.h"
 #include "common/process.h"
 #include "common/message/dispatch.h"
 #include "common/message/dispatch/handle.h"
 #include "common/message/internal.h"
 #include "common/event/listen.h"
 #include "common/event/send.h"
+#include "common/service/type.h"
 
 #include "common/communication/instance.h"
 
@@ -162,7 +164,7 @@ namespace casual
                // send event, at least domain-manager want's to know...
                common::message::event::process::Assassination event{ common::process::handle()};
                event.target = entry.target;
-               event.contract = entry.service->timeout.contract;
+               event.contract = algorithm::coalesce( entry.service->timeout.contract, state.timeout.contract).value_or( common::service::execution::timeout::contract::Type::linger);
                common::event::send( event);
             }
          };


### PR DESCRIPTION
Before:
A specified global execution.timeout.contract setting would be overriden by the default value when using multiple configuration files.

Now:
The setting is only overridden by the rightmost config file where it has been explicitly set.

Resolves #244