### PR TITLE
service: refactoring service-manager - reference based -> index based

### DIFF
--- a/middleware/common/include/casual/container.h
+++ b/middleware/common/include/casual/container.h
@@ -22,8 +22,17 @@ namespace casual
 {
    namespace container
    {
+      namespace detail
+      {
+         namespace id
+         {
+            struct Tag{};
+            using type = common::strong::detail::integral::Type< platform::size::type, Tag, -1>;
+         } // id
+      
+      } // detail
 
-      template< typename T, typename I>
+      template< typename T, typename I = detail::id::type>
       struct Index
       {
          using value_type = T;
@@ -54,54 +63,91 @@ namespace casual
 
          void erase( index_type key)
          {
-            CASUAL_ASSERT( key.value() < std::ssize( m_data));
+            validate_index( key);
             m_data[ key.value()] = std::nullopt;
          }
 
-         const std::optional< value_type>& find( index_type key) const &
-         {
-            CASUAL_ASSERT( key.value() < std::ssize( m_data));
-            return m_data[ key.value()];
-         }
 
-         std::optional< value_type>& find( index_type key) &
+         [[nodiscard]] bool contains( index_type key) const
          {
-            CASUAL_ASSERT( key.value() < std::ssize( m_data));
-            return m_data[ key.value()];
+            if( ! valid_index( key))
+               return false;
+
+            return m_data[ key.value()].has_value();
          }
 
 
          value_type& operator [] ( index_type key) &
          {
-            auto& result = find( key);
-            CASUAL_ASSERT( result);
-            return *result;
+            if( ! contains( key))
+               common::code::raise::error( common::code::casual::invalid_argument, "out of bounds: ", key);
+
+            return *m_data[ key.value()];
          }
 
          const value_type& operator [] ( index_type key) const &
          {
-            auto& result = find( key);
-            CASUAL_ASSERT( result);
-            return *result;
+            if( ! contains( key))
+               common::code::raise::error( common::code::casual::invalid_argument, "out of bounds: ", key);
+
+            return *m_data[ key.value()];
          }
 
          std::optional< value_type> extract( index_type key) &
          {
-            CASUAL_ASSERT( key.value() < std::ssize( m_data));
+            validate_index( key);
             return std::exchange( m_data[ key.value()], {});
          }
 
+         //! @returns all values
+         auto values() const
+         {
+            auto has_value = []( auto& value){ return value.has_value();};
+            auto transform = []( auto& value) -> decltype( *value) { return *value;};
+            
+            return m_data | std::ranges::views::filter( has_value) | std::ranges::views::transform( transform);
+         }
 
-         auto size() const noexcept { return m_data.size();}
-         auto empty() const noexcept { return m_data.empty();}
+         auto indexes() const
+         {            
+            return common::algorithm::accumulate( m_data, std::vector< index_type>{}, [ index = platform::size::type{ 0}]( auto result, auto& value) mutable
+            {
+               if( value)
+                  result.push_back( index_type( index));
+                  
+               ++index;
+               return result;
+            });   
 
-         auto begin() noexcept { return std::begin( m_data);}
-         auto end() noexcept { return std::begin( m_data);}
-         auto begin() const noexcept { return std::begin( m_data);}
-         auto end() const noexcept { return std::begin( m_data);}
-         
+            // Missing enumerate
+            // auto has_value = []( auto index, auto& value){ return value.has_value();};
+            // auto transform = []( auto index, auto& value) -> index_type { return index_type( index);};
+            // return m_data | std::views::enumerate | std::ranges::views::filter( has_value) | std::ranges::views::transform( transform);
+
+
+         }
+
+
+         auto size() const -> platform::size::type { return m_data.size();}
+         auto empty() const { return m_data.empty();}
+
+         auto begin() { return std::begin( m_data);}
+         auto end() { return std::end( m_data);}
+         auto begin() const { return std::begin( m_data);}
+         auto end() const { return std::end( m_data);}
 
       private:
+         bool valid_index( index_type key) const
+         {
+            return key.value() >= 0 && key.value() < std::ssize( m_data);
+         }
+
+         void validate_index( index_type key) const
+         {
+            if( ! valid_index( key))
+               common::code::raise::error( common::code::casual::invalid_argument, "out of bounds: ", key);
+         }
+
          std::vector< std::optional< value_type>> m_data;
       };
 
@@ -112,17 +158,31 @@ namespace casual
 
          index_type insert( lookup_type key, T value)
          {
+            if( auto id = lookup( key))
+            {
+               m_index[ id] = std::move( value);
+               return id;
+            }
+
             auto id = m_index.insert( std::move( value));
             m_lookup.emplace( std::move( key), id);
             return id;
+
          }
 
          template< typename... Ts>
          index_type emplace( lookup_type key, Ts&&... ts)
          {
+            if( auto id = lookup( key))
+            {
+               m_index[ id] = T( std::forward< Ts>( ts)...);
+               return id;
+            }
+
             auto id = m_index.emplace( std::forward< Ts>( ts)...);
             m_lookup.emplace( std::move( key), id);
             return id;
+
          }
 
          index_type lookup( const lookup_type& key) const
@@ -130,6 +190,11 @@ namespace casual
             if( auto found = common::algorithm::find( m_lookup, key))
                return found->second;
             return {};
+         }
+
+         [[nodiscard]] bool contains( index_type key) const 
+         {
+            return m_index.contains( key);
          }
          
          value_type& operator [] ( index_type key) &
@@ -141,6 +206,7 @@ namespace casual
          {
             return m_index[ key];
          }
+
          std::optional< value_type> extract( index_type key) &
          {
             if( auto found = common::algorithm::find_if( m_lookup, [ key]( auto& pair){ return pair.second == key;}))
@@ -151,14 +217,14 @@ namespace casual
 
          void erase_if( auto callback)
          {
-            for( auto current = std::begin( m_lookup); current != std::end( m_lookup); ++current)
+            common::algorithm::container::erase_if( m_lookup, [ this, callback]( auto& pair)
             {
-               if( callback( current->second, current->first, m_index[ current->second]))
-               {
-                  m_index.erase( current->second);
-                  m_lookup.erase( current);
-               }
-            }
+               if( ! callback( pair.second, pair.first, m_index[ pair.second]))
+                  return false;
+               
+               m_index.erase( pair.second);
+               return true;
+            });
          }
 
          void for_each( auto callback)
@@ -180,6 +246,21 @@ namespace casual
             if( auto found = common::algorithm::find_if( m_lookup, [ key]( auto& pair){ return pair.second == key;}))
                m_lookup.erase( std::begin( found)); 
          }
