### PR TITLE
common: improve flag abstraction to use only pure enums

### DIFF
--- a/middleware/administration/unittest/source/cli/test_casual.cpp
+++ b/middleware/administration/unittest/source/cli/test_casual.cpp
@@ -11,9 +11,9 @@
 #include "common/unittest.h"
 
 #include "domain/unittest/manager.h"
-
 #include "administration/unittest/cli/command.h"
 
+#include "common/string.h"
 
 
 namespace casual

--- a/middleware/common/include/common/flag/service/call.h
+++ b/middleware/common/include/common/flag/service/call.h
@@ -11,63 +11,67 @@
 
 namespace casual 
 {
-   namespace common 
+   namespace common::flag::service::call
    {
-      namespace flag
+
+      namespace async
       {
-         namespace service
+         enum class Flag : long
          {
-            namespace call
-            {
-               namespace async
-               {
-                  enum class Flag : long
-                  {
-                     no_flags = std::to_underlying( xatmi::Flag::no_flags),
-                     no_transaction = std::to_underlying( xatmi::Flag::no_transaction),
-                     no_reply = std::to_underlying( xatmi::Flag::no_reply),
-                     no_block = std::to_underlying( xatmi::Flag::no_block),
-                     no_time = std::to_underlying( xatmi::Flag::no_time),
-                     signal_restart = std::to_underlying( xatmi::Flag::signal_restart)
-                  };
-                  using Flags = common::Flags< async::Flag>;
-               } // async
+            no_flags = std::to_underlying( xatmi::Flag::no_flags),
+            no_transaction = std::to_underlying( xatmi::Flag::no_transaction),
+            no_reply = std::to_underlying( xatmi::Flag::no_reply),
+            no_block = std::to_underlying( xatmi::Flag::no_block),
+            no_time = std::to_underlying( xatmi::Flag::no_time),
+            signal_restart = std::to_underlying( xatmi::Flag::signal_restart)
+         };
 
-               namespace reply
-               {
-                  enum class Flag : long
-                  {
-                     no_flags = std::to_underlying( xatmi::Flag::no_flags),
-                     any = std::to_underlying( xatmi::Flag::any),
-                     no_change = std::to_underlying( xatmi::Flag::no_change),
-                     no_block = std::to_underlying( xatmi::Flag::no_block),
-                     no_time = std::to_underlying( xatmi::Flag::no_time),
-                     signal_restart = std::to_underlying( xatmi::Flag::signal_restart)
-                  };
-                  using Flags = common::Flags< reply::Flag>;
+         //! indicate that this enum is used as a flag and uses xatmi::Flag as superset (for description)
+         consteval xatmi::Flag casual_enum_as_flag_superset( Flag);
+
+         constexpr auto valid_flags = Flag::no_flags | Flag::no_transaction | Flag::no_reply | Flag::no_block | Flag::no_time | Flag::signal_restart;
+
+      } // async
+
+      namespace reply
+      {
+         enum class Flag : long
+         {
+            no_flags = std::to_underlying( xatmi::Flag::no_flags),
+            any = std::to_underlying( xatmi::Flag::any),
+            no_change = std::to_underlying( xatmi::Flag::no_change),
+            no_block = std::to_underlying( xatmi::Flag::no_block),
+            no_time = std::to_underlying( xatmi::Flag::no_time),
+            signal_restart = std::to_underlying( xatmi::Flag::signal_restart)
+         };
+
+         //! indicate that this enum is used as a flag and uses xatmi::Flag as superset (for description)
+         consteval xatmi::Flag casual_enum_as_flag_superset( Flag);
+
+         constexpr auto valid_flags = Flag::no_flags | Flag::any | Flag::no_change | Flag::no_block | Flag::no_time | Flag::signal_restart;
+
+      } // reply
 
 
-               } // reply
+      namespace sync
+      {
+         enum class Flag : long
+         {
+            no_flags = std::to_underlying( xatmi::Flag::no_flags),
+            no_transaction = std::to_underlying( xatmi::Flag::no_transaction),
+            no_change = std::to_underlying( xatmi::Flag::no_change),
+            no_block = std::to_underlying( xatmi::Flag::no_block),
+            no_time = std::to_underlying( xatmi::Flag::no_time),
+            signal_restart = std::to_underlying( xatmi::Flag::signal_restart)
+         };
+         
+         //! indicate that this enum is used as a flag and uses xatmi::Flag as superset (for description)
+         consteval xatmi::Flag casual_enum_as_flag_superset( Flag);
 
+         constexpr auto valid_flags = Flag::no_flags | Flag::no_transaction | Flag::no_change | Flag::no_block | Flag::no_time | Flag::signal_restart;
+      } // sync
 
-               namespace sync
-               {
-                  enum class Flag : long
-                  {
-                     no_flags = std::to_underlying( xatmi::Flag::no_flags),
-                     no_transaction = std::to_underlying( xatmi::Flag::no_transaction),
-                     no_change = std::to_underlying( xatmi::Flag::no_change),
-                     no_block = std::to_underlying( xatmi::Flag::no_block),
-                     no_time = std::to_underlying( xatmi::Flag::no_time),
-                     signal_restart = std::to_underlying( xatmi::Flag::signal_restart)
-                  };
-                  using Flags = common::Flags< sync::Flag>;
-               } // sync
-
-            } // call
-         } // service
-      } // flag
-   } // common
+   } // common::flag::service::call
 } // casual
 
 

