### PR TITLE
xatmi - comply to specification signal handling

### DIFF
--- a/middleware/xatmi/include/casual/xatmi/internal/signal.h
+++ b/middleware/xatmi/include/casual/xatmi/internal/signal.h
@@ -1,0 +1,26 @@
+//!
+//! Copyright (c) 2018, The casual project
+//!
+//! This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+//!
+
+#pragma once
+
+#include "common/signal.h"
+
+#include <optional>
+
+
+namespace casual::xatmi::internal::signal
+{
+    template< typename Flags>
+    inline std::optional< casual::common::signal::thread::scope::Block> maybe_block( Flags flags)
+    {
+        using enum_type = typename Flags::enum_type;
+
+        if( flags.exist( enum_type::signal_restart))
+            return casual::common::signal::thread::scope::Block{};
+
+        return {};
+    }
+} // casual::xatmi::internal::signal

--- a/middleware/xatmi/source/xatmi/internal/code.cpp
+++ b/middleware/xatmi/source/xatmi/internal/code.cpp
@@ -10,6 +10,7 @@
 #include "common/exception/capture.h"
 #include "common/code/category.h"
 #include "common/log.h"
+#include "common/code/signal.h"
 
 namespace casual
 {
@@ -27,6 +28,9 @@ namespace casual
 
                if( code == common::code::casual::invalid_argument)
                   return common::code::xatmi::argument;
+
+               if( common::code::is::category< common::code::signal>( code))
+                  return common::code::xatmi::signal;
 
                common::log::line( common::log::category::error, common::code::xatmi::system, " unexpected error-code: ", code);
                return common::code::xatmi::system;


### PR DESCRIPTION
Before: We did not correctly handle signals according to the specification for the TPSIGRSTRT flag.
Nor did we set tperrno to TPGOTSIG if a call failed due to receiving a signal from the OS.

Now: For the XATMI functions where TPSIGRSTRT is valid, we now block incoming signals for the duration of the call. If TPSIGRSTRT is not set and a call fails due to a signal, we now set tperrno to TPGOTSIG.

Resolves #271