+
+         //! @returns all 'occupied' indexes
+         auto indexes() const
+         {
+            return m_index.indexes();
+         }
+
+         //! @returns all values
+         auto values() const
+         {
+            return m_index.values();
+         }
+
+         auto size() const noexcept { return m_lookup.size();}
+         auto empty() const noexcept { return m_lookup.empty();}
 
          CASUAL_LOG_SERIALIZE(
             CASUAL_SERIALIZE( m_index);

--- a/middleware/common/include/common/algorithm/random.h
+++ b/middleware/common/include/common/algorithm/random.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "casual/concepts.h"
+#include "common/range.h"
 
 #include <random>
 #include <algorithm>
@@ -28,7 +29,7 @@ namespace casual
          return container;
       }
 
-      template< typename R>
+      template< concepts::range R>
       auto shuffle( R&& range)
       {
          std::ranges::shuffle( range, random::generator());
@@ -40,6 +41,18 @@ namespace casual
       T value()
       {
          return std::uniform_int_distribution< T>{ min, max}( random::generator());
+      }
+
+      //! @returns a range with size 1 where begin is a random place in `range`
+      auto next( concepts::range auto&& range) -> decltype( range::make( range))
+      {
+         if( std::empty( range))
+            return {};
+
+         auto distribution = std::uniform_int_distribution< platform::size::type>{ 0, std::ssize( range) - 1};
+         auto begin = std::next( std::begin( range), distribution( random::generator()));
+
+         return range::make( begin, std::next( begin));
       }
       
    } // common::algorithm::random

--- a/middleware/common/include/common/range.h
+++ b/middleware/common/include/common/range.h
@@ -14,6 +14,7 @@
 
 #include <iterator>
 #include <concepts>
+#include <span>
 #include <cassert>
 
 namespace casual 
@@ -81,6 +82,8 @@ namespace casual
 
          constexpr reference at( const difference_type index) { return at( m_first, m_last, index);}
          constexpr const reference at( const difference_type index) const { return at( m_first, m_last, index);}
+
+         operator std::span< value_type> () const noexcept { return std::span< value_type>( data(), size());}
 
       private:
 

--- a/middleware/common/makefile.cmk
+++ b/middleware/common/makefile.cmk
@@ -220,6 +220,8 @@ unittest_objectfiles = [
     
     make.Compile( 'unittest/source/test_algorithm.cpp'),
 
+    make.Compile( 'unittest/source/container/test_index.cpp'),
+
     make.Compile( 'unittest/source/test_code.cpp'),
 
     make.Compile( 'unittest/source/test_range.cpp'),

--- a/middleware/common/unittest/source/container/test_index.cpp
+++ b/middleware/common/unittest/source/container/test_index.cpp
@@ -62,24 +62,32 @@ namespace casual
    {
       common::unittest::Trace trace;
 
+      auto count_values = []( auto& index)
+      {
+         return std::ranges::count_if( index, []( auto& value){ return value.has_value();});
+      };
+
       container::Index< char> data;
       auto a = data.insert( 'a');
       auto b = data.insert( 'b');
       auto c = data.insert( 'c');
 
+
       EXPECT_TRUE( b.value() == 1);
 
       data.erase( a);
-      EXPECT_TRUE( data.size() == 2);
+      EXPECT_TRUE( count_values( data) == 2);
 
       data.erase( c);
-      EXPECT_TRUE( data.size() == 1);
+      EXPECT_TRUE( count_values( data) == 1);
 
       auto x = data.insert( 'x');
       EXPECT_TRUE( x.value() == 0);
 
       auto y = data.insert( 'y');
       EXPECT_TRUE( y.value() == 2);
+
+      EXPECT_TRUE( count_values( data) == 3);
    }
 
    

--- a/middleware/common/unittest/source/test_conformance.cpp
+++ b/middleware/common/unittest/source/test_conformance.cpp
@@ -19,13 +19,13 @@
 #include "common/file.h"
 
 #include <type_traits>
-
-
+#include <ranges>
 
 #include <spawn.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <csignal>
+
 
 
 //
@@ -492,8 +492,6 @@ namespace casual
          }
 
       }
