### PR TITLE
gateway: honor group memberships on connections

### DIFF
--- a/middleware/administration/makefile.cmk
+++ b/middleware/administration/makefile.cmk
@@ -22,7 +22,8 @@ make.IncludePaths( [
     '../gateway/unittest/include',
     '../tools/include',
     '../cli/include',
-    '../buffer/include']
+    '../buffer/include',
+    '../../thirdparty/database/include']
     + make.optional_include_paths()
     + dsl.paths().include.gtest
 )
@@ -126,6 +127,7 @@ make.LinkUnittest( 'unittest/bin/test-casual-administration',
       'casual-gateway-unittest',
       'casual-serviceframework',
       'casual-configuration',
+      'sqlite3',
    ])
 
 

--- a/middleware/configuration/include/configuration/model.h
+++ b/middleware/configuration/include/configuration/model.h
@@ -426,6 +426,8 @@ namespace casual::configuration
                std::string address;
                connection::discovery::Directive discovery{};
                std::string note;
+               std::vector< std::string> memberships;
+               bool enabled = true;
 
                Connection set_union( Connection lhs, Connection rhs);
 
@@ -435,6 +437,8 @@ namespace casual::configuration
                   CASUAL_SERIALIZE( address);
                   CASUAL_SERIALIZE( discovery);
                   CASUAL_SERIALIZE( note);
+                  CASUAL_SERIALIZE( memberships);
+                  CASUAL_SERIALIZE( enabled);
                )
             };
 
@@ -504,6 +508,8 @@ namespace casual::configuration
                std::vector< std::string> services;
                std::vector< std::string> queues;
                std::string note;
+               std::vector< std::string> memberships;
+               bool enabled = true;
 
                Connection set_union( Connection lhs, Connection rhs);
                Connection set_difference( Connection lhs, Connection rhs);
@@ -518,6 +524,8 @@ namespace casual::configuration
                   CASUAL_SERIALIZE( address);
                   CASUAL_SERIALIZE( services);
                   CASUAL_SERIALIZE( queues);
+                  CASUAL_SERIALIZE( memberships);
+                  CASUAL_SERIALIZE( enabled);
                )
             };
 

--- a/middleware/configuration/include/configuration/user.h
+++ b/middleware/configuration/include/configuration/user.h
@@ -366,11 +366,13 @@ namespace casual
                   std::string address;
                   std::optional< connection::Discovery> discovery;
                   std::optional< std::string> note;
+                  std::optional< std::vector< std::string>> memberships;
 
                   CASUAL_CONST_CORRECT_SERIALIZE(
                      CASUAL_SERIALIZE( address);
                      CASUAL_SERIALIZE( discovery);
                      CASUAL_SERIALIZE( note);
+                     CASUAL_SERIALIZE( memberships);
                   )
                };
 
@@ -433,6 +435,7 @@ namespace casual
                   std::optional< std::vector< std::string>> services;
                   std::optional< std::vector< std::string>> queues;
                   std::optional< std::string> note;
+                  std::optional< std::vector< std::string>> memberships;
 
 
                   CASUAL_CONST_CORRECT_SERIALIZE(
@@ -440,6 +443,7 @@ namespace casual
                      CASUAL_SERIALIZE( note);
                      CASUAL_SERIALIZE( services);
                      CASUAL_SERIALIZE( queues);
+                     CASUAL_SERIALIZE( memberships);
                   ) 
                };
 

--- a/middleware/configuration/source/model.cpp
+++ b/middleware/configuration/source/model.cpp
@@ -621,7 +621,7 @@ namespace casual
          }
 
          // take care of implicit disabled stuff from group memberships