--- a/middleware/common/include/common/flag/service/conversation.h
+++ b/middleware/common/include/common/flag/service/conversation.h
@@ -11,73 +11,67 @@
 
 namespace casual
 {
-   namespace common
+   namespace common::flag::service::conversation
    {
-      namespace flag
+      enum class Event : long
       {
-         namespace service
+         absent = std::to_underlying( xatmi::Event::absent),
+         disconnect = std::to_underlying( xatmi::Event::disconnect),
+         send_only = std::to_underlying( xatmi::Event::send_only),
+         service_error = std::to_underlying( xatmi::Event::service_error),
+         service_fail = std::to_underlying( xatmi::Event::service_fail),
+         service_success = std::to_underlying( xatmi::Event::service_success),
+      };
+
+      //! indicate that this enum is used as a flag and uses xatmi::Event as superset (for description)
+      consteval xatmi::Event casual_enum_as_flag_superset( Event);
+
+      namespace connect
+      {
+         enum class Flag : long
          {
-            namespace conversation
-            {
-               enum class Event : long
-               {
-                  absent = std::to_underlying( xatmi::Event::absent),
-                  disconnect = std::to_underlying( xatmi::Event::disconnect),
-                  send_only = std::to_underlying( xatmi::Event::send_only),
-                  service_error = std::to_underlying( xatmi::Event::service_error),
-                  service_fail = std::to_underlying( xatmi::Event::service_fail),
-                  service_success = std::to_underlying( xatmi::Event::service_success),
-               };
+            no_transaction = std::to_underlying( xatmi::Flag::no_transaction),
+            send_only =  std::to_underlying( xatmi::Flag::send_only),
+            receive_only =  std::to_underlying( xatmi::Flag::receive_only),
+            no_block =  std::to_underlying( xatmi::Flag::no_block),
+            no_time =  std::to_underlying( xatmi::Flag::no_time),
+            signal_restart =  std::to_underlying( xatmi::Flag::signal_restart)
+         };
 
-               using Events = common::Flags< Event>;
+         //! indicate that this enum is used as a flag and uses xatmi::Flag as superset (for description)
+         consteval xatmi::Flag casual_enum_as_flag_superset( Flag);
 
-               namespace connect
-               {
-                  enum class Flag : long
-                  {
-                     no_transaction = std::to_underlying( xatmi::Flag::no_transaction),
-                     send_only =  std::to_underlying( xatmi::Flag::send_only),
-                     receive_only =  std::to_underlying( xatmi::Flag::receive_only),
-                     no_block =  std::to_underlying( xatmi::Flag::no_block),
-                     no_time =  std::to_underlying( xatmi::Flag::no_time),
-                     signal_restart =  std::to_underlying( xatmi::Flag::signal_restart)
-                  };
+      } // connect
 
-                  using Flags = common::Flags< connect::Flag>;
+      namespace send
+      {
+         enum class Flag : long
+         {
+            receive_only =  std::to_underlying( xatmi::Flag::receive_only),
+            no_block =  std::to_underlying( xatmi::Flag::no_block),
+            no_time =  std::to_underlying( xatmi::Flag::no_time),
+            signal_restart =  std::to_underlying( xatmi::Flag::signal_restart)
+         };
 
-               } // connect
+         //! indicate that this enum is used as a flag and uses xatmi::Flag as superset (for description)
+         consteval xatmi::Flag casual_enum_as_flag_superset( Flag);
+      } // send
 
-               namespace send
-               {
-                  enum class Flag : long
-                  {
-                     receive_only =  std::to_underlying( xatmi::Flag::receive_only),
-                     no_block =  std::to_underlying( xatmi::Flag::no_block),
-                     no_time =  std::to_underlying( xatmi::Flag::no_time),
-                     signal_restart =  std::to_underlying( xatmi::Flag::signal_restart)
-                  };
+      namespace receive
+      {
+         enum class Flag : long
+         {
+            no_change = std::to_underlying( xatmi::Flag::no_change),
+            no_block =  std::to_underlying( xatmi::Flag::no_block),
+            no_time =  std::to_underlying( xatmi::Flag::no_time),
+            signal_restart =  std::to_underlying( xatmi::Flag::signal_restart)
+         };
 
-                  using Flags = common::Flags< send::Flag>;
-               } // send
+         //! indicate that this enum is used as a flag and uses xatmi::Flag as superset (for description)
+         consteval xatmi::Flag casual_enum_as_flag_superset( Flag);
 
-               namespace receive
-               {
-                  enum class Flag : long
-                  {
-                     no_change = std::to_underlying( xatmi::Flag::no_change),
-                     no_block =  std::to_underlying( xatmi::Flag::no_block),
-                     no_time =  std::to_underlying( xatmi::Flag::no_time),
-                     signal_restart =  std::to_underlying( xatmi::Flag::signal_restart)
-                  };
-
-                  using Flags = common::Flags< receive::Flag>;
-
-               } // receive
-
-            } // conversation
-         } // service
-      } // flag
-   } // common
+      } // receive
+   } // common::flag::service::conversation
 } // casual
 
 

--- a/middleware/common/include/common/flag/xa.h
+++ b/middleware/common/include/common/flag/xa.h
@@ -26,7 +26,8 @@ namespace casual
          };
          std::string_view description( Flag value);
          
-         using Flags = common::Flags< resource::Flag>;
+         // indicate that this enum is used as a flag
+         consteval void casual_enum_as_flag( Flag);
       } // resource 
 
 
@@ -48,7 +49,7 @@ namespace casual
       };
       std::string_view description( Flag value);
 
-      using Flags = common::Flags< xa::Flag>;
+      consteval void casual_enum_as_flag( Flag);
 
    } // common::flag::xa 
 } // casual 

--- a/middleware/common/include/common/flag/xatmi.h
+++ b/middleware/common/include/common/flag/xatmi.h
@@ -12,56 +12,55 @@
 
 namespace casual 
 {
-   namespace common 
+   namespace common::flag::xatmi 
    {
-      namespace flag
+
+      enum class Flag : long
       {
-         namespace xatmi
-         {
-            enum class Flag : long
-            {
-               no_flags = 0,
-               no_block = TPNOBLOCK,
-               signal_restart = TPSIGRSTRT,
-               no_reply = TPNOREPLY,
-               no_transaction = TPNOTRAN,
-               in_transaction = TPTRAN,
-               no_time = TPNOTIME,
-               any = TPGETANY,
-               no_change = TPNOCHANGE,
-               conversation = TPCONV,
-               send_only = TPSENDONLY,
-               receive_only = TPRECVONLY
-            };
-            using Flags = common::Flags< xatmi::Flag>;
+         no_flags = 0,
+         no_block = TPNOBLOCK,
+         signal_restart = TPSIGRSTRT,
+         no_reply = TPNOREPLY,
+         no_transaction = TPNOTRAN,
+         in_transaction = TPTRAN,
+         no_time = TPNOTIME,
+         any = TPGETANY,
+         no_change = TPNOCHANGE,
+         conversation = TPCONV,
+         send_only = TPSENDONLY,
+         receive_only = TPRECVONLY
+      };
 
-            enum class Event : long
-            {
-               absent = 0,
-               disconnect = TPEV_DISCONIMM,
-               send_only = TPEV_SENDONLY,
-               service_error = TPEV_SVCERR,
-               service_fail = TPEV_SVCFAIL,
-               service_success = TPEV_SVCSUCC
-            };
+      std::string_view description( Flag value) noexcept;
 
-            enum class Return : int
-            {
-               fail = TPFAIL,
-               success = TPSUCCESS,
-            };
-            inline std::ostream& operator << ( std::ostream& out, Return value)
-            {
-               switch( value)
-               {
-                  case Return::fail: return out << "fail";
-                  case Return::success: return out << "success";
-               }
-               return out << "<unknown>";
-            }
-         } // xatmi 
-      } // flag
-   } // common 
+      // indicate that this enum is used as a flag
+      consteval void casual_enum_as_flag( Flag);
+      
+
+      enum class Event : long
+      {
+         absent = 0,
+         disconnect = TPEV_DISCONIMM,
+         send_only = TPEV_SENDONLY,
+         service_error = TPEV_SVCERR,
+         service_fail = TPEV_SVCFAIL,
+         service_success = TPEV_SVCSUCC
+      };
+
+      std::string_view description( Event value) noexcept;
+
+      // indicate that this enum is used as a flag
+      consteval void casual_enum_as_flag( Event);
+
+      enum class Return : int
+      {
+         fail = TPFAIL,
+         success = TPSUCCESS,
+      };
+
+      std::string_view description( Return value) noexcept;
+
+   } // common::flag::xatmi 
 } // casual 
 
 //