-
-
 
 
       /*

--- a/middleware/configuration/include/configuration/model.h
+++ b/middleware/configuration/include/configuration/model.h
@@ -241,7 +241,7 @@ namespace casual::configuration
             std::optional< platform::time::unit> duration;
             std::optional< Contract> contract;
 
-            Timeout set_union( Timeout lhs, Timeout rhs);
+            friend Timeout set_union( Timeout lhs, Timeout rhs);
 
             friend auto operator <=> ( const Timeout&, const Timeout&) = default;
             inline explicit operator bool() const noexcept { return duration.has_value();}

--- a/middleware/service/include/service/manager/admin/model.h
+++ b/middleware/service/include/service/manager/admin/model.h
@@ -46,6 +46,16 @@ namespace casual
                busy,
             };
 
+            constexpr std::string_view description( State value) noexcept
+            {
+               switch( value)
+               {
+                  case State::idle: return "idle";
+                  case State::busy: return "busy";
+               }
+               return "<unknown>";
+            }
+
             State state = State::busy;
 
             CASUAL_CONST_CORRECT_SERIALIZE(

--- a/middleware/service/include/service/manager/handle.h
+++ b/middleware/service/include/service/manager/handle.h
@@ -28,11 +28,6 @@ namespace casual
          common::communication::ipc::inbound::Device& device();
       } // ipc
 
-      namespace comply
-      {
-         void configuration( State& state, casual::configuration::Model model);
-      } // comply
-
       void timeout( State& state);
 
       namespace metric

--- a/middleware/service/include/service/manager/state.h
+++ b/middleware/service/include/service/manager/state.h
@@ -19,6 +19,8 @@
 
 #include "configuration/model.h"
 
+#include "casual/container.h"
+
 #include <vector>
 #include <string>
 #include <unordered_map>
@@ -31,14 +33,65 @@ namespace casual
 {
    namespace service::manager
    {
+      struct State;
+      
       namespace state
       {
+         template< typename Tag>
+         struct id_policy
+         {
+            constexpr static platform::size::type initialize() noexcept { return -1;}
+            constexpr static bool valid( platform::size::type value) noexcept { return value != -1;}
+         };
+
          using ipc_range_type = common::range::const_type_t< std::vector< common::strong::ipc::id>>;
 
-         struct Service;
+         namespace service
+         {
+            namespace id
+            {
+               struct Tag{};
+               using type = common::strong::Type< platform::size::type, state::id_policy< Tag>>;
+            } // id
+            
+         } // service
 
          namespace instance
          {
+            namespace sequential
+            {
+               namespace id
+               {
+                  struct Tag{};
+                  using type = common::strong::Type< platform::size::type, state::id_policy< Tag>>;
+               } // id
+
+               enum class State : short
+               {
+                  idle,
+                  busy,
+               };
+               std::string_view description( State value) noexcept;
+
+               
+            } // sequential
+
+            namespace concurrent
+            {
+               namespace id
+               {
+                  struct Tag{};
+                  using type = common::strong::Type< platform::size::type, state::id_policy< Tag>>;
+               } // id
+
+               using Property = common::message::service::concurrent::advertise::service::Property;
+
+            } // concurrent
+            
+            template< typename T>
+            constexpr bool is_concurrent = std::same_as< concurrent::id::type, T>;
+
+
             struct Caller
             {
                common::process::Handle process;
@@ -64,49 +117,35 @@ namespace casual
 
                CASUAL_LOG_SERIALIZE(
                   CASUAL_SERIALIZE( process);
+                  CASUAL_SERIALIZE( alias);
                )
+
+
             };
-
-            namespace sequential
-            {
-               enum class State : short
-               {
-                  idle,
-                  busy,
-               };
-               std::string_view description( State value) noexcept;
-               
-            } // sequential
-
 
             struct Sequential : base_instance
             {
                using base_instance::base_instance;
 
                void reserve( 
-                  state::Service* service,
+                  service::id::type service,
                   const common::process::Handle& caller,
                   const common::strong::correlation::id& correlation);
 
-               void unreserve( const common::message::event::service::Metric& metric);
+               //! unreserve the instance, @return the service that was used
+               service::id::type unreserve();
 
                //! discards the reservation
                void discard();
 
                sequential::State state() const;
-               inline bool idle() const { return m_service == nullptr;}
+               inline bool idle() const { return ! common::predicate::boolean( m_reserved_service);}
 
                //! Return true if this instance exposes the service
-               bool service( const std::string& name) const;
+               bool service( service::id::type service) const;
 
-               //! removes this instance from all services
-               //! @returns all associated service names that after the detach has no instances (this instance was the last/only)
-               std::vector< std::string> detach();
-
-               void add( state::Service& service);
-               void remove( const std::string& service);
-               //! removes service from associated 
-               void remove( const state::Service* service, state::Service* replacement);
+               void add( service::id::type service);
+               void remove( service::id::type service);
 
                //! @returns and consumes associated caller to the correlation. 'empty' caller if not found.
                inline instance::Caller consume( const common::strong::correlation::id& correlation)
@@ -120,20 +159,22 @@ namespace casual
                inline const auto& caller() const noexcept { return m_caller;}
 
                //! @returns the name of the reserved service if a reservation exists
-               std::optional< std::string> reserved_service() const;
+               inline service::id::type reserved_service() const noexcept { return m_reserved_service;}
+
+               const auto& services() const noexcept { return m_services;}
 
                CASUAL_LOG_SERIALIZE(
-                  base_instance::serialize( archive);   
-                  CASUAL_SERIALIZE_NAME( m_service, "service");
-                  CASUAL_SERIALIZE_NAME( m_caller, "caller");
-                  CASUAL_SERIALIZE_NAME( m_services, "services");
+                  base_instance::serialize( archive);
+                  CASUAL_SERIALIZE( m_reserved_service);
+                  CASUAL_SERIALIZE( m_caller);
+                  CASUAL_SERIALIZE( m_services);
                )
 
             private:
-               state::Service* m_service = nullptr;
+               service::id::type m_reserved_service{};
                instance::Caller m_caller;
                // all associated services
-               std::vector< state::Service*> m_services;
+               std::vector< service::id::type> m_services;
             };
 
             struct Concurrent : base_instance
@@ -184,8 +225,8 @@ namespace casual
                      platform::time::point::type when;
                      common::strong::correlation::id correlation;
                      //! The actual instance that the timeout refers to.
-                     common::strong::process::id target{};
-                     state::Service* service = nullptr;
+                     instance::sequential::id::type target;
+                     service::id::type service;
 
                      inline friend bool operator < ( const Entry& lhs, const Entry& rhs) { return lhs.when < rhs.when;}
                      inline friend bool operator == ( const Entry& lhs, const common::strong::correlation::id& rhs) { return lhs.correlation == rhs;}
@@ -230,73 +271,37 @@ namespace casual
                };
             } // pending
 
-            namespace instance
+            namespace instances
             {
 
-               using local_base = std::reference_wrapper< state::instance::Sequential>;
-
-               //! Just a helper to simplify usage of the reference
-               struct Sequential : local_base
+               struct Concurrent
                {
-                  using local_base::local_base;
+                  instance::concurrent::id::type id;
+                  platform::size::type order{};
+                  platform::size::type hops{};
 
-                  inline bool idle() const { return get().idle();}
-
-                  inline auto& reserve(                      
-                     state::Service* service,
-                     const common::process::Handle& caller,
-                     const common::strong::correlation::id& correlation)
-                  {
-                     get().reserve( service, caller, correlation);
-                     return get().process;
-                  }
-
-                  inline const common::process::Handle& process() const { return get().process;}
-                  inline auto state() const { return get().state();}
-
-                  inline friend bool operator == ( const Sequential& lhs, common::process::compare_equal_to_handle auto rhs) { return lhs.process() == rhs;}
+                  inline friend bool operator < ( const Concurrent& lhs, const Concurrent& rhs) { return std::tie( lhs.order, lhs.hops) < std::tie( rhs.order, rhs.hops);}
+                  inline friend bool operator == ( const Concurrent& lhs, instance::concurrent::id::type rhs) { return lhs.id == rhs;}
 
                   CASUAL_LOG_SERIALIZE(
-                     get().serialize( archive);
+                     CASUAL_SERIALIZE( id);
+                     CASUAL_SERIALIZE( order);
+                     CASUAL_SERIALIZE( hops);
                   )
                };
-
-               using remote_base = std::reference_wrapper< state::instance::Concurrent>;
-
-               //! Just a helper to simplify usage of the reference
-               struct Concurrent : remote_base, common::Compare< Concurrent>
-               {
-                  using Property = common::message::service::concurrent::advertise::service::Property;
-
-                  Concurrent( state::instance::Concurrent& instance, Property property) : remote_base{ instance}, property{ property} {}
-
-                  inline const common::process::Handle& process() const { return get().process;}
-
-                  inline friend bool operator == ( const Concurrent& lhs, common::process::compare_equal_to_handle auto rhs) { return lhs.process() == rhs;}
-                  
-                  //! for common::Compare. The configured services are 'worth more' than not configured. 
-                  inline auto tie() const { return std::tie( get().order, property.hops);}
-
-                  CASUAL_LOG_SERIALIZE(
-                     get().serialize( archive);
-                     CASUAL_SERIALIZE( property);
-                  )
-
-                  Property property;
-
-               };
-            } // instance
-
-
+               
+            } // instances
+          
             struct Instances
             {
-               void add( state::instance::Concurrent& instance, state::service::instance::Concurrent::Property property);
+               void add( state::instance::sequential::id::type instance);
+               void add( state::instance::concurrent::id::type instance, platform::size::type order, state::instance::concurrent::Property property);
 
-               void remove( const common::strong::ipc::id& ipc, const std::string& service);
-               void remove( const common::strong::ipc::id& ipc);
+               //! @return true if there are no instances left after the removal
+               bool remove( instance::sequential::id::type id);
+               //! @return true if there are no instances left after the removal
+               bool remove( instance::concurrent::id::type id);
 
-               //! removes service from associated 
-               void remove( const state::Service* service, state::Service* replacement);
 
                inline bool has_sequential() const noexcept { return ! m_sequential.empty();}
                inline bool has_concurrent() const noexcept { return ! m_concurrent.empty();}
@@ -304,12 +309,9 @@ namespace casual
                inline bool empty() const noexcept { return m_sequential.empty() && m_concurrent.empty();}
                inline explicit operator bool() const noexcept { return ! empty();}
 
-               //! @returns and consumes associated caller to the correlation. 'empty' caller if not found.
-               state::instance::Caller consume( const common::strong::correlation::id& correlation);
-
                //! @returns the first concurrent instance that in the preferred range
                //!   Otherwise, the first instance, and rotate.
-               state::service::instance::Concurrent* next_concurrent( ipc_range_type preferred) noexcept;
+               instance::concurrent::id::type next_concurrent( std::span< instance::concurrent::id::type> preferred) noexcept;
 
                void update_prioritized();
 
@@ -321,15 +323,13 @@ namespace casual
                   CASUAL_SERIALIZE( m_concurrent);
                )
 
-               friend Service;
-
             private:
 
                void prioritize() noexcept;
 
-               std::vector< state::service::instance::Sequential> m_sequential;
-               std::vector< state::service::instance::Concurrent> m_concurrent;
-               common::range::type_t< std::vector< state::service::instance::Concurrent>> m_prioritized_concurrent;
+               std::vector< instance::sequential::id::type> m_sequential;
+               std::vector< instances::Concurrent> m_concurrent;
+               std::span< instances::Concurrent> m_prioritized_concurrent;
             };
 
             struct Metric
@@ -367,45 +367,113 @@ namespace casual
             casual::configuration::model::service::Timeout timeout{};
             common::service::transaction::Type transaction = common::service::transaction::Type::automatic;
             std::optional< common::service::visibility::Type> visibility;
-            service::Metric metric{};
             std::string category{};
             
-
-            void remove( const common::strong::ipc::id& ipc);
-
-            void add( state::instance::Sequential& instance);
-            void add( state::instance::Concurrent& instance, state::service::instance::Concurrent::Property property);
-
-            common::process::Handle reserve_sequential( 
-               const common::process::Handle& caller, 
-               const common::strong::correlation::id& correlation);
-            
-            //! @return a reserved instance or 'null-handle' if no one is found.
-            common::process::Handle reserve_concurrent( ipc_range_type preferred);
-
             inline bool has_sequential() const noexcept { return instances.has_sequential();}
             inline bool has_concurrent() const noexcept { return instances.has_concurrent();}
             inline bool has_instances() const noexcept { return ! instances.empty();}
+            inline bool is_concurrent_only() const noexcept { return has_concurrent() && ! has_sequential();}
 
             bool is_discoverable() const noexcept;
 
             bool timeoutable() const noexcept;
 
-
             //! @returns the concurrent property of the service, "empty" property if not applicable.
-            service::instance::Concurrent::Property property() const noexcept;
+            instance::concurrent::Property property() const noexcept;
 
             //! @returns and consumes associated caller to the correlation. 'empty' caller if not found.
-            inline auto consume( const common::strong::correlation::id& correlation) { return instances.consume( correlation);}
+            //inline auto consume( const common::strong::correlation::id& correlation) { return instances.consume( correlation);}
+
+            //! equal to service name
+            inline friend bool operator == ( const Service& lhs, const std::string& name) noexcept { return lhs.information.name == name;}
 
             CASUAL_LOG_SERIALIZE(
                CASUAL_SERIALIZE( information);
                CASUAL_SERIALIZE( instances);
                CASUAL_SERIALIZE( timeout);
                CASUAL_SERIALIZE( visibility);
-               CASUAL_SERIALIZE( metric);
                CASUAL_SERIALIZE( category);
                
+            )
+         };
+
+         //! holder for service lookup, service metric and such
+         struct Services
+         {
+            
+            //! insert the serves (if not present), add service name as the lookup (service without routes)
+            state::service::id::type insert( state::Service service);
+            //! insert the serves (if not present), add routes to lookup for the service
+            state::service::id::type insert( state::Service service, const std::vector< std::string>& routes);
+
+            //! @attention slow - only use during configuration
+            void erase( state::service::id::type id);
+            //! remove all current lookup names to the `id` and add the service.name as a lookup
+            //! @attention slow - only use during configuration
+            void restore_origin_name( state::service::id::type id);
+            //! replaces all lookup to the `id` 
+            //! @attention slow - only use during configuration
+            void replace_routes( state::service::id::type id, const std::vector< std::string>& routes);
+
+            state::service::id::type lookup( const std::string& name) const;
+            //! lookup the service by using the origin name the service was advertised as
+            //! @attention slow - only use during configuration
+            state::service::id::type lookup_origin( const std::string& name) const;
+
+            //! @returns all names for the service
+            std::vector< std::string> names( state::service::id::type id) const;
+
+            inline state::Service& operator [] ( state::service::id::type id) & { return m_services[ id];}
+            inline const state::Service& operator [] ( state::service::id::type id) const & { return m_services[ id];}
+
+            service::Metric& metric( const std::string& service);
+            inline auto& metrics() const { return m_metrics;}
+
+            inline auto indexes() const { return m_services.indexes();}
+            inline bool contains( state::service::id::type id) const { return m_services.contains( id);}
+
+            inline void for_each( auto callback) const
+            {
+               for( auto& pair : m_lookup)
+                  callback( pair.second, pair.first, m_services[ pair.second]);
+            }
+
+            inline void for_each( auto callback)
+            {
+               for( auto& pair : m_lookup)
+                  callback( pair.second, pair.first, m_services[ pair.second]);
+            }
+
+            CASUAL_LOG_SERIALIZE(
+               CASUAL_SERIALIZE( m_lookup);
+               CASUAL_SERIALIZE( m_services);
+               CASUAL_SERIALIZE( m_metrics);
+            )
+
+            friend struct manager::State;
+
+         private:
+            //! holds the name -> id mapping, for all exposed services, including routes
+            //! several names can refer to the same service-id
+            std::unordered_map< std::string, state::service::id::type> m_lookup;
+
+            //! holds the actual services
+            casual::container::Index< state::Service, state::service::id::type> m_services;
+
+            std::unordered_map< std::string, service::Metric> m_metrics;
+         };
+
+         struct Instances
+         {
+            casual::container::lookup_index< instance::Sequential, instance::sequential::id::type, common::strong::ipc::id> sequential;
+            casual::container::lookup_index< instance::Concurrent, instance::concurrent::id::type, common::strong::ipc::id> concurrent;
+
+            void remove_service( instance::sequential::id::type instance_id, service::id::type service_id);
+            inline void remove_service( instance::concurrent::id::type, service::id::type) { /*no op*/}
+
+            CASUAL_LOG_SERIALIZE(
+               CASUAL_SERIALIZE( sequential);
+               CASUAL_SERIALIZE( concurrent);
             )
          };
 