-         {            
+         {
             auto update_enabled = [ coordinator = configuration::group::Coordinator{ model.domain.groups}]( auto& entity)
             {
                entity.enabled = coordinator.enabled( entity.memberships);
@@ -629,6 +629,14 @@ namespace casual
 
             algorithm::for_each( model.domain.servers, update_enabled);
             algorithm::for_each( model.domain.executables, update_enabled);
+
+            auto update_connections = [ &]( auto& group)
+            {
+               algorithm::for_each( group.connections, update_enabled);
+            };
+
+            algorithm::for_each( model.gateway.outbound.groups, update_connections);
+            algorithm::for_each( model.gateway.inbound.groups, update_connections);
          }
 
          return model;

--- a/middleware/configuration/source/model/transform.cpp
+++ b/middleware/configuration/source/model/transform.cpp
@@ -341,6 +341,7 @@ namespace casual
                            gateway::inbound::Connection result;
                            result.note = connection.note.value_or( "");
                            result.address = connection.address;
+                           result.memberships = connection.memberships.value_or( result.memberships);
                            
                            if( connection.discovery && connection.discovery->forward)
                               result.discovery = decltype( result.discovery)::forward;
@@ -370,6 +371,7 @@ namespace casual
                            gateway::outbound::Connection result;
                            result.note = connection.note.value_or( "");
                            result.address = connection.address;
+                           result.memberships = connection.memberships.value_or( result.memberships);
                            result.services = local::empty_if_null( std::move( connection.services));
                            result.queues = local::empty_if_null( std::move( connection.queues));
                            return result;
@@ -779,6 +781,7 @@ namespace casual
                         configuration::user::domain::gateway::inbound::Connection result;
                         result.address = value.address;
                         result.note = null_if_empty( value.note);
+                        result.memberships = null_if_empty( value.memberships);
 
                         if( value.discovery == decltype( value.discovery)::forward)
                            result.discovery = configuration::user::domain::gateway::inbound::connection::Discovery{ true};
@@ -799,6 +802,7 @@ namespace casual
                         configuration::user::domain::gateway::outbound::Connection result;
                         result.address = value.address;
                         result.note = null_if_empty( value.note);
+                        result.memberships = null_if_empty( value.memberships);
                         result.services = null_if_empty( value.services);
                         result.queues = null_if_empty( value.queues);
                         return result;

--- a/middleware/domain/unittest/include/domain/unittest/configuration.h
+++ b/middleware/domain/unittest/include/domain/unittest/configuration.h
@@ -22,6 +22,8 @@ namespace casual
       //! the updated configuration state
       casual::configuration::user::Model post( casual::configuration::user::Model wanted);
 
+      casual::configuration::user::Model put( casual::configuration::user::Model wanted);
+
       namespace detail
       {
          casual::configuration::Model load( std::vector< std::string_view> contents);

--- a/middleware/gateway/include/gateway/group/inbound/state.h
+++ b/middleware/gateway/include/gateway/group/inbound/state.h
@@ -164,6 +164,7 @@ namespace casual
          common::communication::ipc::send::Coordinator multiplex{ directive};
 
          group::connection::Holder< configuration::model::gateway::inbound::Connection> connections;
+         std::vector< configuration::model::gateway::inbound::Connection> disabled_connections;
 
          casual::task::concurrent::Coordinator< common::strong::socket::id> tasks;
 

--- a/middleware/gateway/include/gateway/group/outbound/state.h
+++ b/middleware/gateway/include/gateway/group/outbound/state.h
@@ -252,6 +252,7 @@ namespace casual
          common::communication::ipc::send::Coordinator multiplex{ directive};
 
          group::connection::Holder< casual::configuration::model::gateway::outbound::Connection> connections;
+         std::vector< casual::configuration::model::gateway::outbound::Connection> disabled_connections;
 
          state::task_coordinator_type tasks;
          

--- a/middleware/gateway/include/gateway/group/tcp/connect.h
+++ b/middleware/gateway/include/gateway/group/tcp/connect.h
@@ -110,6 +110,15 @@ namespace casual
                return result;
             });
 
+            algorithm::transform( state.disabled_connections, std::back_inserter( reply.state.connections), []( auto& disabled)
+            {
+               Connection result;
+               result.runlevel = decltype( result.runlevel)::disabled;
+               result.configuration = disabled;
+               result.address.peer = disabled.address;
+               return result;
+            });
+
             return reply;
          }
       } // state

