### PR TITLE
queue - send reply on failed dequeues

### DIFF
--- a/middleware/queue/source/group/handle.cpp
+++ b/middleware/queue/source/group/handle.cpp
@@ -243,9 +243,8 @@ namespace casual
                      Trace trace{ "queue::handle::dequeue::Request::handle"};
                      log::line( verbose::log, "message: ", message);
 
-                     auto now = platform::time::clock::type::now();
-
-                     auto reply = state.queuebase.dequeue( message, now);
+                     // send an empty reply on error TODO: is this the api we want?
+                     auto reply = common::message::reverse::type( message);
                      reply.correlation = message.correlation;
 
                      // make sure we always send reply
@@ -253,6 +252,14 @@ namespace casual
                      {
                         state.multiplex.send( message.process.ipc, reply);
                      });
+
+                     // Make sure we've got the quid.
+                     message.queue = state.queuebase.id( message);
+
+                     auto now = platform::time::clock::type::now();
+
+                     reply = state.queuebase.dequeue( message, now);
+                     reply.correlation = message.correlation;
 
                      if( ! reply.message.empty())
                      {
@@ -292,9 +299,6 @@ namespace casual
 
                         try
                         {
-                           // Make sure we've got the quid.
-                           message.queue = state.queuebase.id( message);
-
                            return handle( state, message);
                         }
                         catch( ...)

--- a/middleware/queue/unittest/source/test_queue.cpp
+++ b/middleware/queue/unittest/source/test_queue.cpp
@@ -1260,5 +1260,36 @@ domain:
          }), std::system_error);
       }
 
+      TEST( casual_queue, dequeue_fails__expect_error_reply)
+      {
+         common::unittest::Trace trace;
+
+         auto domain = local::domain();
+
+         auto find_queuegroup = []
+         {
+            ipc::message::lookup::Request request{ common::process::handle()};
+            request.name = "a1";
+
+            common::communication::device::blocking::send( 
+               common::communication::instance::outbound::queue::manager::device(), 
+               request);
+
+            ipc::message::lookup::Reply reply;
+            common::communication::device::blocking::receive( common::communication::ipc::inbound::device(), reply);
+            return reply.process.ipc;
+         };
+
+         // We cause an error by requesting a nonexistent queue
+         ipc::message::group::dequeue::Request request{ common::process::handle()};
+         request.name = "i_dont_exist";
+
+         common::communication::device::blocking::send( find_queuegroup(), request);
+
+         ipc::message::group::dequeue::Reply reply;
+         common::communication::device::blocking::receive( common::communication::ipc::inbound::device(), reply);
+         EXPECT_TRUE( reply.message.empty());
+      }
+
    } // queue
 } // casual


### PR DESCRIPTION
Before:
If sqlite threw an exception before we had dequeued a message, no dequeue_reply would be sent.

Now:
We make sure to always send a reply so that the caller can react appropriately.

Resolves #262