### PR TITLE
queue: add 'signaled' error-code to queue api

### DIFF
--- a/middleware/common/include/common/code/queue.h
+++ b/middleware/common/include/common/code/queue.h
@@ -20,6 +20,7 @@ namespace casual
          no_queue = 10,
          argument = 20,
          system = 30,
+         signaled = 40,
       };
       std::string_view description( code::queue value) noexcept;
 

--- a/middleware/common/source/code/queue.cpp
+++ b/middleware/common/source/code/queue.cpp
@@ -66,6 +66,7 @@ namespace casual
             case code::queue::no_queue: return "no_queue";
             case code::queue::argument: return "argument";
             case code::queue::system: return "system";
+            case code::queue::signaled: return "signaled";
          }
          return "<unknown>";
       }

--- a/middleware/queue/include/casual/queue/c/queue.h
+++ b/middleware/queue/include/casual/queue/c/queue.h
@@ -39,6 +39,7 @@ typedef struct casual_buffer_t casual_buffer_t;
 #define CASUAL_QE_NO_QUEUE 10
 #define CASUAL_QE_INVALID_ARGUMENTS 20
 #define CASUAL_QE_SYSTEM 30
+#define CASUAL_QE_SIGNALED 40
 
 
 extern int casual_queue_get_errno();

--- a/middleware/queue/source/c/queue.cpp
+++ b/middleware/queue/source/c/queue.cpp
@@ -22,6 +22,7 @@
 #include "common/buffer/pool.h"
 #include "common/execute.h"
 #include "common/code/queue.h"
+#include "common/code/signal.h"
 
 namespace casual
 {
@@ -51,6 +52,10 @@ namespace casual
                   if( common::code::is::category< common::code::queue>( error.code()))
                   {
                      global::code = static_cast< common::code::queue>( error.code().value());
+                  }
+                  else if( common::code::is::category< common::code::signal>( error.code()))
+                  {
+                     global::code = common::code::queue::signaled;
                   }
                   else
                   {
@@ -395,6 +400,7 @@ namespace casual
                case CASUAL_QE_NO_QUEUE : return "CASUAL_QE_NO_QUEUE";
                case CASUAL_QE_INVALID_ARGUMENTS: return "CASUAL_QE_INVALID_ARGUMENTS"; 
                case CASUAL_QE_SYSTEM: return "CASUAL_QE_SYSTEM";
+               case CASUAL_QE_SIGNALED: return "CASUAL_QE_SIGNALED";
             }
 
             return "<unknown>";


### PR DESCRIPTION
This commit adds the 'CASUAL_QE_SIGNALED' error code to the queue C-api, to be returned when a call fails due to a signal interrupt.

Resolves #291