### PR TITLE
xatmi: add function to reset execution_id from public api

### DIFF
--- a/middleware/xatmi/include/casual/xatmi/extended.h
+++ b/middleware/xatmi/include/casual/xatmi/extended.h
@@ -37,6 +37,7 @@ extern int casual_user_log( const char* category, const char* const message);
 
 extern void casual_execution_id_set( const uuid_t* id);
 extern const uuid_t* casual_execution_id_get();
+extern const uuid_t* casual_execution_id_reset();
 
 /**
  * @returns the name of current execution service name

--- a/middleware/xatmi/source/xatmi/extended.cpp
+++ b/middleware/xatmi/source/xatmi/extended.cpp
@@ -144,6 +144,12 @@ const uuid_t* casual_execution_id_get()
    return &casual::common::execution::id().underlying().get();
 }
 
+const uuid_t* casual_execution_id_reset()
+{
+   casual::common::execution::reset();
+   return &casual::common::execution::id().underlying().get();
+}
+
 void casual_instance_browse_services( casual_instance_browse_callback callback, void* context)
 {
    using namespace casual;

--- a/middleware/xatmi/unittest/source/test_xatmi.cpp
+++ b/middleware/xatmi/unittest/source/test_xatmi.cpp
@@ -39,6 +39,20 @@ namespace casual
 
          EXPECT_EQ( uuid::string( uuid), uuid::string( *get_id));
       }
+
+      TEST( xatmi_execution, execution_id_reset)
+      {
+         common::unittest::Trace trace;
+
+         uuid_t uuid;
+         uuid_generate( uuid);
+
+         casual_execution_id_set( &uuid);
+
+         auto reset_id = casual_execution_id_reset();
+
+         EXPECT_NE( uuid::string( uuid), uuid::string( *reset_id));
+      }
    } // common
 } // casual
 


### PR DESCRIPTION
Resets the execution_id and returns the new id

Resolves #239