### PR TITLE
cli: header output in porcelain if --header true

### DIFF
--- a/middleware/administration/documentation/cli/casual.operation.md
+++ b/middleware/administration/documentation/cli/casual.operation.md
@@ -33,7 +33,7 @@ pipe           ?                                          pipe related options
 --precision    ?  <value>                              1  set number of decimal points used for output (default: 3)                               
 --block        ?  [true, false]                        1  set/unset blocking - if false return control to user as soon as possible (default: true)
 --verbose      ?  [true, false]                        1  verbose output (default: false)                                                         
---porcelain    ?  [true, false]                        1  easy to parse output format (default: false)                                            
+--porcelain    ?  [true, false]                        1  backward compatible, easy to parse output format (default: false)                       
 internal       ?                                          internal casual stuff for troubleshooting etc...                                        
 --version      ?                                          display version information                                                             
 --help         ?  <value>                              *  use --help <option> to see further details                                              

--- a/middleware/administration/documentation/cli/transaction.operation.md
+++ b/middleware/administration/documentation/cli/transaction.operation.md
@@ -53,6 +53,13 @@ host# casual --help transaction
       -lp, --list-pending [0..1]
             list pending tasks
 
+      --legend [0..1]  (list-resources) [1]
+            the legend for the supplied option
+            
+            Documentation and description for abbreviations and acronyms used as columns in output
+            
+            note: not all options has legend, use 'auto complete' to find out which legends are supported.
+
       --information [0..1]
             collect aggregated information about transactions in this domain
 

--- a/middleware/administration/makefile.cmk
+++ b/middleware/administration/makefile.cmk
@@ -98,6 +98,7 @@ unittest_lib = make.LinkLibrary( 'bin/casual-administration-unittest',
 
 make.LinkUnittest( 'unittest/bin/test-casual-administration',
    [
+      make.Compile( 'unittest/source/cli/test_casual.cpp'),
       make.Compile( 'unittest/source/cli/test_call.cpp'),
       make.Compile( 'unittest/source/cli/test_domain.cpp'),
       make.Compile( 'unittest/source/cli/test_discovery.cpp'),

--- a/middleware/administration/unittest/source/cli/test_casual.cpp
+++ b/middleware/administration/unittest/source/cli/test_casual.cpp
@@ -1,0 +1,90 @@
+//!
+//! Copyright (c) 2023, The casual project
+//!
+//! This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+//!
+
+
+//! The intention with this test suite is to verify the `casual` cli application
+
+
+#include "common/unittest.h"
+
+#include "domain/unittest/manager.h"
+
+#include "administration/unittest/cli/command.h"
+
+
+
+namespace casual
+{
+   using namespace common;
+
+   using namespace std::literals;
+
+   namespace administration
+   {
+
+      namespace local
+      {
+         namespace
+         {
+
+            constexpr auto configuration_base = R"(
+domain: 
+   groups: 
+      -  name: base
+      -  name: user
+         dependencies: [ base]
+      -  name: gateway
+         dependencies: [ user]
+   
+   servers:
+      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager"
+         memberships: [ base]
+)";
+
+            template< typename... C>
+            auto domain( C&&... configurations)
+            {
+               return casual::domain::unittest::manager( configuration_base, std::forward< C>( configurations)...);
+            }
+
+         } // <unnamed>
+      } // local
+
+      TEST( cli_casual, porcelain_help)
+      {
+         common::unittest::Trace trace;
+
+         auto output = administration::unittest::cli::command::execute( R"(casual --help --porcelain )").consume();
+
+         // Arbitrary check that help talks about --header true to help user...
+         EXPECT_TRUE( algorithm::search( output, "--header true"sv)) << output;
+      }
+
+      TEST( cli_casual, porcelain_explicit_header)
+      {
+         common::unittest::Trace trace;
+
+         auto domain = local::domain( R"(
+domain:
+   name: A
+)");
+
+         {
+            auto header = string::split( administration::unittest::cli::command::execute( R"(casual service --list-services --porcelain true --header true | head -n 1 )").consume(), '|');
+            EXPECT_TRUE( algorithm::equal( header, array::make(  "name", "category", "mode", "timeout", "I", "C", "AT", "min", "max", "P", "PAT", "RI", "RC", "last", "contract", "V\n" ))) << CASUAL_NAMED_VALUE( header);
+         }
+
+         // if we don't explicit set --header true we don't get porcelain header
+         {
+            auto header = string::split( administration::unittest::cli::command::execute( R"(casual service --list-services --porcelain true | head -n 1 )").consume(), '|');
+            EXPECT_TRUE( header.empty()) << CASUAL_NAMED_VALUE( header);
+         }
+
+      }
+
+
+   } // administration
+} // casual

--- a/middleware/common/include/common/terminal.h
+++ b/middleware/common/include/common/terminal.h
@@ -32,6 +32,9 @@ namespace casual
             bool color() const;
             inline auto porcelain() const { return m_porcelain;}
             bool header() const;
+            //! user has used --header true explicitly
+            //! @note this is to enable print header with porcelain -> not break backward compatible
+            bool explict_header() const;
             inline auto precision() const { return m_precision;}
             inline auto block() const { return m_block;}
             inline auto verbose() const { return m_verbose;}
@@ -43,6 +46,15 @@ namespace casual
             using options_type = decltype( std::declval< argument::Option>() + std::declval< argument::Option>());
 
             options_type options() &;
+
+            CASUAL_LOG_SERIALIZE(
+               CASUAL_SERIALIZE( m_color);
+               CASUAL_SERIALIZE( m_porcelain);
+               CASUAL_SERIALIZE( m_header);
+               CASUAL_SERIALIZE( m_block);
+               CASUAL_SERIALIZE( m_verbose);
+               CASUAL_SERIALIZE( m_precision);
+            )
 
          private:
             std::string m_color;
@@ -209,6 +221,20 @@ namespace casual
                }
             }
 
+            void print_porcelain_headers( std::ostream& out)
+            {
+               auto print_delimiter = [&](){
+                  out << '|';
+               };
+
+               auto print_name = [&out]( const column_holder& c){
+                  out << c.name();
+               };
+
+               algorithm::for_each_interleave( m_columns, print_name, print_delimiter);
+               out << '\n';
+            }
+
 
 
             template< typename R>
@@ -259,6 +285,10 @@ namespace casual
                {
                   calculate_width( range, out);
                   print_headers( out);
+               }
+               else if( output::directive().explict_header())
+               {
+                  print_porcelain_headers( out);
                }
 
                print_rows( out, range);


### PR DESCRIPTION
Before: There was no way for the user to map the columns in porcelain output. The regular and porcelain differ in some options.

Now: If explict `--heder true` is used, we output the header in porcelain format.

Fixes #283