--- a/middleware/common/include/common/message/service.h
+++ b/middleware/common/include/common/message/service.h
@@ -494,7 +494,9 @@ namespace casual
                   no_reply = std::to_underlying( flag::xatmi::Flag::no_reply),
                   no_time = std::to_underlying( flag::xatmi::Flag::no_time),
                };
-               using Flags = common::Flags< Flag>;
+               
+               // indicate that this enum is used as a flag
+               consteval void casual_enum_as_flag( Flag);
 
             } // request
 
@@ -508,7 +510,7 @@ namespace casual
                std::string parent;
 
                common::transaction::ID trid;
-               request::Flags flags;
+               request::Flag flags{};
 
                common::service::header::Fields header;
 

--- a/middleware/common/include/common/message/transaction.h
+++ b/middleware/common/include/common/message/transaction.h
@@ -263,7 +263,7 @@ namespace casual
             using basic_transaction< type>::basic_transaction;
 
             id::type resource;
-            flag::xa::Flags flags = flag::xa::Flag::no_flags;
+            flag::xa::Flag flags = flag::xa::Flag::no_flags;
 
             CASUAL_CONST_CORRECT_SERIALIZE(
                basic_transaction< type>::serialize( archive);

--- a/middleware/common/include/common/server/handle/call.h
+++ b/middleware/common/include/common/server/handle/call.h
@@ -86,7 +86,7 @@ namespace casual
                   try
                   {
                      using Flag = common::message::service::call::request::Flag;
-                     service::call( m_policy, common::service::call::context(), message, ! message.flags.exist( Flag::no_reply));
+                     service::call( m_policy, common::service::call::context(), message, ! flag::exists( message.flags, Flag::no_reply));
                   }
                   catch( ...)
                   {

--- a/middleware/common/include/common/service/call/context.h
+++ b/middleware/common/include/common/service/call/context.h
@@ -74,15 +74,15 @@ namespace casual
             public:
                static Context& instance();
 
-               descriptor_type async( const std::string& service, common::buffer::payload::Send buffer, async::Flags flags);
+               descriptor_type async( const std::string& service, common::buffer::payload::Send buffer, async::Flag flags);
 
-               descriptor_type async( service::Lookup&& lookup, common::buffer::payload::Send buffer, async::Flags flags);
+               descriptor_type async( service::Lookup&& lookup, common::buffer::payload::Send buffer, async::Flag flags);
 
-               descriptor_type async( service::Lookup&& lookup, common::buffer::payload::Send buffer, service::header::Fields header, async::Flags flags);
+               descriptor_type async( service::Lookup&& lookup, common::buffer::payload::Send buffer, service::header::Fields header, async::Flag flags);
 
-               reply::Result reply( descriptor_type descriptor, reply::Flags flags);
+               reply::Result reply( descriptor_type descriptor, reply::Flag flags);
 
-               sync::Result sync( const std::string& service, common::buffer::payload::Send buffer, sync::Flags flags);
+               sync::Result sync( const std::string& service, common::buffer::payload::Send buffer, sync::Flag flags);
 
                void cancel( descriptor_type descriptor);
 
@@ -94,7 +94,7 @@ namespace casual
 
             private:
                Context();
-               bool receive( message::service::call::Reply& reply, descriptor_type descriptor, reply::Flags);
+               bool receive( message::service::call::Reply& reply, descriptor_type descriptor, reply::Flag);
 
                State m_state;
 

--- a/middleware/common/include/common/service/conversation/context.h
+++ b/middleware/common/include/common/service/conversation/context.h
@@ -23,13 +23,7 @@ namespace casual
       {
          namespace conversation
          {
-            struct Event
-            {
-               Event( flag::service::conversation::Events event) :
-                  event( event) {}
-
-               flag::service::conversation::Events event;
-            };
+            using Event = flag::service::conversation::Event;
 
          } // conversation
 
@@ -40,21 +34,19 @@ namespace casual
          namespace conversation
          {
             using Event = flag::service::conversation::Event;
-            using Events = flag::service::conversation::Events;
 
             namespace connect
             {
                using Flag = flag::service::conversation::connect::Flag;
-               using Flags = flag::service::conversation::connect::Flags;
             } // connect
 
             namespace send
             {
                using Flag = flag::service::conversation::send::Flag;
-               using Flags = flag::service::conversation::send::Flags;
+
                struct Result
                {
-                  common::Flags< Event> event;
+                  Event event{};
                   long user = 0;
                   CASUAL_LOG_SERIALIZE(
                      CASUAL_SERIALIZE( event);
@@ -66,11 +58,10 @@ namespace casual
             namespace receive
             {
                using Flag = flag::service::conversation::receive::Flag;
-               using Flags = flag::service::conversation::receive::Flags;
 
                struct Result
                {
-                  common::Flags< Event> event;
+                  Event event{};
                   long user = 0;
                   common::buffer::Payload buffer;
 
@@ -88,11 +79,11 @@ namespace casual
                static Context& instance();
                ~Context();
 
-               strong::conversation::descriptor::id connect( const std::string& service, common::buffer::payload::Send buffer, connect::Flags flags);
+               strong::conversation::descriptor::id connect( const std::string& service, common::buffer::payload::Send buffer, connect::Flag flags);
 
-               send::Result send( strong::conversation::descriptor::id descriptor, common::buffer::payload::Send&& buffer, common::Flags< send::Flag> flags);
+               send::Result send( strong::conversation::descriptor::id descriptor, common::buffer::payload::Send&& buffer, send::Flag flags);
 
-               receive::Result receive( strong::conversation::descriptor::id descriptor, common::Flags< receive::Flag> flags);
+               receive::Result receive( strong::conversation::descriptor::id descriptor, receive::Flag flags);
 
                void disconnect( strong::conversation::descriptor::id descriptor);
 

--- a/middleware/common/include/common/service/invoke.h
+++ b/middleware/common/include/common/service/invoke.h
@@ -44,7 +44,10 @@ namespace casual
                   send_only = std::to_underlying( flag::xatmi::Flag::send_only),
                   receive_only = std::to_underlying( flag::xatmi::Flag::receive_only),
                };
-               using Flags = common::Flags< Flag>;
+
+               // indicate that this enum is used as a flag
+               friend consteval void casual_enum_as_flag( Flag);
+               
 
                Parameter() = default;
                Parameter( buffer::Payload&& payload) : payload( std::move( payload)) {}
@@ -52,7 +55,7 @@ namespace casual
                Parameter( Parameter&&) noexcept = default;
                Parameter& operator = (Parameter&&) noexcept = default;
 
-               Flags flags;
+               Flag flags{};
                Service service;
                std::string parent;
                buffer::Payload payload;

--- a/middleware/common/include/common/transaction/context.h
+++ b/middleware/common/include/common/transaction/context.h
@@ -160,7 +160,7 @@ namespace casual
          [[nodiscard]] code::tx rollback( const Transaction& transaction);
 
 
-         [[nodiscard]] code::tx resource_commit( strong::resource::id rm, const Transaction& transaction, flag::xa::Flags flags);
+         [[nodiscard]] code::tx resource_commit( strong::resource::id rm, const Transaction& transaction, flag::xa::Flag flags);
          [[nodiscard]] code::tx resource_rollback( strong::resource::id rm, const Transaction& transaction);
 
          [[nodiscard]] code::tx control_continuation( code::tx code);

--- a/middleware/common/include/common/transaction/resource.h
+++ b/middleware/common/include/common/transaction/resource.h
@@ -28,20 +28,19 @@ namespace casual
       struct Resource
       {
          using Flag = flag::xa::Flag;
-         using Flags = flag::xa::Flags;
 
          Resource( resource::Link link, strong::resource::id id, std::string openinfo, std::string closeinfo);
          
-         code::xa start( const transaction::ID& transaction, Flags flags) noexcept;
-         code::xa end( const transaction::ID& transaction, Flags flags) noexcept;
+         code::xa start( const transaction::ID& transaction, Flag flags) noexcept;
+         code::xa end( const transaction::ID& transaction, Flag flags) noexcept;
 
-         code::xa open( Flags flags = Flag::no_flags) noexcept;
-         code::xa close( Flags flags = Flag::no_flags) noexcept;
+         code::xa open( Flag flags = Flag::no_flags) noexcept;
+         code::xa close( Flag flags = Flag::no_flags) noexcept;
 
-         code::xa prepare( const transaction::ID& transaction, Flags flags) noexcept;
+         code::xa prepare( const transaction::ID& transaction, Flag flags) noexcept;
 
-         code::xa commit( const transaction::ID& transaction, Flags flags) noexcept;
-         code::xa rollback( const transaction::ID& transaction, Flags flags) noexcept;
+         code::xa commit( const transaction::ID& transaction, Flag flags) noexcept;
+         code::xa rollback( const transaction::ID& transaction, Flag flags) noexcept;
 
          bool dynamic() const noexcept;
 

--- a/middleware/common/makefile.cmk
+++ b/middleware/common/makefile.cmk
@@ -54,6 +54,7 @@ casual_common_objectfiles = [
 
     make.Compile( 'source/strong/id.cpp'),
     make.Compile( 'source/flag/xa.cpp'),
+    make.Compile( 'source/flag/xatmi.cpp'),
 
     make.Compile( 'source/server/context.cpp'),
     make.Compile( 'source/server/lifetime.cpp'),

--- a/middleware/common/source/communication/socket.cpp
+++ b/middleware/common/source/communication/socket.cpp
@@ -112,7 +112,7 @@ namespace casual
          auto flags = ::fcntl( value.m_descriptor.value(), F_GETFL);
 
          return out << "{ descriptor: " << value.m_descriptor
-            << ", blocking: " << std::boolalpha << ! common::has::flag< O_NONBLOCK>( flags)
+            << ", blocking: " << std::boolalpha << ( ( flags & O_NONBLOCK) == 0)
             << ", reuse: " << ( value.get( socket::option::reuse_address<false>{}) != 0)
             << ", keepalive: " << ( value.get( socket::option::keepalive<false>{}) != 0)
             << ", linger: " << value.get( socket::option::linger{})

--- a/middleware/common/source/communication/tcp.cpp
+++ b/middleware/common/source/communication/tcp.cpp
@@ -85,11 +85,14 @@ namespace casual
                   canonical = AI_CANONNAME,
                };
 
+               //! indicate that the enum is used as a flag (g++11 bug (?) force to define it)
+               [[maybe_unused]] consteval void casual_enum_as_flag( Flag) {};
+
                namespace address
                {
                   struct Native 
                   {
-                     explicit Native( const tcp::Address& address, Flags< Flag> flags = {})
+                     explicit Native( const tcp::Address& address, Flag flags = {})
                      {
                         Trace trace( "common::communication::tcp::local::socket::address::Native::Native");
                         log::line( verbose::log, "address: ", address, ", flags: ", flags);
@@ -102,7 +105,7 @@ namespace casual
                         hints.ai_socktype = SOCK_STREAM;
 
                         flags |= Flag::canonical;
-                        hints.ai_flags = flags.underlying();
+                        hints.ai_flags = std::to_underlying( flags);
 
                         std::string host{ address.host()};
                         std::string port{ address.port()};
@@ -192,7 +195,7 @@ namespace casual
                } // address
 
                template< typename F>
-               auto create( const Address& address, F binder, Flags< Flag> flags = {})
+               auto create( const Address& address, F binder, Flag flags = {})
                   -> decltype( binder( Socket{}, std::declval< const addrinfo&>()))
                {
                   Trace trace( "common::communication::tcp::local::socket::create");
@@ -265,7 +268,7 @@ namespace casual
                   // We block all signals while we're trying to set up a listener...
                   //common::signal::thread::scope::Block block;
 
-                  constexpr auto flags = flags::compose( Flag::address_config, Flag::passive);
+                  constexpr auto flags = Flag::address_config | Flag::passive;
 
                   return create( address,[]( Socket socket, const addrinfo& info) -> Socket
                   {

--- a/middleware/common/source/flag/xa.cpp
+++ b/middleware/common/source/flag/xa.cpp
@@ -47,9 +47,6 @@ namespace casual
          return "<unknown>";
       }
 
-
-      using Flags = common::Flags< xa::Flag>;
-
    } // common::flag::xa 
    
 } // casual

--- a/middleware/common/source/flag/xatmi.cpp
+++ b/middleware/common/source/flag/xatmi.cpp
@@ -1,0 +1,57 @@
+//!
+//! Copyright (c) 2024, The casual project
+//!
+//! This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+//!
+
+#include "common/flag/xatmi.h"
+
+namespace casual 
+{
+   namespace common::flag::xatmi 
+   {
+      std::string_view description( Flag value) noexcept
+      {
+         switch( value)
+         {
+            case Flag::no_flags: return "no_flags";
+            case Flag::no_block: return "no_block";
+            case Flag::signal_restart: return "signal_restart";
+            case Flag::no_reply: return "no_reply";
+            case Flag::no_transaction: return "no_transaction";
+            case Flag::in_transaction: return "in_transaction";
+            case Flag::no_time: return "no_time";
+            case Flag::any: return "any";
+            case Flag::no_change: return "no_change";
+            case Flag::conversation: return "conversation";
+            case Flag::send_only: return "send_only";
+            case Flag::receive_only: return "receive_only";
+         }
+         return "<unknown>";
+      }
+
+      std::string_view description( Event value) noexcept
+      {
+         switch( value)
+         {
+            case Event::absent: return "absent";
+            case Event::disconnect: return "disconnect";
+            case Event::send_only: return "send_only";
+            case Event::service_error: return "service_error";
+            case Event::service_fail: return "service_fail";
+            case Event::service_success: return "service_success";
+         }
+         return "<unknown>";
+      }
+
+      std::string_view description( Return value) noexcept
+      {
+         switch( value)
+         {
+            case Return::fail: return "fail";
+            case Return::success: return "success";
+         }
+         return "<unknown>";
+      }
+   } // common::flag::xatmi 
+} // casual 

--- a/middleware/common/source/server/context.cpp
+++ b/middleware/common/source/server/context.cpp
@@ -36,11 +36,11 @@ namespace casual
          {
             std::ostream& operator << ( std::ostream& out, const Jump& value)
             {
-               return out << "{ value: " << value.state.value
-                     << ", code: " << value.state.code
-                     << ", data: " << value.buffer.data
-                     << ", size: " << value.buffer.size
-                     << ", service: " << value.forward.service << '}';
+               return stream::write( out, "{ value: ", value.state.value,
+                  ", code: ", value.state.code,
+                  ", data: ", value.buffer.data,
+                  ", size: ", value.buffer.size,
+                  ", service: ", value.forward.service, '}');
             }
          } // state
 

--- a/middleware/common/source/server/handle/service.cpp
+++ b/middleware/common/source/server/handle/service.cpp
@@ -71,10 +71,10 @@ namespace casual
             
             auto result = local::parameter( message);
 
-            using Flag = decltype( message.flags.type());
+            using Flag = decltype( message.flags);
 
-            if( message.flags.exist( Flag::no_reply))
-               result.flags |= decltype( result.flags.type())::no_reply;
+            if( flag::exists( message.flags, Flag::no_reply))
+               result.flags |= decltype( result.flags)::no_reply;
 
             return result;
          }

--- a/middleware/common/source/server/service.cpp
+++ b/middleware/common/source/server/service.cpp
@@ -81,7 +81,7 @@ namespace casual
 
                         result.len = argument.payload.data.size();
                         result.cd = argument.descriptor.value();
-                        result.flags = argument.flags.underlying();
+                        result.flags = std::to_underlying( argument.flags);
 
                         // This is the only place where we use adopt
                         result.data = buffer::pool::holder().adopt( std::move( argument.payload)).underlying();

--- a/middleware/common/source/transaction/context.cpp
+++ b/middleware/common/source/transaction/context.cpp
@@ -383,7 +383,7 @@ namespace casual
 
                      //! "helper" for start, branch and resume below
                      template< typename R>
-                     auto start( Transaction& transaction, R& resources, flag::xa::Flags flags)
+                     auto start( Transaction& transaction, R& resources, flag::xa::Flag flags)
                      {
                         // involve the resources
                         transaction.involve( transform::ids( resources));
@@ -446,7 +446,7 @@ namespace casual
                   namespace policy
                   {
                      template< typename R>
-                     auto end( const Transaction& transaction, R& resources, flag::xa::Flags flags)
+                     auto end( const Transaction& transaction, R& resources, flag::xa::Flag flags)
                      {
                         return algorithm::accumulate( transaction.involved(), code::tx::ok, local::accumulate::code( [ &transaction, &resources, flags]( auto& id)
                         {
@@ -1164,7 +1164,7 @@ namespace casual
                "failed to suspend one ore more resource");
          }
 
-         code::tx Context::resource_commit( strong::resource::id rm, const Transaction& transaction, flag::xa::Flags flags)
+         code::tx Context::resource_commit( strong::resource::id rm, const Transaction& transaction, flag::xa::Flag flags)
          {
             Trace trace{ "transaction::Context::resources_commit"};
             log::line( log::category::transaction, "transaction: ", transaction, " - rm: ", rm, " - flags: ", flags);

--- a/middleware/configuration/include/configuration/message.h
+++ b/middleware/configuration/include/configuration/message.h
@@ -41,6 +41,8 @@ namespace casual
             runtime_update = 2,
          };
 
+         consteval void casual_enum_as_flag( Ability);
+
          constexpr std::string_view description( Ability value)
          {
             switch( value)
@@ -51,7 +53,7 @@ namespace casual
             return "<unknown>";
          }
 
-         using Contract = common::Flags< registration::Ability>;
+         using Contract = registration::Ability;
 
          using base_request = common::message::basic_request< common::message::Type::configuration_stakeholder_registration_request>;
          struct Request : base_request

--- a/middleware/domain/include/domain/discovery/admin/model.h
+++ b/middleware/domain/include/domain/discovery/admin/model.h
@@ -113,7 +113,7 @@ namespace casual
 
       struct Provider
       {
-         state::provider::Abilities abilities{};
+         state::provider::Ability abilities{};
          common::process::Handle process;
 
          CASUAL_CONST_CORRECT_SERIALIZE(

--- a/middleware/domain/include/domain/discovery/api.h
+++ b/middleware/domain/include/domain/discovery/api.h
@@ -22,7 +22,7 @@ namespace casual
       using Reply = message::discovery::Reply;
 
       //! Used by _inbounds_ that get's this message from another domain's outbound.
-      //! Will "ask" all regestrated _internals_, and possible _outbounds_, and accumulate one reply.
+      //! Will "ask" all register _internals_, and possible _outbounds_, and accumulate one reply.
       //! @returns the correlation id.
       //! @attention reply will be sent to the process in the request.
       //! @attention will _flush::send_ using ipc::inbound::device()
@@ -33,8 +33,8 @@ namespace casual
       namespace provider
       {
          using Ability = message::discovery::api::provider::registration::Ability;
-         void registration( common::Flags< Ability> abilities);
-         void registration( common::communication::ipc::inbound::Device& device, common::Flags< Ability> abilities);
+         void registration( Ability abilities);
+         void registration( common::communication::ipc::inbound::Device& device, Ability abilities);
       } // provider
 
       common::strong::correlation::id request(

--- a/middleware/domain/include/domain/discovery/state.h
+++ b/middleware/domain/include/domain/discovery/state.h
@@ -128,17 +128,15 @@ namespace casual
          namespace provider
          {
             using Ability = message::discovery::api::provider::registration::Ability;
-            using Abilities = message::discovery::api::provider::registration::Abilities;
-
          } // provider
 
          //! represent an entity that can provide stuff
          struct Provider
          {
-            Provider( provider::Abilities abilities, const common::process::Handle& process)
+            Provider( provider::Ability abilities, const common::process::Handle& process)
                : abilities{ abilities}, process{ process} {}
 
-            provider::Abilities abilities{};
+            provider::Ability abilities{};
             common::process::Handle process;
 
             inline friend bool operator == ( const Provider& lhs, const common::strong::ipc::id& rhs) { return lhs.process.ipc == rhs;}
@@ -157,7 +155,7 @@ namespace casual
             
             void registration( const message::discovery::api::provider::registration::Request& message);
 
-            const_range_type filter( provider::Abilities abilities) noexcept;
+            const_range_type filter( provider::Ability abilities) noexcept;
 
             inline auto& all() const noexcept { return m_providers;}
 

--- a/middleware/domain/include/domain/manager/state.h
+++ b/middleware/domain/include/domain/manager/state.h
@@ -296,12 +296,12 @@ namespace casual
                {
                   constexpr auto predicate( Contract contract) noexcept
                   {
-                     return [ contract]( auto& element){ return ( element.contract & contract) == contract;};
+                     return [ contract]( auto& element){ return common::flag::exists( element.contract, contract);};
                   }
                } // detail
 
-               inline auto supplier() noexcept { return detail::predicate( Contract::enum_type::supply);}
-               inline auto runtime() noexcept { return detail::predicate( Contract::enum_type::runtime_update);}
+               inline auto supplier() noexcept { return detail::predicate( Contract::supply);}
+               inline auto runtime() noexcept { return detail::predicate( Contract::runtime_update);}
                
             } // stakeholder
 

--- a/middleware/domain/include/domain/message/discovery.h
+++ b/middleware/domain/include/domain/message/discovery.h
@@ -302,7 +302,7 @@ namespace casual
                topology = 8,
             };
 
-            using Abilities = common::Flags< registration::Ability>;
+            consteval void casual_enum_as_flag( Ability);
             
             constexpr std::string_view description( Ability value)
             {
@@ -321,7 +321,7 @@ namespace casual
             {
                using base_request::base_request;
 
-               Abilities abilities;
+               Ability abilities;
 
                CASUAL_CONST_CORRECT_SERIALIZE(
                   base_request::serialize( archive);

--- a/middleware/domain/source/discovery/api.cpp
+++ b/middleware/domain/source/discovery/api.cpp
@@ -57,7 +57,7 @@ namespace casual
 
       namespace provider
       {
-         void registration( common::communication::ipc::inbound::Device& device, common::Flags< Ability> abilities)
+         void registration( common::communication::ipc::inbound::Device& device, Ability abilities)
          {
             Trace trace{ "domain::discovery::provider::registration"};
 
@@ -69,7 +69,7 @@ namespace casual
             local::flush::call( device, message);
          }
 
-         void registration( common::Flags< Ability> abilities)
+         void registration( Ability abilities)
          {
             registration( communication::ipc::inbound::device(), abilities);
          }

--- a/middleware/domain/source/discovery/main.cpp
+++ b/middleware/domain/source/discovery/main.cpp
@@ -42,7 +42,7 @@ namespace casual
                // rig the configuration setup
                {
                   using Ability = casual::domain::configuration::registration::Ability;
-                  casual::domain::configuration::registration::apply( flags::compose( Ability::runtime_update));
+                  casual::domain::configuration::registration::apply( Ability::runtime_update);
 
                   handle::configuration_update( state, casual::domain::configuration::fetch());
                }

--- a/middleware/domain/source/discovery/state.cpp
+++ b/middleware/domain/source/discovery/state.cpp
@@ -39,7 +39,7 @@ namespace casual
 
          }
 
-         Providers::const_range_type Providers::filter( provider::Abilities abilities) noexcept
+         Providers::const_range_type Providers::filter( provider::Ability abilities) noexcept
          {
             return algorithm::filter( m_providers, [abilities]( auto& provider)
             {

--- a/middleware/domain/source/manager/handle.cpp
+++ b/middleware/domain/source/manager/handle.cpp
@@ -99,7 +99,7 @@ namespace casual
                   // we push spawn 'event' and dispatch it to tasks and external listeners 
                   // later on
                   {
-                     common::message::event::process::Spawn message;
+                     common::message::event::process::Spawn message{ common::process::handle()};
                      message.path = entity.path;
                      message.alias = entity.alias;
 
@@ -864,6 +864,8 @@ namespace casual
 
                   void connect( State& state, const common::message::domain::process::connect::Request& message)
                   {
+                     Trace trace{ "domain::manager::handle::local::process::detail::connect"};
+
                      if( auto server = state.server( message.information.handle.pid))
                      {
                         server->connect( message.information.handle);

--- a/middleware/domain/unittest/source/test_discovery.cpp
+++ b/middleware/domain/unittest/source/test_discovery.cpp
@@ -289,7 +289,7 @@ namespace casual
          auto domain = unittest::manager();
          using Ability = discovery::provider::Ability;
 
-         discovery::provider::registration( { Ability::discover, Ability::lookup, Ability::fetch_known});
+         discovery::provider::registration( Ability::discover | Ability::lookup | Ability::fetch_known);
 
          auto correlation = discovery::rediscovery::request();
 
@@ -329,7 +329,7 @@ namespace casual
          communication::ipc::send::Coordinator multiplex{ directive};
 
          using Ability = discovery::provider::Ability; 
-         discovery::provider::registration( { Ability::discover, Ability::topology, Ability::fetch_known});
+         discovery::provider::registration( Ability::discover | Ability::topology | Ability::fetch_known);
 
          const auto origin = strong::domain::id{ uuid::make()};
 
@@ -382,7 +382,7 @@ namespace casual
          auto inbound = communication::ipc::inbound::Device{};
 
          using Ability = discovery::provider::Ability;
-         discovery::provider::registration( { Ability::discover, Ability::lookup, Ability::topology, Ability::fetch_known});
+         discovery::provider::registration( Ability::discover | Ability::lookup | Ability::topology | Ability::fetch_known);
 
          {
             message::discovery::topology::implicit::Update message;
@@ -424,7 +424,7 @@ namespace casual
 
 
          using Ability = discovery::provider::Ability; 
-         discovery::provider::registration( { Ability::discover, Ability::lookup});
+         discovery::provider::registration( Ability::discover | Ability::lookup);
 
 
          // send request with forward, will trigger request to our self
@@ -471,7 +471,7 @@ namespace casual
 
 
          using Ability = discovery::provider::Ability; 
-         discovery::provider::registration( { Ability::discover, Ability::lookup});
+         discovery::provider::registration( Ability::discover | Ability::lookup);
 
 
          // send request with forward, will trigger request to our self
@@ -521,7 +521,7 @@ domain:
 
 
          // we register our self
-         discovery::provider::registration( { discovery::provider::Ability::discover, discovery::provider::Ability::lookup});
+         discovery::provider::registration( discovery::provider::Ability::discover | discovery::provider::Ability::lookup);
 
          auto lookup_reply_resources_as_absent = []()
          {
@@ -685,7 +685,7 @@ domain:
          } caller;
 
          // we register our self
-         discovery::provider::registration( { discovery::provider::Ability::discover, discovery::provider::Ability::lookup});
+         discovery::provider::registration( discovery::provider::Ability::discover | discovery::provider::Ability::lookup);
 
 
          constexpr static auto create_service = []( auto name)

--- a/middleware/gateway/source/group/inbound/task/create.cpp
+++ b/middleware/gateway/source/group/inbound/task/create.cpp
@@ -62,7 +62,7 @@ namespace casual
                   
                   // for service calls, it might be a _no-reply_ request.
                   if constexpr( std::same_as< M, common::message::service::call::callee::Request>)
-                     request.context.semantic = message.flags.exist( common::message::service::call::request::Flag::no_reply) ? 
+                     request.context.semantic = flag::exists( message.flags, common::message::service::call::request::Flag::no_reply) ? 
                         Semantic::no_reply : Semantic::no_busy_intermediate;
                   else
                      request.context.semantic = Semantic::no_busy_intermediate;

--- a/middleware/http/source/outbound/handle.cpp
+++ b/middleware/http/source/outbound/handle.cpp
@@ -49,7 +49,7 @@ namespace casual
                               reply.transaction.state = decltype( reply.transaction.state)::rollback;
                            }
 
-                           if( ! message.flags.exist( message::service::call::request::Flag::no_reply))
+                           if( ! flag::exists( message.flags, message::service::call::request::Flag::no_reply))
                               communication::device::blocking::optional::send( message.process.ipc, std::move( reply));
                         };
 

--- a/middleware/queue/source/manager/main.cpp
+++ b/middleware/queue/source/manager/main.cpp
@@ -73,7 +73,7 @@ namespace casual
                // register that we can answer discovery questions.
                {
                   using Ability = casual::domain::discovery::provider::Ability;
-                  casual::domain::discovery::provider::registration( flags::compose( Ability::lookup, Ability::fetch_known));
+                  casual::domain::discovery::provider::registration( Ability::lookup | Ability::fetch_known);
                }
 
                // we can supply configuration

--- a/middleware/queue/unittest/source/utility.cpp
+++ b/middleware/queue/unittest/source/utility.cpp
@@ -28,7 +28,7 @@ namespace casual
       std::vector< manager::admin::model::Message> messages( const std::string& queue)
       {
          using Call = serviceframework::service::protocol::binary::Call;
-         return Call{}( manager::admin::service::name::messages::list, Call::Flags{}, queue).extract< std::vector< manager::admin::model::Message>>();
+         return Call{}( manager::admin::service::name::messages::list, Call::Flag{}, queue).extract< std::vector< manager::admin::model::Message>>();
       }
 
       namespace scale
@@ -36,7 +36,7 @@ namespace casual
          void aliases( const std::vector< manager::admin::model::scale::Alias>& aliases)
          {
             using Call = serviceframework::service::protocol::binary::Call;
-            Call{}( manager::admin::service::name::forward::scale::aliases, Call::Flags{}, aliases);
+            Call{}( manager::admin::service::name::forward::scale::aliases, Call::Flag{}, aliases);
          }
 
          namespace all::forward

--- a/middleware/service/source/forward/handle.cpp
+++ b/middleware/service/source/forward/handle.cpp
@@ -37,7 +37,7 @@ namespace casual
                {
                   Trace trace{ "service::forward::handle::service::send::error::reply"};
 
-                  if( ! message.flags.exist( common::message::service::call::request::Flag::no_reply))
+                  if( ! flag::exists( message.flags, common::message::service::call::request::Flag::no_reply))
                   {
                      common::message::service::call::Reply reply;
                      reply.correlation = message.correlation;

--- a/middleware/service/source/manager/main.cpp
+++ b/middleware/service/source/manager/main.cpp
@@ -57,7 +57,7 @@ namespace casual
                // register so domain-manager can fetch configuration from us, and indicate that we can handle
                // runtime configuration updates.
                using Ability = casual::domain::configuration::registration::Ability;
-               casual::domain::configuration::registration::apply( flags::compose( Ability::supply, Ability::runtime_update));
+               casual::domain::configuration::registration::apply( Ability::supply | Ability::runtime_update);
 
                return state;
             }
@@ -114,7 +114,7 @@ namespace casual
 
                // register that we can answer discovery questions.
                using Ability = casual::domain::discovery::provider::Ability;
-               casual::domain::discovery::provider::registration( flags::compose( Ability::lookup, Ability::fetch_known));
+               casual::domain::discovery::provider::registration( Ability::lookup | Ability::fetch_known);
 
                // Connect to domain
                communication::instance::whitelist::connect( communication::instance::identity::service::manager);

--- a/middleware/service/unittest/source/test_forward.cpp
+++ b/middleware/service/unittest/source/test_forward.cpp
@@ -200,7 +200,7 @@ domain:
             common::message::service::call::callee::Request request;
             request.process = common::process::handle();
             using Flag = common::message::service::call::request::Flag;
-            request.flags = common::flags::compose( Flag::no_reply, Flag::no_transaction);
+            request.flags = Flag::no_reply | Flag::no_transaction;
             request.service.name = "a";
 
             EXPECT_TRUE( common::communication::device::blocking::send( sf.ipc, request));

--- a/middleware/serviceframework/include/serviceframework/service/call.h
+++ b/middleware/serviceframework/include/serviceframework/service/call.h
@@ -17,43 +17,37 @@
 
 namespace casual
 {
-   namespace serviceframework
+   namespace serviceframework::service
    {
-      namespace service
+      using payload_type = common::buffer::Payload;
+      using descriptor_type = platform::descriptor::type;
+
+
+      namespace call
       {
-         using payload_type = common::buffer::Payload;
-         using descriptor_type = platform::descriptor::type;
+         using Flag = common::service::call::sync::Flag;
+         using Result = common::service::call::sync::Result;
 
+         Result invoke( std::string service, const payload_type& payload, Flag flags = Flag{});
+      } // call
 
-         namespace call
-         {
-            using Flag = common::service::call::sync::Flag;
-            using Flags = common::service::call::sync::Flags;
-            using Result = common::service::call::sync::Result;
+      namespace send
+      {
+         using Flag = common::service::call::async::Flag;
 
-            Result invoke( std::string service, const payload_type& payload, Flags flags = Flags{});
-         } // call
+         descriptor_type invoke( std::string service, const payload_type& payload, Flag flags = Flag{});
 
-         namespace send
-         {
-            using Flag = common::service::call::async::Flag;
-            using Flags = common::service::call::async::Flags;
+      } // send
 
-            descriptor_type invoke( std::string service, const payload_type& payload, Flags flags = Flags{});
+      namespace receive
+      {
+         using Result = common::service::call::reply::Result;
+         using Flag = common::service::call::reply::Flag;
 
-         } // send
+         Result invoke( descriptor_type descriptor, Flag flags = Flag{});
+      } // receive
 
-         namespace receive
-         {
-            using Result = common::service::call::reply::Result;
-            using Flag = common::service::call::reply::Flag;
-            using Flags = common::service::call::reply::Flags;
-
-            Result invoke( descriptor_type descriptor, Flags flags = Flags{});
-         } // receive
-
-      } // service
-   } // serviceframework
+   } // serviceframework::service
 } // casual
 
 

--- a/middleware/serviceframework/include/serviceframework/service/protocol/call.h
+++ b/middleware/serviceframework/include/serviceframework/service/protocol/call.h
@@ -68,7 +68,6 @@ namespace casual
                using result_policy = R;
                using result_type = basic_result< service::call::Result, result_policy>;
                using Flag = service::call::Flag;
-               using Flags = service::call::Flags;
 
                basic_call() : m_payload( input_policy::type())
                {
@@ -122,7 +121,6 @@ namespace casual
                using result_policy = R;
                using result_type = basic_result< service::receive::Result, result_policy>;
                using Flag = service::receive::Flag;
-               using Flags = service::receive::Flags;
 
                basic_receive( descriptor_type descriptor) : m_descriptor( descriptor) {}
 
@@ -131,7 +129,7 @@ namespace casual
                   return { service::receive::invoke( m_descriptor)};
                }
 
-               result_type operator () ( Flags flags) const
+               result_type operator () ( Flag flags) const
                {
                   return { service::receive::invoke( m_descriptor, flags)};
                }
@@ -148,8 +146,6 @@ namespace casual
                using result_policy = R;
                using receive_type = basic_receive< result_policy>;
                using Flag = service::send::Flag;
-               using Flags = service::send::Flags;
-
 
                basic_send() : m_payload( input_policy::type()), m_input( m_payload) {}
 
@@ -165,7 +161,7 @@ namespace casual
                   return { service::send::invoke( service, m_payload)};
                }
 
-               receive_type operator () ( const std::string& service, Flags flags)
+               receive_type operator () ( const std::string& service, Flag flags)
                {
                   return { service::send::invoke( service, m_payload, flags)};
                }

--- a/middleware/serviceframework/source/service/call.cpp
+++ b/middleware/serviceframework/source/service/call.cpp
@@ -18,7 +18,7 @@ namespace casual
       {
          namespace call
          {
-            Result invoke( std::string service, const payload_type& payload, Flags flags)
+            Result invoke( std::string service, const payload_type& payload, Flag flags)
             {
                Trace trace{ "sf::service::call::invoke"};
 
@@ -28,7 +28,7 @@ namespace casual
 
          namespace send
          {
-            descriptor_type invoke( std::string service, const payload_type& payload, Flags flags)
+            descriptor_type invoke( std::string service, const payload_type& payload, Flag flags)
             {
                Trace trace{ "sf::service::call::send"};
 
@@ -39,7 +39,7 @@ namespace casual
 
          namespace receive
          {
-            Result invoke( descriptor_type descriptor, Flags flags)
+            Result invoke( descriptor_type descriptor, Flag flags)
             {
                Trace trace{ "sf::service::receive::send"};
 

--- a/middleware/tools/source/service/call/cli.cpp
+++ b/middleware/tools/source/service/call/cli.cpp
@@ -85,18 +85,18 @@ namespace casual
                   multiplexing = pipe | ipc,
                };
                
-               constexpr friend auto description( Flag flag)
+               constexpr friend std::string_view description( Flag flag)
                {
                   switch( flag)
                   {
-                     case Flag::done: return std::string_view{ "done"};
-                     case Flag::pipe: return std::string_view{ "pipe"};
-                     case Flag::ipc: return std::string_view{ "ipc"};
-                     default: return std::string_view{ "<unknown>"};
+                     case Flag::done: return "done";
+                     case Flag::pipe: return "pipe";
+                     case Flag::ipc: return "ipc";
+                     default: return "<unknown>";
                   }
                }
 
-               Flags< Flag> machine = Flag::pipe;
+               Flag machine = Flag::pipe;
 
                struct
                {
@@ -122,6 +122,10 @@ namespace casual
                   CASUAL_SERIALIZE( done);
                )
             };
+
+            // to enable Flag to be used as a flag (g++11 force (need to define it)
+            [[maybe_unused]] consteval void casual_enum_as_flag( State::Flag) {};
+
 
             namespace service
             {

--- a/middleware/transaction/source/manager/handle.cpp
+++ b/middleware/transaction/source/manager/handle.cpp
@@ -329,7 +329,7 @@ namespace casual
                   namespace pending
                   {
                      template< typename Request, typename Branches, typename P>
-                     auto branches( State& state, const Branches& branches, P pending, common::flag::xa::Flags flags = common::flag::xa::Flag::no_flags)
+                     auto branches( State& state, const Branches& branches, P pending, common::flag::xa::Flag flags = common::flag::xa::Flag::no_flags)
                      {
                         return common::algorithm::accumulate( branches, std::move( pending), [ &state, flags]( auto result, const auto& branch)
                         {
@@ -348,7 +348,7 @@ namespace casual
                      }
 
                      template< typename Request, typename Replies, typename P>
-                     auto replies( State& state, Replies&& replies, P pending, common::flag::xa::Flags flags = common::flag::xa::Flag::no_flags)
+                     auto replies( State& state, Replies&& replies, P pending, common::flag::xa::Flag flags = common::flag::xa::Flag::no_flags)
                      {
                         return common::algorithm::accumulate( replies, std::move( pending), [ &state, flags]( auto result, const auto& reply)
                         {
@@ -965,7 +965,7 @@ namespace casual
                            {
                               // this should be a one-phase optimization, if not, we log error and still commit.
                               // TODO: this should not matter, but does it?
-                              if( ! message.flags.exist( common::flag::xa::Flag::one_phase))
+                              if( ! common::flag::exists( message.flags, common::flag::xa::Flag::one_phase))
                                  common::log::error( common::code::casual::invalid_semantics, " resource commit request without TMONEPHASE, gtrid: ", transaction->global);
 
                               // start the prepare phase

--- a/middleware/xatmi/include/casual/xatmi/internal/signal.h
+++ b/middleware/xatmi/include/casual/xatmi/internal/signal.h
@@ -7,18 +7,17 @@
 #pragma once
 
 #include "common/signal.h"
+#include "common/flag.h"
 
 #include <optional>
 
 
 namespace casual::xatmi::internal::signal
 {
-    template< typename Flags>
-    inline std::optional< casual::common::signal::thread::scope::Block> maybe_block( Flags flags)
+    template< typename Flag>
+    inline std::optional< casual::common::signal::thread::scope::Block> maybe_block( Flag flags)
     {
-        using enum_type = typename Flags::enum_type;
-
-        if( flags.exist( enum_type::signal_restart))
+        if( common::flag::exists( flags, Flag::signal_restart))
             return casual::common::signal::thread::scope::Block{};
 
         return {};


### PR DESCRIPTION
A lot cleaner and quite "clever" (subjective) reduction of the abstraction.

Using _declare a function with a specific name_ to opt in if a `enum` should be treated as a flag-like. Quite terse, and one can opt in directly where the `enum` is defined. Using "classic" type-specialization to opt in, one (often) need to opt in "far" from the type. I'm not sure which is better... time will tell.