@@ -429,23 +497,9 @@ namespace casual
          common::communication::ipc::send::Coordinator multiplex{ directive};
 
          //! holds the total known services, including routes
-         std::unordered_map< std::string, state::Service> services;
+         state::Services services;
 
-         struct
-         {
-            template< typename T>
-            using instance_mapping_type = std::unordered_map< common::strong::ipc::id, T>;
-
-            instance_mapping_type< state::instance::Sequential> sequential;
-            instance_mapping_type< state::instance::Concurrent> concurrent;
-
-            CASUAL_LOG_SERIALIZE(
-               CASUAL_SERIALIZE( sequential);
-               CASUAL_SERIALIZE( concurrent);
-            )
-
-         } instances;
-
+         state::Instances instances;
 
          struct
          {
@@ -462,7 +516,7 @@ namespace casual
 
          struct
          {
-            std::unordered_map< common::transaction::global::ID, std::vector< common::strong::ipc::id>> associations;
+            std::unordered_map< common::transaction::global::ID, std::vector< state::instance::concurrent::id::type>> associations;
 
             CASUAL_LOG_SERIALIZE(
                CASUAL_SERIALIZE( associations);
@@ -496,7 +550,12 @@ namespace casual
 
          // TODO merge this to a timeout { duration, instances} 
          casual::configuration::model::service::Timeout timeout;
+         //! TODO this should be with correlation instead of instance
          std::vector< common::strong::process::id> timeout_instances;
+
+         //! instances that is in "shutdown" mode. We just keep track of them here
+         //! until they're gone to prevent advertising new services and such
+         std::vector< state::instance::sequential::id::type> disabled;
 
          //! holds all the routes, for services that has routes
          std::map< std::string, std::vector< std::string>> routes;
@@ -509,29 +568,43 @@ namespace casual
 
          //! @returns true if we're ready to shutdown
          bool done() const noexcept;
-
-
-         //! find a service from name
-         //! @param name of the service wanted
-         //! @return pointer to service, nullptr if not found
-         //! @{
-         [[nodiscard]] state::Service* service( const std::string& name) noexcept;
-         [[nodiscard]] const state::Service* service( const std::string& name) const noexcept;
-         //! @}
-
-         //! find service from an `origin` service name
-         //! @param name of the service wanted
-         //! @return pointer to service, nullptr if not found
-         //[[nodiscard]] state::Service* origin_service( const std::string& origin);
          
          //! removes the instance (deduced from `pid`) and remove the instance from all services 
-         void remove( common::strong::process::id pid);
-         void remove( common::strong::ipc::id ipc);
+         //! @returns possible callers to that waits for reply from the removed instance (in practice 0..1)
+         [[nodiscard]] std::vector< state::instance::Caller> remove( common::strong::process::id pid);
+         //! @returns possible caller to the remove instance
+         std::vector< state::instance::Caller> remove( common::strong::ipc::id ipc);
+
+         //! Tries to reserve a sequential instance for the given `service`
+         //! @return id of the instance, or 'nil-id' if no idle is found
+         state::instance::sequential::id::type reserve_sequential( 
+            state::service::id::type service,
+            const common::process::Handle& caller, 
+            const common::strong::correlation::id& correlation);
+            
+         //! @return a reserved instance for the given `service` 
+         //!   or 'nil-id' if no one is found.
+         state::instance::concurrent::id::type reserve_concurrent( 
+            state::service::id::type service,
+            std::span< state::instance::concurrent::id::type> preferred);
+
+         void unreserve( state::instance::sequential::id::type instance, const common::message::event::service::Metric& metric);
 
 
-         using prepare_shutdown_result = std::tuple< std::vector< std::string>, std::vector< state::instance::Sequential>, std::vector< common::process::Handle>>;
+         struct prepare_shutdown_result
+         {
+            std::vector< std::string> services;
+            std::vector< state::instance::sequential::id::type> instances;
+            std::vector< common::process::Handle> unknown;
+
+            CASUAL_LOG_SERIALIZE(
+               CASUAL_SERIALIZE( services);
+               CASUAL_SERIALIZE( instances);
+               CASUAL_SERIALIZE( unknown);
+            )
+         };
+
          //! removes and extract all instances (deduced from `pid`) from all services
-         //! @returns a tuple of (origin) services with no instances - extracted sequential instances - unknown processes
          [[nodiscard]] prepare_shutdown_result prepare_shutdown( std::vector< common::process::Handle> processes);
 
          //! adds or "updates" service
@@ -542,16 +615,13 @@ namespace casual
          //! @}
 
          //! @returns the previously associated "instances" to the `gtrid`, if any.
-         std::vector< common::strong::ipc::id> disassociate( common::transaction::global::id::range gtrid);
+         std::vector< state::instance::concurrent::id::type> disassociate( common::transaction::global::id::range gtrid);
 
          //! Resets metrics for the provided services, if empty all metrics are reset.
          //! @param services
          //!
          //! @return the services that was reset.
          std::vector< std::string> metric_reset( std::vector< std::string> services);
-
-         //! @returns a sequential (local) instances that has the `ipc`, or nullptr if absent.
-         [[nodiscard]] state::instance::Sequential* sequential( common::strong::ipc::id ipc);
 
          void connect_manager( std::vector< common::server::Service> services);
 
@@ -560,6 +630,7 @@ namespace casual
             CASUAL_SERIALIZE( directive);
             CASUAL_SERIALIZE( multiplex);
             CASUAL_SERIALIZE( services);
+            CASUAL_SERIALIZE( instances);
             CASUAL_SERIALIZE( pending);
             CASUAL_SERIALIZE( transaction);
             CASUAL_SERIALIZE( events);
@@ -567,6 +638,7 @@ namespace casual
             CASUAL_SERIALIZE( forward);
             CASUAL_SERIALIZE( timeout);
             CASUAL_SERIALIZE( routes);
+            CASUAL_SERIALIZE( disabled);
             CASUAL_SERIALIZE( restriction);
             
          ) 

--- a/middleware/service/source/manager/main.cpp
+++ b/middleware/service/source/manager/main.cpp
@@ -7,6 +7,7 @@
 
 #include "service/manager/state.h"
 #include "service/manager/handle.h"
+#include "service/manager/configuration.h"
 #include "service/forward/instance.h"
 #include "service/common.h"
 
@@ -52,7 +53,7 @@ namespace casual
                State state;
 
                // We ask the domain manager for configuration, and 'comply' to it...
-               handle::comply::configuration( state, casual::domain::configuration::fetch());
+               configuration::conform( state, {}, casual::domain::configuration::fetch().service);
 
                // register so domain-manager can fetch configuration from us, and indicate that we can handle
                // runtime configuration updates.

--- a/middleware/service/source/manager/state.cpp
+++ b/middleware/service/source/manager/state.cpp
@@ -152,7 +152,7 @@ namespace casual
                if( auto found = algorithm::find_first_of( m_prioritized_concurrent, preferred))
                   return found->id;
 
-               return std::ranges::rotate( m_prioritized_concurrent, std::next( std::begin( m_prioritized_concurrent))).front().id;
+               return algorithm::random::next( m_prioritized_concurrent)->id;
             }
 
             void Instances::update_prioritized()
@@ -171,8 +171,6 @@ namespace casual
 
                // find the range/end of the most prioritized group/partition.
                m_prioritized_concurrent = std::get< 0>( algorithm::sorted::upper_bound( m_concurrent, range::front( m_concurrent)));
-               algorithm::random::shuffle( m_prioritized_concurrent);
-
             }
 
             void Metric::update( const common::message::event::service::Metric& metric)
