### PR TITLE
service - improve handling of service timeout

### DIFF
--- a/middleware/administration/makefile.cmk
+++ b/middleware/administration/makefile.cmk
@@ -106,6 +106,7 @@ make.LinkUnittest( 'unittest/bin/test-casual-administration',
       make.Compile( 'unittest/source/cli/test_internal.cpp'),
       make.Compile( 'unittest/source/cli/test_transaction.cpp'),
       make.Compile( 'unittest/source/cli/test_gateway.cpp'),
+      make.Compile( 'unittest/source/cli/test_service.cpp')
    ],
    [ 
       unittest_lib,

--- a/middleware/administration/unittest/source/cli/test_service.cpp
+++ b/middleware/administration/unittest/source/cli/test_service.cpp
@@ -1,0 +1,172 @@
+//!
+//! Copyright (c) 2023, The casual project
+//!
+//! This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+//!
+
+#include "common/unittest.h"
+
+#include "domain/unittest/manager.h"
+
+#include "administration/unittest/cli/command.h"
+
+namespace casual
+{
+   using namespace common;
+
+   namespace administration
+   {
+      namespace local
+      {
+         namespace
+         {
+            namespace cli
+            {
+               constexpr auto base = R"(
+domain: 
+   groups: 
+      -  name: base
+      -  name: user
+         dependencies: [ base]
+      -  name: gateway
+         dependencies: [ user]
+   
+   servers:
+      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager"
+         memberships: [ base]
+)";
+
+               template< typename... C>
+               auto domain( C&&... configurations)
+               {
+                  return casual::domain::unittest::manager( base, std::forward< C>( configurations)...);
+               }
+            } // cli
+         } // <unnamed>
+      } // local
+
+
+      TEST( cli_service, list_services)
+      {
+         common::unittest::Trace trace;
+
+         auto domain = local::cli::domain( R"(
+domain:
+   name: test-service-cli
+   services:
+      -  name: some-service
+         execution:
+            timeout:
+               duration: 90
+               contract: terminate
+)");
+
+         // name
+         {
+            const auto output = administration::unittest::cli::command::execute( R"(casual service --list-services --porcelain true | awk -F'|' '{printf $1}')").string();
+            constexpr auto expected = "some-service";
+            EXPECT_EQ( output, expected);
+         }
+
+         // timeout duration
+         {
+            const auto output = administration::unittest::cli::command::execute( R"(casual service --list-services --porcelain true | awk -F'|' '{printf $4}')").string();
+            constexpr auto expected = "90.000";
+            EXPECT_EQ( output, expected);
+         }
+
+         // timeout contract
+         {
+            const auto output = administration::unittest::cli::command::execute( R"(casual service --list-services --porcelain true | awk -F'|' '{printf $15}')").string();
+            constexpr auto expected = "terminate";
+            EXPECT_EQ( output, expected);
+         }
+      }
+
+      TEST( cli_service, list_services__global_values)
+      {
+         common::unittest::Trace trace;
+
+         auto domain = local::cli::domain( R"(
+domain:
+   name: test-service-cli
+
+   global:
+      service:
+         execution:
+            timeout:
+               duration: 30
+               contract: kill
+
+   services:
+      -  name: some-service
+)");
+
+         // name
+         {
+            const auto output = administration::unittest::cli::command::execute( R"(casual service --list-services --porcelain true | awk -F'|' '{printf $1}')").string();
+            constexpr auto expected = "some-service";
+            EXPECT_EQ( output, expected);
+         }
+
+         // timeout duration
+         {
+            const auto output = administration::unittest::cli::command::execute( R"(casual service --list-services --porcelain true | awk -F'|' '{printf $4}')").string();
+            constexpr auto expected = "30.000";
+            EXPECT_EQ( output, expected);
+         }
+
+         // timeout contract
+         {
+            const auto output = administration::unittest::cli::command::execute( R"(casual service --list-services --porcelain true | awk -F'|' '{printf $15}')").string();
+            constexpr auto expected = "kill";
+            EXPECT_EQ( output, expected);
+         }
+      }
+
+      TEST( cli_service, list_services__override_global_value)
+      {
+         common::unittest::Trace trace;
+
+         auto domain = local::cli::domain( R"(
+domain:
+   name: test-service-cli
+
+   global:
+      service:
+         execution:
+            timeout:
+               duration: 30
+               contract: kill
+
+   services:
+      -  name: some-service
+         execution:
+            timeout:
+               duration: 90
+)");
+
+         // name
+         {
+            const auto output = administration::unittest::cli::command::execute( R"(casual service --list-services --porcelain true | awk -F'|' '{printf $1}')").string();
+            constexpr auto expected = "some-service";
+            EXPECT_EQ( output, expected);
+         }
+
+         // timeout duration
+         {
+            const auto output = administration::unittest::cli::command::execute( R"(casual service --list-services --porcelain true | awk -F'|' '{printf $4}')").string();
+            constexpr auto expected = "90.000";
+            EXPECT_EQ( output, expected);
+         }
+
+         // timeout contract
+         {
+            const auto output = administration::unittest::cli::command::execute( R"(casual service --list-services --porcelain true | awk -F'|' '{printf $15}')").string();
+            constexpr auto expected = "kill";
+            EXPECT_EQ( output, expected);
+         }
+      }
+
+   } // administration
+} // casual

