### PR TITLE
discovery: use the general message count

### DIFF
--- a/middleware/common/include/common/message/counter.h
+++ b/middleware/common/include/common/message/counter.h
@@ -41,6 +41,9 @@ namespace casual
       //
       std::vector< Entry> entries() noexcept;
 
+      //! @returns the Entry associated with the `type`
+      Entry entry( message::Type type) noexcept;
+
       
       using Request = basic_request< Type::counter_request>;
       

--- a/middleware/common/source/message/counter.cpp
+++ b/middleware/common/source/message/counter.cpp
@@ -47,6 +47,14 @@ namespace casual
       {
          return local::global_counter;
       }
+
+      Entry entry( message::Type type) noexcept
+      {
+         if( auto found = algorithm::find( local::global_counter, type))
+            return *found;
+
+         return { type};
+      }
       
    } // common::message::counter
 } // casual

--- a/middleware/domain/include/domain/discovery/admin/model.h
+++ b/middleware/domain/include/domain/discovery/admin/model.h
@@ -128,12 +128,11 @@ namespace casual
          state::Runlevel runlevel;
          std::vector< Provider> providers;
          Pending pending;
-         Metric metric;
 
          CASUAL_CONST_CORRECT_SERIALIZE(
             CASUAL_SERIALIZE( runlevel);
             CASUAL_SERIALIZE( providers);
-            CASUAL_SERIALIZE( metric);
+            CASUAL_SERIALIZE( pending);
          )
 
       };

