### PR TITLE
queue: add --force flag to --remove-message cli

### DIFF
--- a/middleware/queue/include/queue/api/queue.h
+++ b/middleware/queue/include/queue/api/queue.h
@@ -93,7 +93,7 @@ namespace casual
 
       namespace messages
       {
-         std::vector< common::Uuid> remove( const std::string& queue, const std::vector< common::Uuid>& messages);
+         std::vector< common::Uuid> remove( const std::string& queue, const std::vector< common::Uuid>& messages, bool force = false);
       } // messages
 
       } // v1

--- a/middleware/queue/include/queue/common/ipc/message.h
+++ b/middleware/queue/include/queue/common/ipc/message.h
@@ -937,11 +937,13 @@ namespace casual
                   common::strong::queue::id queue;
                   //! messages to remove
                   std::vector< common::Uuid> ids;
+                  bool force = false;
 
                   CASUAL_CONST_CORRECT_SERIALIZE(
                      base_request::serialize( archive);
                      CASUAL_SERIALIZE( queue);
                      CASUAL_SERIALIZE( ids);
+                     CASUAL_SERIALIZE( force);
                   )
                };
 

--- a/middleware/queue/include/queue/group/queuebase.h
+++ b/middleware/queue/include/queue/group/queuebase.h
@@ -164,13 +164,17 @@ namespace casual
          //! @note: only `enqueued` messages are deleted (no pending for commit)
          platform::size::type clear( common::strong::queue::id queue);
 
-         //! @returns total size of messages deleted and id:s of the messages that was removed
+         //! @returns ids of the removed messages
          std::vector< common::Uuid> remove( common::strong::queue::id queue, std::vector< common::Uuid> messages);
+
+         //! @returns ids of the removed messages
+         //! @note removes messages regardless of state
+         std::vector< common::Uuid> force_remove( common::strong::queue::id queue, std::vector< common::Uuid> messages);
 
          //! @returns total size of messages deleted and gtrid:s of the messages that was commited
          std::tuple< platform::size::type, std::vector< common::transaction::global::ID>> recovery_commit( common::strong::queue::id queue, std::vector< common::transaction::global::ID> gtrids);
 
-         //! @returns gtrid:s of the messages that was rollbacked
+         //! @returns total size of messages deleted and gtrids:s of the messages that was rollbacked
          std::tuple< platform::size::type, std::vector< common::transaction::global::ID>> recovery_rollback( common::strong::queue::id queue, std::vector< common::transaction::global::ID> gtrids);
 
          //! @returns total size of messages deleted (committed dequeues)

--- a/middleware/queue/include/queue/group/queuebase/statement.h
+++ b/middleware/queue/include/queue/group/queuebase/statement.h
@@ -76,6 +76,7 @@ namespace casual
          {
             //! arguments: queue, id;
             sql::database::Statement remove;
+            sql::database::Statement force_remove;
          } message;
 
          struct

--- a/middleware/queue/source/api/queue.cpp
+++ b/middleware/queue/source/api/queue.cpp
@@ -646,7 +646,7 @@ namespace casual
 
          namespace messages
          {
-            std::vector< common::Uuid> remove( const std::string& queue, const std::vector< common::Uuid>& messages)
+            std::vector< common::Uuid> remove( const std::string& queue, const std::vector< common::Uuid>& messages, bool force)
             {
                Trace trace{ "casual::queue::messages::remove"};
                common::log::line( verbose::log, "queue: ", queue, ", messages: ", messages);
@@ -654,6 +654,7 @@ namespace casual
                serviceframework::service::protocol::binary::Call call;
                call << CASUAL_NAMED_VALUE( queue);
                call << CASUAL_NAMED_VALUE( messages);
+               call << CASUAL_NAMED_VALUE( force);
 
                auto reply = call( manager::admin::service::name::messages::remove);
 

--- a/middleware/queue/source/group/handle.cpp
+++ b/middleware/queue/source/group/handle.cpp
@@ -179,7 +179,9 @@ namespace casual
                            log::line( verbose::log, "message: ", message);
 
                            auto reply = common::message::reverse::type( message);
-                           reply.ids = state.queuebase.remove( message.queue, std::move( message.ids));
+                           reply.ids = message.force ?
+                              state.queuebase.force_remove( message.queue, std::move( message.ids)) :
+                              state.queuebase.remove( message.queue, std::move( message.ids));
 
                            state.size.current = state.queuebase.size();
 

--- a/middleware/queue/source/group/queuebase.cpp
+++ b/middleware/queue/source/group/queuebase.cpp
@@ -610,6 +610,18 @@ namespace casual
          return messages;
       }
 
+      std::vector< common::Uuid> Queuebase::force_remove( common::strong::queue::id queue, std::vector< common::Uuid> messages)
+      {
+         auto missing_message = [ &]( auto& id)
+         {
+            m_statement.message.force_remove.execute( queue.value(), id.range());
+            return m_connection.affected() == 0;
+         };
+
+         algorithm::container::trim( messages, algorithm::remove_if( messages, missing_message));
+         return messages;
+      }
+
       std::tuple< platform::size::type, std::vector< common::transaction::global::ID>> Queuebase::recovery_commit( common::strong::queue::id queue, std::vector< common::transaction::global::ID> gtrids)
       {
          std::vector< platform::size::type> deleted_sizes{};

--- a/middleware/queue/source/group/queuebase/statement.cpp
+++ b/middleware/queue/source/group/queuebase/statement.cpp
@@ -277,6 +277,10 @@ WHERE queue = :queue AND state = 2 AND timestamp > :timestamp AND available < :a
             DELETE FROM message
             WHERE state = 2 AND queue = :queue AND id = :id; )");
 
+         result.message.force_remove = connection.precompile(R"(
+            DELETE FROM message
+            WHERE queue = :queue AND id = :id; )");
+
          result.metric.reset = connection.precompile(R"( 
             UPDATE queue
             SET metric_dequeued = 0, metric_enqueued = 0

--- a/middleware/queue/source/manager/admin/server.cpp
+++ b/middleware/queue/source/manager/admin/server.cpp
@@ -72,7 +72,7 @@ namespace casual
                   return transform::model::message::meta( { std::move( reply)});
                }  
 
-               std::vector< common::Uuid> remove( manager::State& state, const std::string& queue, std::vector< common::Uuid> ids)
+               std::vector< common::Uuid> remove( manager::State& state, const std::string& queue, std::vector< common::Uuid> ids, bool force)
                {
                   auto found = common::algorithm::find( state.queues, queue);
 
@@ -81,6 +81,7 @@ namespace casual
                      ipc::message::group::message::remove::Request request{ common::process::handle()};
                      request.queue = found->second.front().queue;
                      request.ids = std::move( ids);
+                     request.force = force;
 
                      return communication::ipc::call( found->second.front().process.ipc, request).ids;
                   }
@@ -309,13 +310,15 @@ namespace casual
 
                         auto queue = protocol.extract< std::string>( "queue");
                         auto ids = protocol.extract< std::vector< common::Uuid>>( "ids");
+                        auto force = protocol.extract< bool>( "force");
 
                         return serviceframework::service::user( 
                            std::move( protocol), 
                            &local::messages::remove, 
                            state, 
                            std::move( queue),
-                           std::move( ids));
+                           std::move( ids),
+                           force);
                      };
                   }
                } // messages


### PR DESCRIPTION
This commit introduces the ability to force remove messages from queues regardless of their state (i.e. messages that are either dequeued or enqueued but not committed).

Resolves #267