### PR TITLE
transaction: error log when resource fail

### DIFF
--- a/middleware/common/source/transaction/context.cpp
+++ b/middleware/common/source/transaction/context.cpp
@@ -600,13 +600,13 @@ namespace casual
 
             auto invoke_rollback = [ this]( const Transaction& transaction)
             {
-               return local::log::code( Context::rollback( transaction), "failed to rollback transaction: ", transaction.trid);
+               return local::log::code( Context::rollback( transaction), "failed to rollback trid: ", transaction.trid);
             };
 
             auto invoke_commit_rollback = [ this, invoke_rollback, commit]( const Transaction& transaction)
             {
                if( commit && transaction.state == Transaction::State::active)
-                  return Context::commit( transaction);
+                  return local::log::code( Context::commit( transaction), "failed to commit trid: ", transaction.trid);
                else
                   return invoke_rollback( transaction);
             };

--- a/middleware/common/source/transaction/resource.cpp
+++ b/middleware/common/source/transaction/resource.cpp
@@ -189,6 +189,9 @@ namespace casual
             return local::convert( m_xa->xa_commit_entry( local::non_const_xid( transaction), m_id.value(), flags.underlying()));
          });
 
+         if( result != code::xa::ok)
+            log::line( log::category::error, result, " error during commit - xid: ", transaction.xid, ", rm: ", m_id);
+
          local::log::event( "resource-commit|", m_id, '|', transaction, '|', result);
 
          return result;
@@ -198,10 +201,13 @@ namespace casual
       {
          log::line( log::category::transaction, "rollback resource: ", m_id, " transaction: ", transaction, " flags: ", flags);
 
-         auto result =  reopen_guard( [&]()
+         auto result = reopen_guard( [&]()
          {
             return local::convert( m_xa->xa_rollback_entry( local::non_const_xid( transaction), m_id.value(), flags.underlying()));
          });
+
+         if( result != code::xa::ok)
+            log::line( log::category::error, result, " error during rollback - xid: ", transaction.xid, ", rm: ", m_id);
 
          local::log::event( "resource-rollback|", m_id, '|', transaction, '|', result);
 

--- a/middleware/configuration/documentation/domain.queue.operation.md
+++ b/middleware/configuration/documentation/domain.queue.operation.md
@@ -91,11 +91,22 @@ alias : `string`     | the (unique) alias of the group.
 property                   | description                         | default
 ---------------------------|-------------------------------------|----------------------------------------
 source : `string`          | the queue to dequeue from           |
+[alias : `string`]         | the (unique) alias of the forward   | `<source>`, on collisions `<source>.#`
 [instances : `integer`]    | number of multiplexing 'instances'  | `domain.queue.forward.default.service.instances`
 target.service : `string`  | service to call                     |
 [reply.queue : `string`]   | queue to enqueue reply to           |
 [reply.delay : `Duration`] | reply enqueue available delay       | 
 
+
+##### domain.queue.forward.groups.queues _(list)_
+
+property                    | description                         | default
+----------------------------|-------------------------------------|----------------------------------------
+source : `string`           | the queue to dequeue from           |
+[alias : `string`]          | the (unique) alias of the forward   | `<source>`, on collisions `<source>.#`
+[instances : `integer`]     | number of multiplexing 'instances'  | `domain.queue.forward.default.queue.instances`
+target.queue : `string`     | queue to enqueue to                 |
+[target.delay : `Duration`] | enqueued available delay            | `domain.queue.forward.default.queue.target.delay`
 
 ## examples 
 
@@ -152,7 +163,8 @@ domain:
       groups:
         - alias: "forward-group-1"
           services:
-            - source: "b1"
+            - alias: "foo"
+              source: "b1"
               instances: 4
               target:
                 service: "casual/example/echo"
@@ -161,11 +173,13 @@ domain:
                 delay: "10ms"
           queues:
             - source: "c1"
+              note: "gets the alias 'c1'"
               target:
                 queue: "a4"
         - alias: "forward-group-2"
           services:
-            - source: "b2"
+            - alias: "bar"
+              source: "b2"
               target:
                 service: "casual/example/echo"
 ...
@@ -260,6 +274,7 @@ domain:
                         "alias": "forward-group-1",
                         "services": [
                             {
+                                "alias": "foo",
                                 "source": "b1",
                                 "instances": 4,
                                 "target": {
@@ -274,6 +289,7 @@ domain:
                         "queues": [
                             {
                                 "source": "c1",
+                                "note": "gets the alias 'c1'",
                                 "target": {
                                     "queue": "a4"
                                 }
@@ -284,6 +300,7 @@ domain:
                         "alias": "forward-group-2",
                         "services": [
                             {
+                                "alias": "bar",
                                 "source": "b2",
                                 "target": {
                                     "service": "casual/example/echo"

--- a/middleware/configuration/source/documentation/main.cpp
+++ b/middleware/configuration/source/documentation/main.cpp
@@ -396,11 +396,22 @@ alias : `string`     | the (unique) alias of the group.
 property                   | description                         | default
 ---------------------------|-------------------------------------|----------------------------------------
 source : `string`          | the queue to dequeue from           |
+[alias : `string`]         | the (unique) alias of the forward   | `<source>`, on collisions `<source>.#`
 [instances : `integer`]    | number of multiplexing 'instances'  | `domain.queue.forward.default.service.instances`
 target.service : `string`  | service to call                     |
 [reply.queue : `string`]   | queue to enqueue reply to           |
 [reply.delay : `Duration`] | reply enqueue available delay       | 
 
+
+##### domain.queue.forward.groups.queues _(list)_
+
+property                    | description                         | default
+----------------------------|-------------------------------------|----------------------------------------
+source : `string`           | the queue to dequeue from           |
+[alias : `string`]          | the (unique) alias of the forward   | `<source>`, on collisions `<source>.#`
+[instances : `integer`]     | number of multiplexing 'instances'  | `domain.queue.forward.default.queue.instances`
+target.queue : `string`     | queue to enqueue to                 |
+[target.delay : `Duration`] | enqueued available delay            | `domain.queue.forward.default.queue.target.delay`
 
 )";
                   examples( out, example::user::part::domain::queue());

--- a/middleware/configuration/source/example/model.cpp
+++ b/middleware/configuration/source/example/model.cpp
@@ -269,7 +269,8 @@ domain:
          groups:
             -  alias: forward-group-1
                services:
-                  -  source: b1
+                  -  alias: foo
+                     source: b1
                      target: 
                         service: casual/example/echo
                      instances: 4
@@ -280,9 +281,11 @@ domain:
                   -  source: c1
                      target:
                         queue: a4
+                     note: gets the alias 'c1'
             -  alias: forward-group-2
                services:
-                  -  source: b2
+                  -  alias: bar
+                     source: b2
                      target:
                         service: casual/example/echo
 


### PR DESCRIPTION
Error log when resource commit/rollback returns other than xa:ok.

We don't error log on prepare fails, since this could be an "expected" outcome. Resources use optimistic locking and so on.

Resolves #428

I'm also going to update queue documentation in this PR. 