### PR TITLE
domain: cli add enabled to domain --list-servers/executables

### DIFF
--- a/middleware/administration/unittest/source/cli/test_domain.cpp
+++ b/middleware/administration/unittest/source/cli/test_domain.cpp
@@ -61,9 +61,153 @@ domain:
             {
                return casual::domain::unittest::manager( configuration::base, std::forward< C>( configurations)...);
             }
+
+            auto execute_get_lines( auto command)
+            {
+               return string::split( administration::unittest::cli::command::execute( command).standard.out, '\n');
+            };
+
          } // <unnamed>      
 
       } // local
+
+      TEST( cli_domain, list_servers_executables)
+      {
+         common::unittest::Trace trace;
+         
+         auto domain = local::domain( R"(
+domain:
+   groups:
+      -  name: A
+         dependencies: [ user]
+      -  name: B
+         enabled: false
+         dependencies: [ B]      
+   servers:
+      -  alias: a
+         path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+         memberships: [ A]
+         instances: 2
+         restart: true
+      -  alias: b
+         path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+         memberships: [ B]
+         instances: 2
+      -  alias: c
+         path: "/non/existent/path"
+         memberships: [ A]
+         instances: 2
+   executables:
+      -  alias: t
+         path: sleep
+         arguments: [ 60]
+         memberships: [ A]
+         instances: 0
+         restart: true
+      -  alias: x
+         path: sleep
+         instances: 2
+         arguments: [ 60]
+         memberships: [ A]
+      -  alias: y
+         instances: 2
+         path: sleep
+         arguments: [ 60]
+         memberships: [ B]
+      -  alias: z
+         path: "/non/existent/path"
+         memberships: [ A]
+         instances: 2
+
+)");
+         {
+
+/*
+alias                       CI  I  state     restart  #r  path                                                                              
+--------------------------  --  -  --------  -------  --  ----------------------------------------------------------------------------------
+a                            2  2  enabled      true   0  "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"  
+b                            2  0  disabled    false   0  "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"  
+c                            2  0  error       false   0  "/non/existent/path"                                                              
+casual-domain-discovery      1  1  enabled      true   0  "/Users/lazan/git/casual/1.7/casual/middleware/domain/bin/casual-domain-discovery"
+casual-domain-manager        1  1  enabled     false   0  "casual-domain-manager"                                                           
+casual-gateway-manager       1  1  enabled     false   0  "${CASUAL_MAKE_SOURCE_ROOT}/middleware/gateway/bin/casual-gateway-manager"        
+casual-service-manager       1  1  enabled     false   0  "${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager"        
+casual-transaction-manager   1  1  enabled     false   0  "${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/casual-transaction-manager"
+*/
+            auto lines = local::execute_get_lines(  "casual domain --header false --color false --list-servers");
+
+            auto a = string::adjacent::split( lines.at( 0), ' ');
+            EXPECT_TRUE( a.at( 0) == "a");
+            EXPECT_TRUE( a.at( 1) == "2");
+            EXPECT_TRUE( a.at( 2) == "2");
+            EXPECT_TRUE( a.at( 3) == "enabled");
+            EXPECT_TRUE( a.at( 4) == "true");
+            EXPECT_TRUE( a.at( 5) == "0");
+
+            auto b = string::adjacent::split( lines.at( 1), ' ');
+            EXPECT_TRUE( b.at( 0) == "b");
+            EXPECT_TRUE( b.at( 1) == "2");
+            EXPECT_TRUE( b.at( 2) == "0");
+            EXPECT_TRUE( b.at( 3) == "disabled");
+            EXPECT_TRUE( b.at( 4) == "false");
+            EXPECT_TRUE( b.at( 5) == "0");
+
+            auto c = string::adjacent::split( lines.at( 2), ' ');
+            EXPECT_TRUE( c.at( 0) == "c");
+            EXPECT_TRUE( c.at( 1) == "2");
+            EXPECT_TRUE( c.at( 2) == "0");
+            EXPECT_TRUE( c.at( 3) == "error");
+            EXPECT_TRUE( c.at( 4) == "false");
+            EXPECT_TRUE( c.at( 5) == "0");
+
+         }
+
+         {
+
+/*
+alias  CI  I  state     restart  #r  path                
+-----  --  -  --------  -------  --  --------------------
+t       0  0  enabled      true   0  "sleep"             
+x       2  2  enabled     false   0  "sleep"             
+y       2  0  disabled    false   0  "sleep"             
+z       2  0  error       false   0  "/non/existent/path"
+*/
+            auto lines = local::execute_get_lines( "casual domain --header false --color false --list-executables");
+
+            auto t = string::adjacent::split( lines.at( 0), ' ');
+            EXPECT_TRUE( t.at( 0) == "t");
+            EXPECT_TRUE( t.at( 1) == "0");
+            EXPECT_TRUE( t.at( 2) == "0");
+            EXPECT_TRUE( t.at( 3) == "enabled");
+            EXPECT_TRUE( t.at( 4) == "true");
+            EXPECT_TRUE( t.at( 5) == "0");
+
+            auto x = string::adjacent::split( lines.at( 1), ' ');
+            EXPECT_TRUE( x.at( 0) == "x");
+            EXPECT_TRUE( x.at( 1) == "2");
+            EXPECT_TRUE( x.at( 2) == "2");
+            EXPECT_TRUE( x.at( 3) == "enabled");
+            EXPECT_TRUE( x.at( 4) == "false");
+            EXPECT_TRUE( x.at( 5) == "0");
+
+            auto y = string::adjacent::split( lines.at( 2), ' ');
+            EXPECT_TRUE( y.at( 0) == "y");
+            EXPECT_TRUE( y.at( 1) == "2");
+            EXPECT_TRUE( y.at( 2) == "0");
+            EXPECT_TRUE( y.at( 3) == "disabled");
+            EXPECT_TRUE( y.at( 4) == "false");
+            EXPECT_TRUE( y.at( 5) == "0");
+
+            auto z = string::adjacent::split( lines.at( 3), ' ');
+            EXPECT_TRUE( z.at( 0) == "z");
+            EXPECT_TRUE( z.at( 1) == "2");
+            EXPECT_TRUE( z.at( 2) == "0");
+            EXPECT_TRUE( z.at( 3) == "error");
+            EXPECT_TRUE( z.at( 4) == "false");
+            EXPECT_TRUE( z.at( 5) == "0");
+         }
+
+      }
 
       TEST( cli_domain, scale_out_to_5__expected_configured_instances_5)
       {

--- a/middleware/domain/include/domain/manager/admin/model.h
+++ b/middleware/domain/include/domain/manager/admin/model.h
@@ -63,6 +63,7 @@ namespace casual
 
             } environment;
 
+            bool enabled = true;
             bool restart = false;
             size_type restarts = 0;
 
@@ -74,6 +75,7 @@ namespace casual
                CASUAL_SERIALIZE( note);
                CASUAL_SERIALIZE( memberships);
                CASUAL_SERIALIZE( environment);
+               CASUAL_SERIALIZE( enabled);
                CASUAL_SERIALIZE( restart);
                CASUAL_SERIALIZE( restarts);
             )

--- a/middleware/domain/source/manager/transform.cpp
+++ b/middleware/domain/source/manager/transform.cpp
@@ -203,6 +203,7 @@ namespace casual
                      result.path = value.path;
                      result.arguments = value.arguments;
                      result.note = value.note;
+                     result.enabled = value.enabled;
                      using instance_type = typename R::instance_type;
                      result.instances = algorithm::transform( value.instances, detail::instance< instance_type>());
                      result.memberships = algorithm::transform( value.memberships, []( auto id){


### PR DESCRIPTION
This patch adds a `state` column for --list-servers and --list-executables.

state column can have the following values:

* enabled:  the entity is enabled
* disabled: the entity has explicit/implicit membership to at least one disabled group
* error:    all of the instances has state error

issue #324