### PR TITLE
http: improved error logging in http-outbound

### DIFF
--- a/middleware/http/include/http/outbound/state.h
+++ b/middleware/http/include/http/outbound/state.h
@@ -65,6 +65,7 @@ namespace casual
                   std::string service;
                   std::string parent;
                   common::transaction::ID trid;
+                  std::string url;
 
                   struct Header
                   {
@@ -107,7 +108,7 @@ namespace casual
                      CASUAL_SERIALIZE( parent);
                      CASUAL_SERIALIZE( trid);
                      CASUAL_SERIALIZE( header);
-                  )                     
+                  )
                };
 
                inline const curl::type::easy& easy() const { return m_easy;}

--- a/middleware/http/source/outbound/request.cpp
+++ b/middleware/http/source/outbound/request.cpp
@@ -23,6 +23,8 @@
 
 #include <curl/curl.h>
 
+#include <iomanip>
+
 namespace casual
 {
    using namespace common;
@@ -261,6 +263,7 @@ namespace casual
          request.state().parent = std::move( message.parent);
          request.state().trid = message.trid;
          request.state().start = now;
+         request.state().url = node.url;
 
          common::log::line( http::verbose::log, "request.state(): ", request.state());
 
@@ -386,7 +389,10 @@ namespace casual
             }
             else
             {
-               common::log::line( common::log::category::error, common::code::xatmi::service_error, " curl error: ", curl_easy_strerror( code));
+               common::log::line(
+                  common::log::category::error,
+                  common::code::xatmi::service_error,
+                  " call to http-outbound service ", std::quoted( request.state().service), " failed - curl error: ", curl_easy_strerror( code), ", url: ", request.state().url);
                common::log::line( common::log::category::verbose::error, CASUAL_NAMED_VALUE( request));
 
                return { common::code::xatmi::service_error, 0};

--- a/middleware/http/unittest/source/outbound/test_request.cpp
+++ b/middleware/http/unittest/source/outbound/test_request.cpp
@@ -59,6 +59,7 @@ namespace casual::http::outbound
       EXPECT_TRUE( request.state().service == expected.service.logical_name()) << request.state().service;
       EXPECT_TRUE( request.state().parent == expected.parent) << request.state().parent;
       EXPECT_TRUE( request.state().trid == expected.trid) << request.state().trid;
+      EXPECT_TRUE( request.state().url == local::node().url) << request.state().url;
    }
 
 } // casual::http::outbound


### PR DESCRIPTION
This patch adds additional information to the error that is logged when a curl request in the http-outbound fails

Resolves #367