### PR TITLE
domain: assassinate needs more precise logging

### DIFF
--- a/middleware/common/include/common/message/event.h
+++ b/middleware/common/include/common/message/event.h
@@ -172,11 +172,13 @@ namespace casual
 
                common::strong::process::id target{};
                Contract contract = Contract::linger;
+               std::string announcement;
                   
                CASUAL_CONST_CORRECT_SERIALIZE(
                   base_assassination_contract::serialize( archive);
                   CASUAL_SERIALIZE( target);
                   CASUAL_SERIALIZE( contract);
+                  CASUAL_SERIALIZE( announcement);
                )
             };
 

--- a/middleware/domain/unittest/source/manager/test_manager.cpp
+++ b/middleware/domain/unittest/source/manager/test_manager.cpp
@@ -599,6 +599,7 @@ domain:
          message::event::process::Assassination assassination;
          assassination.target = target;
          assassination.contract = Contract::kill;
+         assassination.announcement = "Revenge is a dish that tastes best when it is cold.";
          communication::device::blocking::send( communication::instance::outbound::domain::manager::device(), assassination);
 
          // check if/when hit is performed

--- a/middleware/service/unittest/source/manager/test_manager.cpp
+++ b/middleware/service/unittest/source/manager/test_manager.cpp
@@ -355,6 +355,7 @@ domain:
 
          EXPECT_TRUE( event.target == common::process::id());
          EXPECT_TRUE( event.contract == decltype( event.contract)::linger);
+         EXPECT_TRUE( event.announcement == "service a timed out");
       }
 
 


### PR DESCRIPTION
- Added logging of server/executable alias to complement pid in assassinate error logging.
- Added an annoncement to assassinate message to be able to log a textual reason.

Resolves #307