### PR TITLE
service: don't reserve instance after fatal assassination event

### DIFF
--- a/middleware/common/include/common/algorithm/compare.h
+++ b/middleware/common/include/common/algorithm/compare.h
@@ -10,7 +10,7 @@ namespace casual
 {
    namespace common::algorithm::compare
    {      
-      //! @returns true if `value` is equal to ane other `values`
+      //! @returns true if `value` is equal to any other `values`
       template< typename V, typename... Vs>
       constexpr bool any( V&& value, Vs&&... values)
       {

--- a/middleware/common/include/common/service/type.h
+++ b/middleware/common/include/common/service/type.h
@@ -67,6 +67,9 @@ namespace casual
 
          Type transform( std::string_view contract);
          std::string transform( Type contract);
+
+         //! @returns true if timeout contract is fatal
+         bool fatal( Type value) noexcept;
       }
 
       namespace transaction

--- a/middleware/common/include/common/unittest.h
+++ b/middleware/common/include/common/unittest.h
@@ -200,13 +200,14 @@ namespace casual
          template< typename A, typename C> 
          auto expect_code( A&& action, C code) -> decltype( ::testing::AssertionSuccess())
          {
+            bool thrown = false;
             try 
             {
                action();
-               return ::testing::AssertionFailure() << "no std::error_code was throwned\n";
             }
             catch( ...)
             {
+               thrown = true;
                auto error = exception::capture();
 
                if( error.code() == code)
@@ -214,6 +215,12 @@ namespace casual
 
                return ::testing::AssertionFailure() << "expected: " << code << " - got: " << error.code() << '\n';
             }
+
+            if( thrown)
+               return ::testing::AssertionSuccess();
+            else
+               return ::testing::AssertionFailure() << "no std::error_code was thrown\n";
+            
          }
          
       } // detail
@@ -228,7 +235,7 @@ casual::common::unittest::detail::expect_code( [&](){ action;}, code_value)
 #define ASSERT_CODE( action, code_value)                                                  \
 try                                                                                       \
 {                                                                                         \
-   action                                                                                 \
+   action;                                                                                \
    FAIL() << "no std::error_code was throwned";                                           \
 }                                                                                         \
 catch( ...)                                                                               \

--- a/middleware/common/source/service/type.cpp
+++ b/middleware/common/source/service/type.cpp
@@ -6,6 +6,7 @@
 
 #include "common/service/type.h"
 #include "common/string.h"
+#include "common/algorithm/compare.h"
 
 #include "common/code/raise.h"
 #include "common/code/casual.h"
@@ -86,6 +87,11 @@ namespace casual
                case Type::abort: return "abort";
             }
             return "unknown";
+         }
+
+         bool fatal( Type value) noexcept
+         {
+            return algorithm::compare::any( value, Type::kill, Type::abort);
          }
 
       }


### PR DESCRIPTION
Before:
* SM has pending lookups for services that 'x' has
* SM has reserved 'x' for a call (lookup)
* a timeout occur for instance 'x'
* SM sends _fatal_ assassination event
* SM receives ACK from 'x'
* SM reserves 'x' for the next pending lookup for services that 'x' has
* Extremely likely that 'x' gets killed before or during the reservation.

Now:

If we send a _fatal_ assassination for 'x', we keep track of 'x' as disabled. If we get an ACK from 'x' we don't reserve if 'x' is disabled.

Resolves #305