### PR TITLE
ipc: fix discard while message is only partially received

### DIFF
--- a/middleware/common/include/common/communication/device.h
+++ b/middleware/common/include/common/communication/device.h
@@ -259,11 +259,8 @@ namespace casual
 
             auto complete = algorithm::find_if( m_cache, [&]( auto& complete){ return complete.correlation() == correlation;});
 
-            if( complete)
+            if( complete && complete->complete())
             {
-               if( ! complete->complete())
-                  m_discarded.push_back( correlation);
-
                m_cache.erase( complete.begin());
             }
             else
@@ -402,7 +399,7 @@ namespace casual
                      if( discard( *found))
                         m_cache.erase( std::begin( found));
 
-                     // Try to find a massage that matches the predicate
+                     // Try to find a message that matches the predicate
                      found = algorithm::find_if( m_cache, predicate);
                   }
 


### PR DESCRIPTION
Before: We cleared the partially complete message from the device cache when being told to discard. This caused an out-of-bounds error when subsequent parts of the message arrived.
Now: We wait til the entire message has a arrived before clearing it from the cache.

Resolves #311

The unittest could perhaps be done in a more simple way, open to suggestions.