### PR TITLE
service: prevent instances about to be assassinated  being reserved

### DIFF
--- a/middleware/service/include/service/manager/state.h
+++ b/middleware/service/include/service/manager/state.h
@@ -119,6 +119,10 @@ namespace casual
                //! @returns the name of the reserved service if a reservation exists
                std::optional< std::string> reserved_service() const;
 
+               //! marks this instance as soon to die and thus ineligible for service reservations
+               inline void condemn() { m_condemned = true;}
+               inline bool condemned() const { return m_condemned;}
+
                friend std::ostream& operator << ( std::ostream& out, State value);
 
                CASUAL_LOG_SERIALIZE(
@@ -126,6 +130,7 @@ namespace casual
                   CASUAL_SERIALIZE_NAME( m_service, "service");
                   CASUAL_SERIALIZE_NAME( m_caller, "caller");
                   CASUAL_SERIALIZE_NAME( m_services, "services");
+                  CASUAL_SERIALIZE_NAME( m_condemned, "condemned");
                )
 
             private:
@@ -133,6 +138,7 @@ namespace casual
                instance::Caller m_caller;
                // all associated services
                std::vector< state::Service*> m_services;
+               bool m_condemned = false;
             };
 
             struct Concurrent : base_instance
@@ -247,6 +253,8 @@ namespace casual
 
                   inline const common::process::Handle& process() const { return get().process;}
                   inline auto state() const { return get().state();}
+
+                  inline bool condemned() const { return get().condemned();}
 
                   inline friend bool operator == ( const Sequential& lhs, common::strong::process::id rhs) { return lhs.process().pid == rhs;}
 

--- a/middleware/service/source/manager/state.cpp
+++ b/middleware/service/source/manager/state.cpp
@@ -299,7 +299,12 @@ namespace casual
             const common::process::Handle& caller, 
             const strong::correlation::id& correlation)
          {
-            if( auto found = algorithm::find_if( instances.sequential, []( auto& i){ return i.idle();}))
+            auto reservable = [ &]( auto& instance)
+            {
+               return instance.idle() && ! instance.condemned();
+            };
+
+            if( auto found = algorithm::find_if( instances.sequential, reservable))
                return found->reserve( this, caller, correlation);
 
             return {};


### PR DESCRIPTION
Before: if a call to a service with a 'lethal' timeout contract reached the timeout and then completed soon after, the SM would reserve this instance again even though it would soon die Now: instances are marked as condemned when a hit is put out on them, preventing them from being reserved

Resolves #305