### PR TITLE
build: adapt pipeline to multiple runners

### DIFF
--- a/.github/workflows/casual-build-beta.yaml
+++ b/.github/workflows/casual-build-beta.yaml
@@ -281,7 +281,7 @@ jobs:
           tag_prefix: ""
 
   publish-version:
-    runs-on: self-hosted
+    runs-on: [self-hosted, casual, publish]
     needs: [build-centos,build-suse,tag-repo]
     if: ${{ success() }}
     steps:

--- a/.github/workflows/casual-build-release.yaml
+++ b/.github/workflows/casual-build-release.yaml
@@ -280,7 +280,7 @@ jobs:
           tag_prefix: ""
 
   publish-version:
-    runs-on: self-hosted
+    runs-on: [self-hosted, casual, publish]
     needs: [build-centos,build-suse,tag-repo]
     if: ${{ success() }}
     steps:


### PR DESCRIPTION
Has adapted github actions pipeline to handle multiple runners.

As previously stated, in order to get any beta or release build to work properly, this fix is needed. That is, merging to release or main-branch may fail until this fix is used.
