### PR TITLE
service: fix invisible route being created when updating service config

### DIFF
--- a/middleware/service/include/service/manager/admin/model.h
+++ b/middleware/service/include/service/manager/admin/model.h
@@ -190,13 +190,13 @@ namespace casual
 
       struct Route 
       {
-         //! the exposed service name
-         std::string service;
+         //! the exposed names for the service
+         std::vector< std::string> services;
          //! the actual invoked service
          std::string target;
 
          CASUAL_CONST_CORRECT_SERIALIZE(
-            CASUAL_SERIALIZE( service);
+            CASUAL_SERIALIZE( services);
             CASUAL_SERIALIZE( target);
          )
       };

--- a/middleware/service/source/manager/configuration.cpp
+++ b/middleware/service/source/manager/configuration.cpp
@@ -153,7 +153,6 @@ namespace casual
                         return name == iterator->first;
                      }));
 
-
                      for( auto& route : add)
                      {
                         // add the route and use an existing service to keep possible instances.
@@ -164,7 +163,7 @@ namespace casual
 
                      if( auto found = algorithm::find( state.routes, configuration.name))
                         algorithm::append( add, found->second);
-                     else 
+                     else if( add)
                         state.routes.emplace( configuration.name, algorithm::container::vector::create( add));
                   }
 

--- a/middleware/service/source/manager/state.cpp
+++ b/middleware/service/source/manager/state.cpp
@@ -460,12 +460,13 @@ namespace casual
 
                if( auto found = algorithm::find( state.routes, service.information.name))
                {
+                  log::line( verbose::log, "routes: ", found->second);
+
                   // service has routes, use them instead
                   algorithm::for_each( found->second, add_service);
                }
                else
                   add_service( service.information.name);
-                  
             }
 
 

--- a/middleware/service/source/manager/transform.cpp
+++ b/middleware/service/source/manager/transform.cpp
@@ -120,6 +120,17 @@ namespace casual
                };
             }
 
+            auto route()
+            {
+               return []( auto& pair)
+               {
+                  manager::admin::model::Route result;
+                  result.target = pair.first;
+                  result.services = pair.second;
+                  return result;
+               };
+            }
+
             auto reservation()
             {
                return []( auto& pair)
@@ -159,17 +170,7 @@ namespace casual
 
          common::algorithm::transform( state.services, result.services, local::service());
 
-         common::algorithm::for_each( state.routes, [&result]( auto& pair)
-         {
-            manager::admin::model::Route route;
-            route.target = pair.first;
-
-            common::algorithm::transform( pair.second, result.routes, [&route]( auto& service)
-            {
-               route.service = service;
-               return route;
-            });
-         });
+         common::algorithm::transform( state.routes, result.routes, local::route());
 
          common::algorithm::transform_if(
             state.instances.sequential, std::back_inserter( result.reservations), local::reservation(), []( auto& pair){ return ! pair.second.idle();}


### PR DESCRIPTION
This patch fixes an issue where a route with no name would be created to a service whose configuration was changed during runtime. This would make it so that no additional instances of that service could be advertised.

Resolves #370