### PR TITLE
domain: assassination contract lethal or non-lethal

### DIFF
--- a/middleware/administration/unittest/source/cli/test_service.cpp
+++ b/middleware/administration/unittest/source/cli/test_service.cpp
@@ -68,7 +68,7 @@ domain:
          execution:
             timeout:
                duration: 90
-               contract: terminate
+               contract: kill
 )");
 
          // name
@@ -88,7 +88,7 @@ domain:
          // timeout contract
          {
             const auto capture = administration::unittest::cli::command::execute( R"(casual service --list-services --porcelain true | awk -F'|' '{printf $15}')");
-            constexpr auto expected = "terminate";
+            constexpr auto expected = "kill";
             EXPECT_EQ( capture.standard.out, expected);
          }
       }

--- a/middleware/common/include/common/code/signal.h
+++ b/middleware/common/include/common/code/signal.h
@@ -31,6 +31,7 @@ namespace casual
          user = SIGUSR1,
          pipe = SIGPIPE,
          hangup = SIGHUP,
+         abort = SIGABRT,
       };
       std::string_view description( code::signal code) noexcept;
 

--- a/middleware/common/include/common/service/type.h
+++ b/middleware/common/include/common/service/type.h
@@ -58,8 +58,9 @@ namespace casual
          enum class Type : short
          {
             linger,
+            interrupt,
             kill,
-            terminate
+            abort
          };
          
          std::string_view description( Type value) noexcept;

--- a/middleware/common/source/code/signal.cpp
+++ b/middleware/common/source/code/signal.cpp
@@ -58,13 +58,14 @@ namespace casual
             case signal::absent: return "absent";
             case signal::alarm: return "alarm";
             case signal::child: return "child";
-            case signal::interrupt: return "interupt";
+            case signal::interrupt: return "interrupt";
             case signal::kill: return "kill";
             case signal::pipe: return "pipe";
             case signal::quit: return "quit";
             case signal::terminate: return "terminate";
             case signal::user: return "user";
             case signal::hangup: return "hangup";
+            case signal::abort: return "abort";
          }
          return "unknown";
       }

--- a/middleware/common/source/service/type.cpp
+++ b/middleware/common/source/service/type.cpp
@@ -58,8 +58,15 @@ namespace casual
          Type transform( std::string_view contract)
          {
             if( contract == "linger") return Type::linger;
+            if( contract == "interrupt") return Type::interrupt;
             if( contract == "kill") return Type::kill;
-            if( contract == "terminate") return Type::terminate;
+            if( contract == "abort") return Type::abort;
+
+            if( contract == "terminate")
+            {
+               log::warning( code::casual::invalid_configuration, "contract 'terminate' is removed - using 'kill' instead");
+               return Type::kill;
+            }
             
             code::raise::error( code::casual::invalid_configuration, "unexpected value: ", contract);
          }
@@ -74,8 +81,9 @@ namespace casual
             switch( value)
             {
                case Type::linger: return "linger";
+               case Type::interrupt: return "interrupt";
                case Type::kill: return "kill";
-               case Type::terminate: return "terminate";
+               case Type::abort: return "abort";
             }
             return "unknown";
          }

--- a/middleware/configuration/source/documentation/main.cpp
+++ b/middleware/configuration/source/documentation/main.cpp
@@ -112,11 +112,12 @@ undiscoverable  | service is **not** discoverable from other domains
 
 A string representation that defines the timeout contract. Can be one of the following:
 
-value         | description
---------------|---------------------
-linger        | no action, let the server be
-kill          | send `kill` signal
-terminate     | `@deprecated` send terminate signal
+value         |  severity  | description
+--------------|------------|---------------------
+linger        | non-lethal | no action, let the server be
+interrupt     | non-lethal | send `interrupt` signal as a tap on the shoulder
+kill          | lethal     | send `kill` signal
+abort         | lethal     | send 'abort' signal 
 
 
 ### domain::service::Timeout _(structure)_

--- a/middleware/configuration/source/example/model.cpp
+++ b/middleware/configuration/source/example/model.cpp
@@ -152,7 +152,7 @@ domain:
          execution:
             timeout:
                duration: 64ms