--- a/middleware/gateway/include/gateway/group/tcp/listen.h
+++ b/middleware/gateway/include/gateway/group/tcp/listen.h
@@ -154,6 +154,16 @@ namespace casual
                return result;
             });
 
+            algorithm::transform( state.disabled_connections, std::back_inserter( reply.state.listeners), []( auto& disabled)
+            {
+               message::state::Listener result;
+               result.runlevel = decltype( result.runlevel)::disabled;
+               result.address = disabled.address;
+
+               return result;
+            });
+
+
             log::line( verbose::log, "reply: ", reply);
 
             return reply;

--- a/middleware/gateway/include/gateway/manager/admin/model.h
+++ b/middleware/gateway/include/gateway/manager/admin/model.h
@@ -70,6 +70,7 @@ namespace casual
                pending = 4,
                connected = 2,
                failed = 3,
+               disabled = 5,
 
                //! @deprecated remove in 2.0
                online = connected,
@@ -82,6 +83,7 @@ namespace casual
                   case Runlevel::pending: return "pending";
                   case Runlevel::connected: return "connected";
                   case Runlevel::failed: return "failed";
+                  case Runlevel::disabled: return "disabled";
                }
                return "<unknown>";
             }
@@ -113,6 +115,7 @@ namespace casual
             connection::Address address;
             common::strong::ipc::id ipc;
             platform::time::point::type created{};
+            bool enabled = true;
             
             
             inline friend bool operator == ( const Connection& lhs, std::string_view rhs) { return lhs.remote == rhs;}
@@ -133,6 +136,7 @@ namespace casual
                CASUAL_SERIALIZE( address);
                CASUAL_SERIALIZE( ipc);
                CASUAL_SERIALIZE( created);
+               CASUAL_SERIALIZE( enabled);
             
                //! @deprecated remove in 2.0
                CASUAL_SERIALIZE( process);
@@ -280,6 +284,7 @@ namespace casual
             {
                listening = 1,
                failed = 2,
+               disabled = 3,
             };
 
             constexpr std::string_view description( Runlevel value) noexcept
@@ -288,6 +293,7 @@ namespace casual
                {
                   case Runlevel::listening: return "listening";
                   case Runlevel::failed: return "failed";
+                  case Runlevel::disabled: return "disabled";
                }
                return "<not used>";
             }

--- a/middleware/gateway/include/gateway/message.h
+++ b/middleware/gateway/include/gateway/message.h
@@ -110,6 +110,7 @@ namespace casual
             {
                listening,
                failed,
+               disabled,
             };
             constexpr std::string_view description( Runlevel value) noexcept
             {
@@ -117,6 +118,7 @@ namespace casual
                {
                   case Runlevel::listening: return "listening";
                   case Runlevel::failed: return "failed";
+                  case Runlevel::disabled: return "disabled";
                }
                return "<unknown>";
             }
@@ -145,6 +147,7 @@ namespace casual
                pending,
                connected,
                failed,
+               disabled,
             };
             constexpr std::string_view description( Runlevel value) noexcept
             {
@@ -154,6 +157,7 @@ namespace casual
                   case Runlevel::pending: return "pending";
                   case Runlevel::connected: return "connected";
                   case Runlevel::failed: return "failed";
+                  case Runlevel::disabled: return "disabled";
                }
                return "<unknown>";
             }

--- a/middleware/gateway/source/group/inbound/reverse/main.cpp
+++ b/middleware/gateway/source/group/inbound/reverse/main.cpp
@@ -17,6 +17,8 @@
 #include "common/signal.h"
 #include "common/message/signal.h"
 #include "common/message/dispatch/handle.h"
+#include "common/algorithm.h"
+#include "common/algorithm/container.h"
 
 #include "common/communication/instance.h"
 #include "common/communication/select/ipc.h"
@@ -108,11 +110,16 @@ namespace casual
                            state.alias = message.model.alias;
                            state.limit = message.model.limit;
 