@@ -784,12 +782,12 @@ namespace casual
                if( service.timeout.duration > platform::time::unit::zero())
                   timeout.duration = service.timeout.duration;
 
-               auto add_service_to_instance = [ &]( auto service_id, auto instance_id)
+               auto relate_service_and_instance = [ &]( auto service_id, auto instance_id)
                {
                   services[ service_id].instances.add( instance_id, message.order, service.property);
                };
 
-               local::find_or_add_service( *this, service, timeout, instance_id, add_service_to_instance);
+               local::find_or_add_service( *this, service, timeout, instance_id, relate_service_and_instance);
             };
 
             algorithm::for_each( message.services.add, add_service);

--- a/middleware/service/unittest/source/manager/test_manager.cpp
+++ b/middleware/service/unittest/source/manager/test_manager.cpp
@@ -205,7 +205,7 @@ domain:
 domain:
    services:
       -  name: b
-         routes: [ x, y, z]
+         routes: [ e, f, g]
          execution:
             timeout: 
                duration: 20ms
@@ -227,7 +227,7 @@ domain:
          auto updated = casual::configuration::model::transform( 
             casual::domain::unittest::configuration::post( casual::configuration::model::transform( wanted)));
 
-         EXPECT_TRUE( wanted.service == updated.service) << CASUAL_NAMED_VALUE( wanted.service) << '\n' << CASUAL_NAMED_VALUE( updated.service);
+         EXPECT_TRUE( wanted.service == updated.service) << " " << CASUAL_NAMED_VALUE( wanted.service) << '\n' << CASUAL_NAMED_VALUE( updated.service);
 
       }
 