--- a/middleware/configuration/source/model/transform.cpp
+++ b/middleware/configuration/source/model/transform.cpp
@@ -275,9 +275,8 @@ namespace casual
 
                         if( service.visibility)
                            result.visibility = common::service::visibility::transform( *service.visibility);
-                           
-                        if( service.execution)
-                           result.timeout = detail::execution::timeout( algorithm::coalesce( service.execution, defaults.execution));
+
+                        result.timeout = detail::execution::timeout( algorithm::coalesce( service.execution, defaults.execution));
 
                         return result;
                      });
@@ -574,7 +573,7 @@ namespace casual
                {
                   auto execution( const configuration::model::service::Timeout& model)
                   {
-                     configuration::user::domain::service::execution::Timeout timeout;                  
+                     configuration::user::domain::service::execution::Timeout timeout;
                      if( model.duration)
                         timeout.duration = chronology::to::string( model.duration.value());
 
@@ -585,7 +584,7 @@ namespace casual
                      if( timeout.duration || timeout.contract)
                         result.emplace().timeout = std::move( timeout);
 
-                     return result;                     
+                     return result;
                   }
 
                }

--- a/middleware/service/source/manager/admin/cli.cpp
+++ b/middleware/service/source/manager/admin/cli.cpp
@@ -289,7 +289,16 @@ namespace casual
 
                      static auto instances = normalized::instances( state);
 
