### PR TITLE
service admin: unittest in test_service causes SIGSEGV

### DIFF
--- a/middleware/administration/unittest/source/cli/test_service.cpp
+++ b/middleware/administration/unittest/source/cli/test_service.cpp
@@ -184,15 +184,15 @@ domain:
                contract: kill
 )");
 
-         casual::service::unittest::concurrent::advertise( { "without-contract"});
-
          {  
             const auto output = administration::unittest::cli::command::execute( R"(casual --color false service --list-services | grep with-contract | awk '{ print $6}' )").consume();
             EXPECT_EQ( output, "kill\n");
          }
 
          {  
-            const auto output = administration::unittest::cli::command::execute( R"(casual --color false service --list-services | grep without-contract | awk '{ print $6}' )").consume();
+            // list admin services to check oputput in contract column for a service
+            // without contract. Admin services do not have contract specified. 
+            const auto output = administration::unittest::cli::command::execute( R"(casual --color false service --list-admin-services | grep configuration/get | awk '{ print $6}' )").consume();
             EXPECT_EQ( output, "-\n");
          }
       }


### PR DESCRIPTION
The unit test cli_service.list_services__unknown_contract__expect_hyphen got a SIGSEGV. Seems as if this was related to the unittest doing "advertise" on a service named "without-contract". The SEGV did not occur when the advertise and test that relied on it was removed. The SIGSEGV occurs if the adverise is the only thing done in the test case!

Removed the advertise() call and modified the command that checks output in "contract" column for services that do not have a contract to instead use --list-admin-services. The admin services do not have contracts specified.

The unit test was introduced when the code for listing services was modified to print a "-" in this column for services without contract (issue #281, PR #282). I verified that code before this change did not print a "-" in this column in versions before that change, and recent versions print the "-". Therefore checking the output of --list-admin-services is likely to be a valid unit test for the change.

The SIGSEGV occured on every run of the test suite in my environment, but apparently not in the github builds and test executions. A possibility is that building with --debug is a factor.