### PR TITLE
http: outbound always send metric on service call

### DIFF
--- a/middleware/http/include/http/outbound/state.h
+++ b/middleware/http/include/http/outbound/state.h
@@ -205,6 +205,8 @@ namespace casual
          {
             void add( const state::pending::Request& request, common::service::Code code);
 
+            void add( common::message::event::service::Metric metric);
+
             explicit operator bool () const noexcept;
 
             void clear();

--- a/middleware/http/source/outbound/state.cpp
+++ b/middleware/http/source/outbound/state.cpp
@@ -128,6 +128,11 @@ namespace casual
          }());
       }
 
+      void State::Metric::add( message::event::service::Metric metric)
+      {
+         m_message.metrics.push_back( std::move( metric));
+      }
+
       State::Metric::operator bool () const noexcept
       {
          return m_message.metrics.size() >= platform::batch::http::outbound::concurrent::metrics;


### PR DESCRIPTION
This commit ensures that the outbound always sends metrics to the service manager even when a call fails immediately due to violated preconditions.

Resolves #397