### PR TITLE
domain: propagate restart to configuration-get

### DIFF
--- a/middleware/domain/source/manager/transform.cpp
+++ b/middleware/domain/source/manager/transform.cpp
@@ -460,6 +460,7 @@ namespace casual
             result.memberships = name_groups( server.memberships);
             result.instances = server.instances.size();
             result.note = server.note;
+            result.lifetime.restart = server.restart;
 
             return result;
          }, [&reserved_groups]( auto& server)
@@ -477,6 +478,7 @@ namespace casual
             result.memberships = name_groups( executable.memberships);
             result.instances = executable.instances.size();
             result.note = executable.note;
+            result.lifetime.restart = executable.restart;
 
             return result;
          });

--- a/middleware/domain/unittest/source/manager/test_manager.cpp
+++ b/middleware/domain/unittest/source/manager/test_manager.cpp
@@ -1334,6 +1334,7 @@ domain:
          alias: simple-server
          instances: 2
          memberships: [ A]
+         restart: true
 
    executables:
       -  alias: sleep
@@ -1341,6 +1342,7 @@ domain:
          arguments: [60]
          instances: 2
          memberships: [ B]
+         restart: true
 
 )";
 
@@ -1351,7 +1353,6 @@ domain:
          auto model = casual::configuration::model::transform( unittest::internal::call< casual::configuration::user::Model>( admin::service::name::configuration::get));
 
          EXPECT_TRUE( origin.domain == model.domain) << CASUAL_NAMED_VALUE( origin.domain) << "\n " << CASUAL_NAMED_VALUE( model.domain);
-
       }
 
       namespace local


### PR DESCRIPTION
The restart attribute in model is now propagated correctly to cli.

Resolves #240