### PR TITLE
queue: correct runlevel for queue-forward-group

### DIFF
--- a/middleware/queue/source/forward/handle.cpp
+++ b/middleware/queue/source/forward/handle.cpp
@@ -453,6 +453,8 @@ namespace casual
 
                         comply::to::state( state);
 
+                        state.runlevel = decltype( state.runlevel())::running;
+
                         state.multiplex.send( message.process.ipc, common::message::reverse::type( message, process::handle()));
                      };
                   }


### PR DESCRIPTION
Before: casual-queue-forward-group would never reach runlevel::running, remaining in startup until it was shut down.
Now: we set runlevel::running after receiving config from the queue-manager.

Resolves #221