@@ -512,7 +512,7 @@ domain:
          {
             auto instance = local::instance::find( state, common::process::id());
             ASSERT_TRUE( instance);
-            EXPECT_TRUE( instance->state == decltype( instance->state)::idle);
+            EXPECT_TRUE( instance->state == decltype( instance->state)::idle) << CASUAL_NAMED_VALUE( *instance);
          }
       }
 

--- a/test/unittest/source/test_gateway.cpp
+++ b/test/unittest/source/test_gateway.cpp
@@ -1589,7 +1589,7 @@ domain:
          });
       }
 
-      TEST( test_gateway, domain_A_to__B_C_D__outbound_same_group___expect_round_robin_between_A_B_C)
+      TEST( test_gateway, domain_A_to__B_C_D__outbound_same_group___expect_random_between_A_B_C__could_fail)
       {
          common::unittest::Trace trace;
 
@@ -1629,16 +1629,21 @@ domain:
 
          std::map< std::string, int> domains;
 
-         algorithm::for_n< 9>( [ &domains]() mutable
+         algorithm::for_n< 100>( [ &domains]() mutable
          {
             auto buffer = local::call( "casual/example/domain/name");
             domains[ buffer.get()]++;
          });
 
-         // expect even distribution
-         EXPECT_TRUE( domains[ "B"] == 3);
-         EXPECT_TRUE( domains[ "C"] == 3);
-         EXPECT_TRUE( domains[ "D"] == 3);
+         // for a domain to have 0 calls after 100 events:
+         // ( 2 / 3 ) ^100 ~~ 1 in 4,065611775352153e17
+         // 1 in 400'000'000'000'000'000
+         // one in 400 million billions. 
+
+         // expect all to have at least one call.
+         EXPECT_TRUE( domains[ "B"] > 0) << CASUAL_NAMED_VALUE( domains);
+         EXPECT_TRUE( domains[ "C"] > 0) << CASUAL_NAMED_VALUE( domains);
+         EXPECT_TRUE( domains[ "D"] > 0) << CASUAL_NAMED_VALUE( domains);
       }
 
       TEST( test_gateway, domains_A_B__B_has_echo__call_echo_from_A__expect_discovery__shutdown_B__expect_no_ent__boot_B__expect_discovery)

--- a/test/unittest/source/test_service.cpp
+++ b/test/unittest/source/test_service.cpp
@@ -470,7 +470,7 @@ domain:
          instances: 1
          arguments:
             - --sleep
-            - 2s
+            - 30s
    services:
       -  name: "casual/example/sleep"
          execution:
@@ -511,7 +511,7 @@ domain:
             auto len = tptypes( buffer, nullptr, nullptr);
             auto result = tpgetrply( &descriptor, &buffer, &len, 0);
             EXPECT_EQ( result, -1);
-            EXPECT_EQ( tperrno, TPESVCERR);
+            EXPECT_EQ( tperrno, TPETIME);
          }
 
          {


### PR DESCRIPTION
Before: services and instances had their circular dependencies made of pointers and references. This made it a bit error prune and hard to reason about.

Now: Every service has an id, every instance has an id. The relation between them is just "a vector with ids". This is:
* a service has all ids of instances that has advertise the service
* an instance has all the ids of services that the instance has advertised.

Also, added a _disabled_ set that holds all instances that is in _prepare for shutdown_ mode. This enables us to keep track of _disabled_ instances and be able to handle a timeout properly during this mode.

Resolves #407