### PR TITLE
queue: enqueue/dequeue to muliple queues in example server

### DIFF
--- a/middleware/queue/source/example/main.cpp
+++ b/middleware/queue/source/example/main.cpp
@@ -1,4 +1,5 @@
 #include "common/argument.h"
+#include "common/algorithm.h"
 #include "common/communication/ipc.h"
 #include "common/communication/instance.h"
 #include "common/exception/guard.h"
@@ -18,28 +19,28 @@ namespace casual
          {
             struct
             {
-               std::string queue;
+               std::vector<std::string> queues;
             } settings;
 
             namespace service
             {
-               auto enqueue()
+               auto enqueue( const std::string& queue)
                {
-                  return []( common::service::invoke::Parameter&& parameter)
+                  return [queue]( common::service::invoke::Parameter&& parameter)
                   {
                      queue::Message message;
                      message.payload.data = std::move(parameter.payload.data);
                      message.payload.type = parameter.payload.type;
-                     queue::enqueue(settings.queue, message);
+                     queue::enqueue(queue, message);
                      return common::service::invoke::Result{ nullptr };
                   };
                }
 
-               auto dequeue()
+               auto dequeue( const std::string& queue)
                {
-                  return []( common::service::invoke::Parameter&& parameter)
+                  return [queue]( common::service::invoke::Parameter&& parameter)
                   {
-                     if (auto message = queue::dequeue( settings.queue); ! message.empty())
+                     if (auto message = queue::dequeue( queue); ! message.empty())
                      {
                         common::buffer::Payload payload { message.front().payload.type };
                         payload.data = std::move( message.front().payload.data);
@@ -50,41 +51,52 @@ namespace casual
                }
             }
 
-            common::server::Arguments services()
+            common::server::Arguments services( std::vector<std::string> queues)
             {
-               return {{
-                  {
-                     "casual/example/enqueue",
-                     service::enqueue(),
-                     common::service::transaction::Type::automatic,
-                     common::service::visibility::Type::discoverable,
-                     "example"
-                  },
-                  {
-                     "casual/example/dequeue",
-                     service::dequeue(),
-                     common::service::transaction::Type::automatic,
-                     common::service::visibility::Type::discoverable,
-                     "example"
-                  }
-               }};
+               auto to_services = [](const auto& queue) -> std::vector<common::server::Service>
+               {
+                  return {
+                     {
+                        common::string::compose( "casual/example/enqueue/", queue),
+                        service::enqueue( queue),
+                        common::service::transaction::Type::automatic,
+                        common::service::visibility::Type::discoverable,
+                        "example"
+                     },
+                     {
+                        common::string::compose( "casual/example/dequeue/", queue),
+                        service::dequeue( queue),
+                        common::service::transaction::Type::automatic,
+                        common::service::visibility::Type::discoverable,
+                        "example"
+                     },
+                  };
+               };
+
+               auto services = common::algorithm::accumulate(
+                  common::algorithm::transform( queues, to_services),
+                  std::vector<common::server::Service>{},
+                  [](auto&& a, auto&& b) {
+                     return common::algorithm::append( b, a);
+                  });
+
+               return {{ services }};
             }
 
             void main( int argc, char **argv)
             {
                common::argument::Parse{
                   R"(Example server)",
-                  common::argument::Option{ std::tie( settings.queue), {"--queue"}, "queue that casual/example/{enqueue,dequeue} should use"},
+                  common::argument::Option{ std::tie( settings.queues), {"--queues"}, "queues that casual/example/{enqueue,dequeue} should use"},
                }(argc, argv);
 
-               common::log::line( common::log::category::information, "queue: ", settings.queue);
-
+               common::log::line( common::log::category::information, "queues: ", settings.queues);
                common::communication::instance::connect();
 
                auto handler = common::message::dispatch::handler(
                   common::communication::ipc::inbound::device(),
                   common::message::dispatch::handle::defaults(),
-                  common::server::handle::Call{services()}
+                  common::server::handle::Call{services(settings.queues)}
                );
 
                common::message::dispatch::pump( handler, common::communication::ipc::inbound::device());

--- a/middleware/queue/unittest/source/test_example.cpp
+++ b/middleware/queue/unittest/source/test_example.cpp
@@ -48,6 +48,8 @@ domain:
            queuebase: ":memory:"
            queues:
             - name: example.q1
+            - name: example.q2
+            - name: example.q3
 
    servers:
       - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager"
@@ -68,10 +70,10 @@ domain:
             }
 
             template< typename B>
-            int call_enqueue( B&& buffer)
+            int call_enqueue( B&& buffer, const std::string& queuename)
             {
                auto len = tptypes( buffer, nullptr, nullptr);
-               return tpcall( "casual/example/enqueue", buffer, len, &buffer, &len, 0);
+               return tpcall( common::string::compose("casual/example/enqueue/", queuename).data(), buffer, len, &buffer, &len, 0);
             }
 
          } // <unnamed> 
@@ -87,7 +89,7 @@ domain:
    servers:
       - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/queue/bin/casual-queue-example-server"
         memberships: [ user]
-        arguments: [ --queue, non-existing]
+        arguments: [ --queues, non-existing]
 )";
          auto domain = local::domain( example_server);
 
@@ -95,7 +97,7 @@ domain:
          auto buffer = tpalloc( X_OCTET, nullptr, contents.size());
          common::algorithm::copy( contents, buffer);
 
-         EXPECT_EQ( local::call_enqueue( buffer), -1);
+         EXPECT_EQ( local::call_enqueue( buffer, "non-existing"), -1);
          tpfree( buffer);
       }
 
