### PR TITLE
service: perform discovery on external_discovery

### DIFF
--- a/middleware/service/source/manager/handle.cpp
+++ b/middleware/service/source/manager/handle.cpp
@@ -548,7 +548,7 @@ namespace casual
                               break;
                            case Enum::external_discovery:
                               if( ! dispatch::lookup::external_internal( state, *service, message, pending))
-                                 dispatch::lookup::no_entry( state, message);
+                                 discover( state, std::move( message), service->information.name);
                               break;
                            case Enum::internal:
                               if( ! dispatch::lookup::external_internal( state, *service, message, pending))


### PR DESCRIPTION
Before: No discovery was made for external_discovery requester if service was known by service-manager but no routing existed and tpenoent was returned.

After: A new discovery was made and the service was found.

Resolves #269