+                           auto is_enabled = []( auto& connection){ return connection.enabled;};
+                           auto [ enabled, disabled] = algorithm::stable::partition( message.model.connections, is_enabled);
+
+                           state.disabled_connections = algorithm::container::vector::create( disabled);
+
                            auto equal_address = []( auto& lhs, auto& rhs){ return lhs.address == rhs.address;};
 
                            auto change = casual::configuration::model::change::concrete::calculate( 
                               state.connections.configuration(), 
-                              message.model.connections, 
+                              algorithm::container::vector::create( enabled), 
                               equal_address);
 
                            log::line( verbose::log, "change: ", change);

--- a/middleware/gateway/source/group/outbound/main.cpp
+++ b/middleware/gateway/source/group/outbound/main.cpp
@@ -19,6 +19,8 @@
 #include "casual/argument.h"
 #include "common/message/signal.h"
 #include "common/message/dispatch/handle.h"
+#include "common/algorithm.h"
+#include "common/algorithm/container.h"
 
 #include "common/communication/instance.h"
 #include "common/communication/select/ipc.h"
@@ -116,11 +118,16 @@ namespace casual
                               outbound::handle::advertise::connections( state);
                            }
 
+                           auto is_enabled = []( auto& connection){ return connection.enabled;};
+                           auto [ enabled, disabled] = algorithm::stable::partition( message.model.connections, is_enabled);
+
+                           state.disabled_connections = algorithm::container::vector::create( disabled);
+
                            auto equal_address = []( auto& lhs, auto& rhs){ return lhs.address == rhs.address;};
 
                            auto change = casual::configuration::model::change::concrete::calculate( 
                               state.connections.configuration(), 
-                              message.model.connections, 
+                              algorithm::container::vector::create( enabled), 
                               equal_address);
 
                            log::line( verbose::log, "change: ", change);

--- a/middleware/gateway/source/group/outbound/reverse/main.cpp
+++ b/middleware/gateway/source/group/outbound/reverse/main.cpp
@@ -17,6 +17,8 @@
 #include "common/communication/select/ipc.h"
 #include "casual/argument.h"
 #include "common/message/dispatch/handle.h"
+#include "common/algorithm.h"
+#include "common/algorithm/container.h"
 
 #include "configuration/model/change.h"
 
@@ -92,11 +94,16 @@ namespace casual
                               outbound::handle::advertise::connections( state);
                            }
 
+                           auto is_enabled = []( auto& connection){ return connection.enabled;};
+                           auto [ enabled, disabled] = algorithm::stable::partition( message.model.connections, is_enabled);
+
+                           state.disabled_connections = algorithm::container::vector::create( disabled);
+
                            auto equal_address = []( auto& lhs, auto& rhs){ return lhs.address == rhs.address;};
 
                            auto change = casual::configuration::model::change::concrete::calculate( 
                               state.listen.configuration(), 
-                              message.model.connections, 
+                              algorithm::container::vector::create( enabled), 
                               equal_address);
 
                            log::line( verbose::log, "change: ", change);

--- a/middleware/gateway/source/manager/admin/cli.cpp
+++ b/middleware/gateway/source/manager/admin/cli.cpp
@@ -155,6 +155,7 @@ namespace casual
                            case Enum::pending: return 7;
                            case Enum::connected: return 9;
                            case Enum::failed: return 6;
+                           case Enum::disabled: return 8;
                         }
                         return 0;
                      }
@@ -170,6 +171,7 @@ namespace casual
                            case Enum::pending: common::stream::write( out, terminal::color::yellow, value.runlevel); break;
                            case Enum::connected: common::stream::write( out, terminal::color::green, value.runlevel); break;
                            case Enum::failed: common::stream::write( out, terminal::color::red, value.runlevel); break;
+                           case Enum::disabled: common::stream::write( out, terminal::color::white, value.runlevel); break;
                         }
                      }
                   };
@@ -203,6 +205,7 @@ namespace casual
                            case Enum::pending: return "pending";
                            case Enum::connected: return "online";
                            case Enum::failed: return "failed";
