### PR TITLE
communication: add message send/receive event logging

### DIFF
--- a/middleware/common/include/common/communication/device.h
+++ b/middleware/common/include/common/communication/device.h
@@ -405,6 +405,10 @@ namespace casual
                      // Try to find a massage that matches the predicate
                      found = algorithm::find_if( m_cache, predicate);
                   }
+
+                  if( found)
+                     log::line( log::category::event::message::received, found->type(), '|', found->correlation(), '|', found->execution(), '|', found->size());
+
                   return found;
                }
                catch( ...)
@@ -512,7 +516,10 @@ namespace casual
                   auto result = policy.send( Base::connector(), std::forward< C>( complete));
 
                   if( result)
+                  {
                      message::counter::add::sent( complete.type());
+                     log::line( log::category::event::message::sent, complete.type(), '|', complete.correlation(), '|', complete.execution(), '|', complete.size());
+                  }
 
                   return result;
                }

--- a/middleware/common/include/common/communication/ipc/message.h
+++ b/middleware/common/include/common/communication/ipc/message.h
@@ -189,6 +189,9 @@ namespace casual
          inline auto& correlation() const noexcept { return m_correlation;}
          inline auto offset() noexcept { return m_offset;}
 
+         //! @returns the extracted mandatory execution id from the payload
+         strong::execution::id execution() const noexcept;
+
          platform::binary::type payload;
 
          //! Adds a transport message.
@@ -269,7 +272,9 @@ namespace casual
                m_offset += left();
             }
 
+            inline auto execution() const noexcept { return m_complete.execution();}
             inline const auto& correlation() const noexcept { return m_complete.correlation();}
+            inline auto size() const noexcept { return m_complete.size();}
             inline const auto& complete() const noexcept { return m_complete;}
             inline auto type() const noexcept { return m_complete.type();}
 

--- a/middleware/common/include/common/communication/tcp/message.h
+++ b/middleware/common/include/common/communication/tcp/message.h
@@ -100,6 +100,8 @@ namespace casual
          inline auto correlation() const noexcept { return header::detail::correlation( m_header);}
          //! @}
 
+         //! @returns the extracted mandatory execution id from the payload
+         strong::execution::id execution() const noexcept;
 
          inline const char* header_data() const noexcept { return reinterpret_cast< const char*>( &m_header);}
          inline char* header_data() noexcept { return reinterpret_cast< char*>( &m_header);}

--- a/middleware/common/include/common/log/category.h
+++ b/middleware/common/include/common/log/category.h
@@ -48,6 +48,18 @@ namespace casual
          extern Stream service;
          extern Stream server;
          extern Stream transaction;
+
+         namespace message
+         {
+            namespace part
+            {
+               extern Stream sent;
+               extern Stream received;
+            } // part
+
+            extern Stream sent;
+            extern Stream received;
+         } // message
          
       } // event
       

--- a/middleware/common/source/communication/ipc.cpp
+++ b/middleware/common/source/communication/ipc.cpp
@@ -172,6 +172,7 @@ namespace casual
 
                   if( ! error)
                   {
+                     log::line( log::category::event::message::part::sent, transport.type(), '|', transcode::hex::stream::wrapper( transport.correlation()), '|', transport.size(), '|', transport.payload_offset(), '|', transport.complete_size());
                      log::line( verbose::log, "ipc ---> blocking send - socket: ", socket, ", destination: ", destination, ", transport: ", transport);
                      return true;
                   }
@@ -201,6 +202,7 @@ namespace casual
                if( result == -1)
                   return local::check_error();
 
+               log::line( log::category::event::message::part::received, transport.type(), '|', transcode::hex::stream::wrapper( transport.correlation()), '|', result, '|', transport.payload_offset(), '|', transport.complete_size());
                log::line( verbose::log, "ipc <--- blocking receive - handle: ", handle, ", transport: ", transport);
                assert( result == transport.size());
 
@@ -231,6 +233,7 @@ namespace casual
                   if( error)
                      return local::check_error( std::errc{ error.value()});
 
+                  log::line( log::category::event::message::part::sent, transport.type(), '|', transcode::hex::stream::wrapper( transport.correlation()), '|', transport.size(), '|', transport.payload_offset(), '|', transport.complete_size());
                   log::line( verbose::log, "ipc ---> non blocking send - socket: ", socket, ", destination: ", destination, ", transport: ", transport);
                   return true;
                }
@@ -248,6 +251,7 @@ namespace casual
                   if( result == -1)
                      return local::check_error();
 
+                  log::line( log::category::event::message::part::received, transport.type(), '|', transcode::hex::stream::wrapper( transport.correlation()), '|', result, '|', transport.payload_offset(), '|', transport.complete_size());
                   log::line( verbose::log, "ipc <--- non blocking receive - handle: ", handle, ", transport: ", transport);
 
                   assert( result == transport.size());
@@ -405,8 +409,6 @@ namespace casual
             } // blocking
          } // non
 
-
-
       } // policy
 
       namespace inbound
@@ -493,7 +495,10 @@ namespace casual
 
                complete.pop();
             }
+            
             common::message::counter::add::sent( complete.type());
+            log::line( log::category::event::message::sent, complete.type(), '|', complete.correlation(), '|', complete.execution(), '|', complete.size());
+
             return true;
          }
          

--- a/middleware/common/source/communication/ipc/message.cpp
+++ b/middleware/common/source/communication/ipc/message.cpp
@@ -68,6 +68,17 @@ namespace casual
 
       bool Complete::complete() const noexcept { return static_cast< platform::size::type>( payload.size()) == m_offset;}
 
+      strong::execution::id Complete::execution() const noexcept
+      {
+         if( payload.size() < 16)
+            return {};
+
+         Uuid::uuid_type uuid{};
+         algorithm::copy_max( payload, uuid);
+
+         return strong::execution::id{ uuid};
+      }
+
       std::ostream& operator << ( std::ostream& out, const Complete& value)
       {
          return stream::write( out, "{ type: ", value.type(), ", correlation: ", value.correlation(), ", size: ",

--- a/middleware/common/source/communication/tcp/message.cpp
+++ b/middleware/common/source/communication/tcp/message.cpp
@@ -53,6 +53,17 @@ namespace casual
          m_header.size = network::byteorder::size::encode( Complete::payload.size());
       }
 
+      strong::execution::id Complete::execution() const noexcept
+      {
+         if( payload.size() < 16)
+            return {};
+
+         Uuid::uuid_type uuid{};
+         algorithm::copy_max( payload, uuid);
+
+         return strong::execution::id{ uuid};
+      }
+
       bool Complete::complete() const noexcept 
       { 
          return type() != common::message::Type::absent_message 

--- a/middleware/common/source/log/category.cpp
+++ b/middleware/common/source/log/category.cpp
@@ -32,7 +32,21 @@ namespace casual
       {
          Stream service{ "casual.event.service"};
          Stream server{ "casual.event.server"};
-         Stream transaction{ "casual.event.transaction"}; 
+         Stream transaction{ "casual.event.transaction"};
+
+         namespace message
+         {
+            namespace part
+            {
+               Stream sent{ "casual.event.message.part.sent"};
+               Stream received{ "casual.event.message.part.received"};
+            } // part
+
+            Stream sent{ "casual.event.message.sent"};
+            Stream received{ "casual.event.message.received"};
+
+         } // message
+
       } // event
 
    } // common::log::category


### PR DESCRIPTION
This patch adds event logging for send/receive messages.

casual.event.message.(part)?.(sent|received)

This will help troubleshoot communication issues.