### PR TITLE
build: add dsl for documentation

### DIFF
--- a/middleware/buffer/makefile.cmk
+++ b/middleware/buffer/makefile.cmk
@@ -1,5 +1,7 @@
 import casual.make.api as make
 import casual.middleware.make.api as dsl
+import os
+
 
 make.IncludePaths( [
    'include',
@@ -189,6 +191,21 @@ install_bin.append( binary)
 make.Install( install_lib,  dsl.paths().install + '/lib')
 make.Install( install_bin,  dsl.paths().install + '/bin')
 make.Install( install_headers,  dsl.paths().install + '/include')
+
+# GenerateDocumentation
+
+
+def casual_buffer_protocol_sample( input):
+    import casual.make.tools.executor as executor
+
+    cmd = "bin/casual-buffer-protocol-sample"
+
+    print(f"Executing {cmd}")
+
+    context_directory = os.path.dirname(input['target'].makefile())
+    executor.command(cmd, directory=context_directory, show_command=False)
+
+dsl.GenerateDocumentation(".", dependencies = [exe_field_sample], generator_function = casual_buffer_protocol_sample)
 
 
 

--- a/middleware/buffer/sample/protocol/field.md
+++ b/middleware/buffer/sample/protocol/field.md
@@ -15,7 +15,7 @@ Every field in the buffer has the following parts: `<field-id><size><data>`
 
 ## example
 
-### host values
+### host representation
 
  type   | field-id     | size value   | value       
 --------|--------------|--------------|------------ 

--- a/middleware/gateway/makefile.cmk
+++ b/middleware/gateway/makefile.cmk
@@ -2,6 +2,8 @@ import unittest
 import casual.make.api as make
 import casual.middleware.make.api as dsl
 
+import os
+
 
 
 make.IncludePaths([
@@ -293,7 +295,7 @@ make.Dependencies( target_unittest, build_executables_for_testing_protocol_v1_2(
 
 
 
-target = make.LinkExecutable( "bin/casual-gateway-markdown-protocol",
+markdown_protocol_target = make.LinkExecutable( "bin/casual-gateway-markdown-protocol",
     [
         make.Compile( 'source/documentation/protocol/markdown.cpp')
     ] + protocol_objects,
@@ -302,7 +304,7 @@ target = make.LinkExecutable( "bin/casual-gateway-markdown-protocol",
         'casual-common'
     ])
 
-install_example_bin.append( target)
+install_example_bin.append( markdown_protocol_target)
 
 target = make.LinkExecutable( "bin/casual-gateway-binary-protocol",
     [
@@ -321,4 +323,16 @@ make.Install( install_example_bin, dsl.paths().install + '/example/bin')
 make.Install( install_bin, dsl.paths().install + '/bin')
 make.Install( install_lib, dsl.paths().install + '/lib')
 
+# GenerateDocumentation
+def casual_gateway_markdown_protocol( input):
+    import casual.make.tools.executor as executor
 
+    output = "documentation/protocol/protocol.maintenance.md"
+    cmd = "bin/casual-gateway-markdown-protocol"
+
+    print(f"Executing {cmd} > {output}")
+
+    context_directory = os.path.dirname(input['target'].makefile())
+    executor.execute_result_to_file(cmd, directory=context_directory, file=output)
+
+dsl.GenerateDocumentation(".", dependencies = [markdown_protocol_target], generator_function = casual_gateway_markdown_protocol)


### PR DESCRIPTION
Added dsl functionality to be able to generate documentation. Used dsl on casual-buffer-protocol-sample and gateway as a POC.

Resolves #355