### PR TITLE
common: do not set environment when (re)setting execution-id

### DIFF
--- a/middleware/common/include/common/environment.h
+++ b/middleware/common/include/common/environment.h
@@ -227,6 +227,11 @@ namespace casual
                   constexpr auto transient = "CASUAL_TRANSIENT_DIRECTORY"sv;
                   constexpr auto persistent = "CASUAL_PERSISTENT_DIRECTORY"sv;
                } // directory
+
+               namespace execution
+               {
+                  constexpr auto id = "CASUAL_EXECUTION_ID"sv;
+               } // execution
                
 
                //! the name of the environment variables that holds ipc queue id:s

--- a/middleware/common/include/common/environment/variable.h
+++ b/middleware/common/include/common/environment/variable.h
@@ -45,6 +45,20 @@ namespace casual
 
          static_assert( traits::is::string::like_v< Variable>, "environment::Variable should be string-like");
 
+         namespace variable::predicate
+         {
+            inline auto is_name( std::string_view name)
+            {
+               return [ name]( const Variable& value){ return value.name() == name;};
+            }
+
+            inline auto equal_name()
+            {
+               return []( const Variable& lhs, const Variable& rhs){ return lhs.name() == rhs.name();};
+            }
+
+         } // variable::predicate
+
       } // environment
    } // common
 } // casual

--- a/middleware/common/source/execution.cpp
+++ b/middleware/common/source/execution.cpp
@@ -21,18 +21,11 @@ namespace casual
          {
             namespace
             {
-               constexpr auto environment = "CASUAL_EXECUTION_ID";
-
-               auto reset()
-               {
-                  auto id = uuid::make();
-                  environment::variable::set( environment, uuid::string( id));
-                  return id;
-               }
-
                auto initialize()
                {
-                  return environment::variable::get( environment, &reset);
+                  if( environment::variable::exists( environment::variable::name::execution::id))
+                     return Uuid{ environment::variable::get( environment::variable::name::execution::id)};
+                  return uuid::make();
                }
 
                execution::type& id()
@@ -50,7 +43,7 @@ namespace casual
 
          void reset()
          {
-            local::id() = execution::type{ local::reset()};
+            local::id() = execution::type{ uuid::make()};
          }
 
          const type& id()


### PR DESCRIPTION
Before: We set an environment variable when (re)setting exection-id to propagate this to potential children. Setting environment variables leads to memory leaks on most linux (which in it self is very odd).

Now: We add an environment variable when we spawn a child, in the spawn api. Hence, we don't alter parent variable state -> no memory leaks

Fixes #333