--- a/middleware/domain/include/domain/discovery/state.h
+++ b/middleware/domain/include/domain/discovery/state.h
@@ -24,94 +24,6 @@ namespace casual
    {
       namespace state
       {
-         namespace metric::message
-         {
-            namespace detail
-            {
-               namespace count
-               {
-                  enum class Tag : short
-                  {
-                     received,
-                     sent
-                  };
-
-                  template< Tag tag, common::message::Type type>
-                  struct basic_count
-                  {
-                     static void increment() noexcept { ++m_count;}
-                     static auto value() noexcept { return m_count;}
-                  private:
-                     static platform::size::type m_count;
-                  };
-
-                  template< Tag tag, common::message::Type type>
-                  platform::size::type basic_count< tag, type>::m_count = {};
-
-
-                  template< common::message::Type type>
-                  using Receive = basic_count< count::Tag::received, type>;
-
-                  template< common::message::Type type>
-                  using Send = basic_count< count::Tag::sent, type>;
-
-               } // count
-
-               template< count::Tag tag, typename C, typename Message>
-               constexpr auto create( C creator, const Message&)
-               {
-                  constexpr auto type = common::message::type< std::remove_cvref_t< Message>>();
-                  return creator( 
-                     type, 
-                     detail::count::basic_count< tag, type>::value());
-               }
-
-               template< count::Tag tag, typename C, typename... Messages>
-               constexpr auto counts( C creator, Messages... messages) noexcept
-               {
-                  using value_type = decltype( creator( common::message::Type{}, platform::size::type{}));
-
-                  std::vector< value_type> result;
-                  result.reserve( sizeof...( Messages));
-
-                  ( ... , result.push_back( detail::create< tag>( creator, messages)) );
-
-                  return result;
-               }
-
-            } // detail
-
-            namespace count
-            {
-               template< typename Message>
-               constexpr void receive( Message&&)
-               {
-                  detail::count::Receive< common::message::type< std::remove_cvref_t< Message>>()>::increment();
-               }
-
-               template< typename C, typename... Messages>
-               constexpr auto received( C creator, Messages... messages) noexcept
-               {
-                  return detail::counts< detail::count::Tag::received>( std::move( creator), std::forward< Messages>( messages)...);
-               }
-
-               template< typename Message>
-               constexpr void send( Message&&)
-               {
-                  detail::count::Send< common::message::type< std::remove_cvref_t< Message>>()>::increment();
-               }
-
-               template< typename C, typename... Messages>
-               constexpr auto sent( C creator, Messages... messages) noexcept
-               {
-                  return detail::counts< detail::count::Tag::sent>( std::move( creator), std::forward< Messages>( messages)...);
-               }
-               
-            } // count 
-            
-         } // metric::message
-
-
          namespace runlevel
          {
             enum struct State : short
@@ -139,8 +51,8 @@ namespace casual
             provider::Ability abilities{};
             common::process::Handle process;
 
-            inline friend bool operator == ( const Provider& lhs, const common::strong::ipc::id& rhs) { return lhs.process.ipc == rhs;}
-            inline friend bool operator == ( const Provider& lhs, common::strong::process::id rhs) { return lhs.process.pid == rhs;}
+            friend bool operator == ( const Provider& lhs, common::process::compare_equal_to_handle auto rhs) { return lhs.process == rhs;}
+
 
             CASUAL_LOG_SERIALIZE(
                CASUAL_SERIALIZE( abilities);
@@ -315,8 +227,6 @@ namespace casual
 
                static const platform::size::type in_flight_window;
                static const platform::time::unit duration;
-
-
 
                CASUAL_LOG_SERIALIZE(
                   CASUAL_SERIALIZE_NAME( in_flight(), "in_flight");

--- a/middleware/domain/source/discovery/admin/transform.cpp
+++ b/middleware/domain/source/discovery/admin/transform.cpp
@@ -59,47 +59,9 @@ namespace casual
                   
                   return result;
                }
-
-               auto metric( const State& state)
-               {
-                  model::Metric result;
-
-                  auto create_count = []( auto type, auto count)
-                  {
-                     return model::metric::message::Count{ type, count};
-                  };
-
-                  result.message.count.receive = state::metric::message::count::received( create_count, 
-                     message::discovery::api::Request{},
-                     message::discovery::api::rediscovery::Request{},
-                     message::discovery::fetch::known::Reply{},
-                     message::discovery::Request{},
-                     message::discovery::Reply{},
-                     message::discovery::lookup::Reply{},
-                     message::discovery::topology::implicit::Update{},
-                     message::discovery::topology::direct::Update{},
-                     common::message::shutdown::Request{}
-                  );
-
-                  result.message.count.send = state::metric::message::count::sent( create_count, 
-                     message::discovery::Request{},
-                     message::discovery::Reply{},
-                     message::discovery::lookup::Request{},
-                     message::discovery::fetch::known::Request{},
-                     message::discovery::api::Reply{},
-                     message::discovery::api::rediscovery::Reply{},
-                     message::discovery::topology::implicit::Update{},
-                     message::discovery::topology::direct::Explore{}
-                  );
-
-                  return result;
-               }
-
-               
             } // transform
          } // <unnamed>
       } // local
-
 
       model::State transform( const State& state)
       {
@@ -109,9 +71,7 @@ namespace casual
 
          result.runlevel = state.runlevel();
          result.providers = local::transform::providers( state.providers);
-
          result.pending = local::transform::pending( state);
-         result.metric = local::transform::metric( state);
 
          return result;
       }

--- a/middleware/domain/source/discovery/handle.cpp
+++ b/middleware/domain/source/discovery/handle.cpp
@@ -43,7 +43,6 @@ namespace casual
                void entry( const M& message)
                {
                   log::line( verbose::log, "message: ", message);
-                  state::metric::message::count::receive( message);
                }
             
             } // handler
@@ -81,7 +80,6 @@ namespace casual
                   template< typename M>
                   auto multiplex( State& state, const strong::ipc::id& destination, const M& message)
                   {
-                     state::metric::message::count::send( message);
                      return state.multiplex.send( destination, message);
                   }
 

--- a/middleware/domain/source/discovery/state.cpp
+++ b/middleware/domain/source/discovery/state.cpp
@@ -150,10 +150,10 @@ namespace casual
 
             platform::size::type Heuristic::in_flight() noexcept
             {
-               using discovery_sent = state::metric::message::detail::count::Send< message::discovery::Request::type()>;
-               using discovery_received = state::metric::message::detail::count::Receive< message::discovery::Reply::type()>;
+               auto request = common::message::counter::entry( message::discovery::Request::type());
+               auto reply = common::message::counter::entry( message::discovery::Reply::type());
 
-               return discovery_sent::value() - discovery_received::value();
+               return request.sent - reply.received;
             }
 
 


### PR DESCRIPTION
Before: discovery had it's own message count abstraction to keep track of sent and received messages.

Now: We use the general message count (common::message::counter...)