-               contract: terminate
+               contract: abort
          visibility: undiscoverable
 )");
             }

--- a/middleware/configuration/source/model/transform.cpp
+++ b/middleware/configuration/source/model/transform.cpp
@@ -238,7 +238,9 @@ namespace casual
                         if( timeout.duration)
                            result.duration = common::chronology::from::string( *timeout.duration);
                         if( timeout.contract)
+                        {
                            result.contract = common::service::execution::timeout::contract::transform( *timeout.contract);
+                        }
                      }
                      return result;
                   }

--- a/middleware/configuration/unittest/source/test_model.cpp
+++ b/middleware/configuration/unittest/source/test_model.cpp
@@ -293,7 +293,7 @@ domain:
       execution:
          timeout:
             duration: 88s
-            contract: terminate
+            contract: abort 
 )";
          
          auto model = local::configuration( configuration);
@@ -303,9 +303,10 @@ domain:
          EXPECT_TRUE( model.service.services.at(0).name == "a");
 
          EXPECT_TRUE( model.service.services.at(0).timeout.duration == common::chronology::from::string( "88s"));
-         EXPECT_TRUE( model.service.services.at(0).timeout.contract == common::service::execution::timeout::contract::Type::terminate );
+         EXPECT_TRUE( model.service.services.at(0).timeout.contract == common::service::execution::timeout::contract::Type::abort);
 
       }
+
 
       TEST( configuration_model_transform, service_no_defaults_with_error)
       {
@@ -369,13 +370,13 @@ domain:
       execution:
          timeout:
             duration: 53min
-            contract: terminate
+            contract: linger
 )";
          
          auto model = local::configuration( configuration);
 
          EXPECT_TRUE( model.service.global.timeout.duration == common::chronology::from::string( "53min"));
-         EXPECT_TRUE( model.service.global.timeout.contract == common::service::execution::timeout::contract::Type::terminate);
+         EXPECT_TRUE( model.service.global.timeout.contract == common::service::execution::timeout::contract::Type::linger);
 
       }
 
@@ -391,7 +392,7 @@ domain:
     execution:
       timeout:
         duration: 53min
-        contract: terminate
+        contract: interrupt
 
   default:
     service:
@@ -424,7 +425,7 @@ domain:
          EXPECT_TRUE( model.service.services.at(1).timeout.contract == common::service::execution::timeout::contract::Type::linger );
 
          EXPECT_TRUE( model.service.global.timeout.duration == common::chronology::from::string( "53min"));
-         EXPECT_TRUE( model.service.global.timeout.contract == common::service::execution::timeout::contract::Type::terminate );
+         EXPECT_TRUE( model.service.global.timeout.contract == common::service::execution::timeout::contract::Type::interrupt );
 
       }
 
@@ -698,7 +699,7 @@ domain:
          execution:
             timeout:
                duration: 90
-               contract: terminate
+               contract: kill
    servers:
       - alias: a
         path: a
@@ -727,7 +728,7 @@ domain:
          execution:
             timeout:
                duration: 45
-               contract: terminate
+               contract: kill
    servers:
       - alias: a
         path: a

--- a/middleware/domain/unittest/source/manager/test_manager.cpp
+++ b/middleware/domain/unittest/source/manager/test_manager.cpp
@@ -644,7 +644,7 @@ domain:
          // order hit
          message::event::process::Assassination assassination;
          assassination.target = target;
-         assassination.contract = Contract::terminate;
+         assassination.contract = Contract::kill;
          communication::device::blocking::send( communication::instance::outbound::domain::manager::device(), assassination);
 
          // check if/when hit is performed


### PR DESCRIPTION
Before: We had _terminate_ which is some where between lethal and non-lethal.

Now: We have:
* linger    | non-lethal | no action, let the server be
* interrupt | non-lethal | send `interrupt` signal as a tap on the shoulder
* kill      | lethal     | send `kill` signal
* abort     | lethal     | send 'abort' signal

`abort` enables core's to be created with assassination

Resolves #344
Resolves #304