### PR TITLE
domain - add option to unset environment variables

### DIFF
--- a/middleware/administration/unittest/source/cli/test_domain.cpp
+++ b/middleware/administration/unittest/source/cli/test_domain.cpp
@@ -232,7 +232,30 @@ domain:
          EXPECT_TRUE( ! capture.standard.out.empty()) << CASUAL_NAMED_VALUE( capture);
       }
 
-     
+      TEST( cli_domain, environment__set_and_unset)
+      {
+         common::unittest::Trace trace;
+
+         auto domain = local::domain( R"(
+domain:
+   servers:
+      - alias: echo-server
+        path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+        memberships: [ user]
+        instances: 1
+)");
+
+         administration::unittest::cli::command::execute( "casual domain --set-environment test 123");
+         auto capture = administration::unittest::cli::command::execute( "casual domain --state");
+
+         EXPECT_TRUE( capture.standard.out.find("test=123") != std::string::npos);
+
+         administration::unittest::cli::command::execute( "casual domain --unset-environment test");
+
+         capture = administration::unittest::cli::command::execute( "casual domain --state");
+
+         EXPECT_TRUE( capture.standard.out.find("test=123") == std::string::npos);
+      }
 
    } // administration
 } // casual

--- a/middleware/domain/include/domain/manager/admin/model.h
+++ b/middleware/domain/include/domain/manager/admin/model.h
@@ -303,6 +303,21 @@ namespace casual
             };
             
          } // set
+
+         namespace unset
+         {
+            struct Environment
+            {
+               std::vector< std::string> variables;
+               std::vector< std::string> aliases;
+
+               CASUAL_CONST_CORRECT_SERIALIZE(
+                  CASUAL_SERIALIZE( variables);
+                  CASUAL_SERIALIZE( aliases);
+               )
+            };
+            
+         } // unset
          
       } // v1
    } // domain::manager::admin::model

--- a/middleware/domain/include/domain/manager/admin/server.h
+++ b/middleware/domain/include/domain/manager/admin/server.h
@@ -44,6 +44,7 @@ namespace casual
          namespace environment
          {
             constexpr auto set = ".casual/domain/environment/set";
+            constexpr auto unset = ".casual/domain/environment/unset";
          } // environment
 
       } // service::name


### PR DESCRIPTION
"casual domain --unset-environment" can be used to unset environment variables