-                     auto format_timeout_duration = []( const auto& value)
+                     auto format_timeout_duration_string = []( const auto& value) -> std::string
+                     {
+                        if( ! value.execution.timeout.duration || *value.execution.timeout.duration == platform::time::unit::zero())
+                           return "-";
+                        using second_t = std::chrono::duration< double>;
+                        return std::to_string( std::chrono::duration_cast< second_t>( value.execution.timeout.duration.value()).count());
+                     };
+
+                     // porcelain
+                     auto format_timeout_duration_double = []( const auto& value)
                      {
                         if( ! value.execution.timeout.duration)
                            return 0.0;
@@ -320,7 +329,8 @@ namespace casual
 
                      // we need to set something when category is empty to help
                      // enable possible use of sort, cut, awk and such
-                     auto format_category = []( const admin::model::Service& value) -> std::string_view{
+                     auto format_category = []( const admin::model::Service& value) -> std::string_view
+                     {
                         if( value.category.empty())
                            return "-";
                         return value.category;
@@ -338,13 +348,15 @@ namespace casual
                      };
 
 
-                     auto format_invoked = []( const admin::model::Service& value){
+                     auto format_invoked = []( const admin::model::Service& value)
+                     {
                         return value.metric.invoked.count;
                      };
 
                      using time_type = std::chrono::duration< double>;
 
-                     auto format_avg_time = []( const admin::model::Service& value){
+                     auto format_avg_time = []( const admin::model::Service& value)
+                     {
                         if( value.metric.invoked.count == 0)
                            return 0.0;
 
@@ -366,7 +378,8 @@ namespace casual
                         return value.metric.pending.count;
                      };
 
-                     auto format_avg_pending_time = []( const admin::model::Service& value){
+                     auto format_avg_pending_time = []( const admin::model::Service& value)
+                     {
                         if( value.metric.pending.count == 0)
                            return 0.0;
 
@@ -390,7 +403,7 @@ namespace casual
                            terminal::format::column( "category", format_category, terminal::color::no_color, terminal::format::Align::left),
                            terminal::format::column( "V", format_visibility, terminal::color::no_color, terminal::format::Align::left),
                            terminal::format::column( "mode", std::mem_fn( &admin::model::Service::transaction), terminal::color::no_color, terminal::format::Align::left),
-                           terminal::format::column( "timeout", format_timeout_duration, terminal::color::blue, terminal::format::Align::right),
+                           terminal::format::column( "timeout", format_timeout_duration_string, terminal::color::blue, terminal::format::Align::right),
                            terminal::format::column( "contract", format_timeout_contract, terminal::color::blue, terminal::format::Align::right),
                            terminal::format::column( "I", format::instance::local::total{}, terminal::color::white, terminal::format::Align::right),
                            terminal::format::column( "C", format_invoked, terminal::color::white, terminal::format::Align::right),
@@ -410,7 +423,7 @@ namespace casual
                            terminal::format::column( "name", std::mem_fn( &admin::model::Service::name)),
                            terminal::format::column( "category", format_category),
                            terminal::format::column( "mode", std::mem_fn( &admin::model::Service::transaction)),
-                           terminal::format::column( "timeout", format_timeout_duration),
+                           terminal::format::column( "timeout", format_timeout_duration_double),
                            terminal::format::column( "I", format::instance::local::total{}),
                            terminal::format::column( "C", format_invoked),
                            terminal::format::column( "AT", format_avg_time),
@@ -442,7 +455,8 @@ namespace casual
 
                      auto format_pid = []( auto& v){ return v.process.pid;};
 
-                     auto format_service_name = []( const value_type& v){
+                     auto format_service_name = []( const value_type& v)
+                     {
                         return v.service.get().name;
                      };
 
@@ -485,7 +499,8 @@ namespace casual
                         }
                      };
 
-                     auto format_hops = []( const value_type& value){
+                     auto format_hops = []( const value_type& value)
+                     {
                         return value.hops;
                      };
 

--- a/test/unittest/source/test_assassinate.cpp
+++ b/test/unittest/source/test_assassinate.cpp
@@ -67,6 +67,51 @@ domain:
 
       }
 
+      TEST( test_assassinate, timeout_1ms__call__global_config)
+      {
+         unittest::Trace trace;
+
+         constexpr auto configuration = R"(
+domain: 
+   name: A
+
+   global:
+      service:
+         execution:
+            timeout:
+               duration: 2ms
+               contract: kill
+
+   groups: 
+      - name: base
+      - name: user
+        dependencies: [ base]
+
+   servers:
+      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager
+        memberships: [ base]
+      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/casual-transaction-manager
+        memberships: [ base]
+      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server
+        memberships: [ user]
+        arguments: [ --sleep, 1s]
+)";
+
+         auto domain = casual::domain::unittest::manager( configuration);
+
+         auto start = platform::time::clock::type::now();
+
+         auto buffer = tpalloc( X_OCTET, nullptr, 128);
+         auto len = tptypes( buffer, nullptr, nullptr);
+
+         EXPECT_TRUE( tpcall( "casual/example/sleep", buffer, 128, &buffer, &len, 0) == -1);
+         EXPECT_TRUE( tperrno == TPETIME) << "tperrno: " << tperrnostring( tperrno);
+         EXPECT_TRUE( platform::time::clock::type::now() - start > std::chrono::milliseconds{ 2});
+
+         tpfree( buffer);
+
+      }
+
 
 
    } //test


### PR DESCRIPTION
* We now take the global config into account when calculating the timeout duration for services that are featured in the configuration
* Timeout contract is now displayed correctly when listing services with the cli
* A service with no timeout duration is now indicated by '-' rather than 0.00 when listing services with the cli