+                           case Enum::disabled: return "disabled";
                         }
                         return "<unknown>";
                      };
@@ -247,23 +250,22 @@ namespace casual
                            {
                               case Enum::listening: return 9;
                               case Enum::failed: return 6;
+                              case Enum::disabled: return 8;
                            }
                            return 0;
                         }
 
                         void print( std::ostream& out, const model::Listener& value, std::size_t width) const
                         {
-                           out << std::setfill( ' ');
+                           out << std::setfill( ' ') << std::left << std::setw( width);
 
-                           auto color = []( auto value)
+                           using Enum = decltype( value.runlevel);
+                           switch( value.runlevel)
                            {
-                              using Enum = decltype( value);
-                              if( value == Enum::listening)
-                                 return terminal::color::green;
-                              return terminal::color::red;
-                           };
-
-                           common::stream::write( out, std::left, std::setw( width), color( value.runlevel), value.runlevel);
+                              case Enum::listening: common::stream::write( out, terminal::color::green, value.runlevel); break;
+                              case Enum::failed: common::stream::write( out, terminal::color::red, value.runlevel); break;
+                              case Enum::disabled: common::stream::write( out, terminal::color::white, value.runlevel); break;
+                           }
                         }
                      };
 
@@ -302,6 +304,7 @@ namespace casual
                            using Enum = decltype( value.runlevel);
                            case Enum::listening: return "listening";
                            case Enum::failed: return "failed";
+                           case Enum::disabled: return "disabled";
                         }
                         return "<unknown>";
                      };

--- a/middleware/gateway/source/manager/transform.cpp
+++ b/middleware/gateway/source/manager/transform.cpp
@@ -48,6 +48,7 @@ namespace casual
                            case Enum::pending: return manager::admin::model::connection::Runlevel::pending;
                            case Enum::connected: return manager::admin::model::connection::Runlevel::connected;
                            case Enum::failed: return manager::admin::model::connection::Runlevel::failed;
+                           case Enum::disabled: return manager::admin::model::connection::Runlevel::disabled;
                         }
                         return manager::admin::model::connection::Runlevel::failed;
                      };
@@ -65,8 +66,11 @@ namespace casual
                      result.ipc = connection.ipc;
                      result.remote = connection.domain;
                      result.created = connection.created;
+                     result.enabled = connection.configuration.enabled;
 
-                     if( result.address.local.empty())
+                     if( ! result.enabled)
+                        result.runlevel = manager::admin::model::connection::Runlevel::disabled;
+                     else if( result.address.local.empty())
                         result.runlevel = manager::admin::model::connection::Runlevel::connecting;
                      else
                         result.runlevel = manager::admin::model::connection::Runlevel::connected;
@@ -176,6 +180,7 @@ namespace casual
                         {
                            case Enum::listening: return manager::admin::model::listener::Runlevel::listening;
                            case Enum::failed: return manager::admin::model::listener::Runlevel::failed;
+                           case Enum::disabled: return manager::admin::model::listener::Runlevel::disabled;
                         }
                         return manager::admin::model::listener::Runlevel::failed;
                      };

--- a/middleware/gateway/unittest/include/gateway/unittest/utility.h
+++ b/middleware/gateway/unittest/include/gateway/unittest/utility.h
@@ -82,7 +82,15 @@ namespace casual
                      {
                         return connection.runlevel == decltype( connection.runlevel)::failed;
                      };
-                  } 
+                  }
+
+                  inline auto disabled()
+                  {
+                     return []( auto& connection)
+                     {
+                        return connection.runlevel == decltype( connection.runlevel)::disabled;
+                     };
+                  }
                } // runlevel
 
                namespace connected


### PR DESCRIPTION
This obviously needs a bunch of tests, but I'm doing a draft too see what you think of the overall idea. 

Basically, by filtering out disabled connections before calculating the 'difference' we can piggyback on the existing implementation. The alternative would probably be something like putting them in the connection::Holder and moving them around as their 'enabledness' changes, but this felt way too cumbersome when I tried to implement it.