@@ -108,7 +110,7 @@ domain:
    servers:
       - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/queue/bin/casual-queue-example-server"
         memberships: [ user]
-        arguments: [ --queue, example.q1]
+        arguments: [ --queues, example.q1]
 )";
          auto domain = local::domain( example_server);
 
@@ -119,7 +121,7 @@ domain:
             auto buffer = tpalloc( X_OCTET, nullptr, contents.size());
             common::algorithm::copy( contents, buffer);
 
-            EXPECT_EQ( local::call_enqueue( buffer), 0);
+            EXPECT_EQ( local::call_enqueue( buffer, "example.q1"), 0);
             tpfree( buffer);
          }
 
@@ -142,7 +144,7 @@ domain:
    servers:
       - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/queue/bin/casual-queue-example-server"
         memberships: [ user]
-        arguments: [ --queue, example.q1]
+        arguments: [ --queues, example.q1]
 )";
          auto domain = local::domain( example_server);
 
@@ -155,7 +157,7 @@ domain:
             auto buffer = tpalloc( X_OCTET, nullptr, contents.size());
             common::algorithm::copy( contents, buffer);
 
-            EXPECT_EQ( local::call_enqueue( buffer), 0);
+            EXPECT_EQ( local::call_enqueue( buffer, "example.q1"), 0);
             tpfree( buffer);
          }
 
@@ -175,14 +177,14 @@ domain:
    servers:
       - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/queue/bin/casual-queue-example-server"
         memberships: [ user]
-        arguments: [ --queue, non-existing]
+        arguments: [ --queues, non-existing]
 )";
          auto domain = local::domain( example_server);
 
          auto buffer = tpalloc( X_OCTET, nullptr, 128);
          long olen = 999;
 
-         EXPECT_EQ( tpcall( "casual/example/dequeue", nullptr, 0, &buffer, &olen, 0), -1);
+         EXPECT_EQ( tpcall( "casual/example/dequeue/non-existing", nullptr, 0, &buffer, &olen, 0), -1);
       }
 
       TEST( casual_queue_example_server, dequeue_empty_queue__expect_empty_response)
@@ -194,14 +196,14 @@ domain:
    servers:
       - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/queue/bin/casual-queue-example-server"
         memberships: [ user]
-        arguments: [ --queue, example.q1]
+        arguments: [ --queues, example.q1]
 )";
          auto domain = local::domain( example_server);
 
          auto buffer = tpalloc( X_OCTET, nullptr, 128);
          long olen = 999;
 
-         EXPECT_EQ( tpcall( "casual/example/dequeue", nullptr, 0, &buffer, &olen, 0), 0);
+         EXPECT_EQ( tpcall( "casual/example/dequeue/example.q1", nullptr, 0, &buffer, &olen, 0), 0);
          EXPECT_EQ( olen, 0);
       }
 
@@ -214,7 +216,7 @@ domain:
    servers:
       - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/queue/bin/casual-queue-example-server"
         memberships: [ user]
-        arguments: [ --queue, example.q1]
+        arguments: [ --queues, example.q1]
 )";
          auto domain = local::domain( example_server);
 
@@ -233,7 +235,7 @@ domain:
             auto buffer = tpalloc( X_OCTET, nullptr, 256);
             long olen = 0;
 
-            EXPECT_EQ( tpcall( "casual/example/dequeue", nullptr, 0, &buffer, &olen, 0), 0);
+            EXPECT_EQ( tpcall( "casual/example/dequeue/example.q1", nullptr, 0, &buffer, &olen, 0), 0);
             EXPECT_EQ( olen, 128);
 
             char buf_type[9];
@@ -246,6 +248,56 @@ domain:
 
          EXPECT_EQ( queue::dequeue( "example.q1").size(), 0UL);
 
+      }
+
+      TEST( casual_queue_example_server, enqueue_multiple_queues)
+      {
+         common::unittest::Trace trace;
+         
+         constexpr auto example_server = R"(
+domain:
+   servers:
+      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/queue/bin/casual-queue-example-server"
+        memberships: [ user]
+        arguments: [ --queues, example.q1, example.q2, example.q3]
+)";
+         auto domain = local::domain( example_server);
+
+         auto contents = common::unittest::random::binary( 128);
+
+         // enqueue 1 message
+         {
+            auto buffer = tpalloc( X_OCTET, nullptr, contents.size());
+            common::algorithm::copy( contents, buffer);
+
+            EXPECT_EQ( local::call_enqueue( buffer, "example.q1"), 0);
+            tpfree( buffer);
+         }
+         // dequeue 1 message
+         {
+            auto messages = queue::dequeue( "example.q1");
+            EXPECT_EQ( messages.size(), 1UL);
+
+            EXPECT_EQ( messages.front().payload.type, "X_OCTET/");
+            EXPECT_TRUE( common::algorithm::equal(messages.front().payload.data, contents));
+         }
+
+         // enqueue 1 message
+         {
+            auto buffer = tpalloc( X_OCTET, nullptr, contents.size());
+            common::algorithm::copy( contents, buffer);
+
+            EXPECT_EQ( local::call_enqueue( buffer, "example.q2"), 0);
+            tpfree( buffer);
+         }
+         // dequeue 1 message
+         {
+            auto messages = queue::dequeue( "example.q2");
+            EXPECT_EQ( messages.size(), 1UL);
+
+            EXPECT_EQ( messages.front().payload.type, "X_OCTET/");
+            EXPECT_TRUE( common::algorithm::equal(messages.front().payload.data, contents));
+         }
       }
 
    } // queue::example


### PR DESCRIPTION
Added functionality to configure the example server with multiple queues. Each queue will have a dedicated enqueue- and dequeue service.