### PR TITLE
cli: add precondition casual log can't be tied to stdout

### DIFF
--- a/middleware/administration/unittest/source/cli/test_pipe.cpp
+++ b/middleware/administration/unittest/source/cli/test_pipe.cpp
@@ -62,6 +62,16 @@ domain:
          } // <unnamed>
       } // local
 
+      TEST( cli_pipe, log_file_to_stdout__expect_cli_error)
+      {
+         auto domain = local::domain();
+
+          auto output = local::execute( R"(CASUAL_LOG_PATH=/dev/stdout casual service --list-services 2>&1 )");
+
+          EXPECT_TRUE( algorithm::search( output, std::string_view( "casual:precondition"))) << output;
+
+      }
+
       TEST( cli_pipe, enqueue_dequeue_call_echo)
       {
          common::unittest::Trace trace;

--- a/middleware/common/include/common/code/casual.h
+++ b/middleware/common/include/common/code/casual.h
@@ -23,6 +23,8 @@ namespace casual
             shutdown = 1,
             interrupted,
 
+            preconditions,
+
             invalid_configuration,
             invalid_document,
             invalid_node,

--- a/middleware/common/source/code/casual.cpp
+++ b/middleware/common/source/code/casual.cpp
@@ -75,6 +75,7 @@ namespace casual
          {
             case casual::shutdown: return "shutdown";
             case casual::interrupted: return "interrupted";
+            case casual::preconditions: return "preconditions";
             case casual::invalid_configuration: return "invalid-configuration";
             case casual::invalid_document: return "invalid-document";
             case casual::invalid_node: return "invalid-node";


### PR DESCRIPTION
This patch checks if casual log is tied to stdout and if so, we exit the cli and print the violated precondition to stderr.

Resolves #259