### PR TITLE
unittest: fix gateway test to be deterministic

### DIFF
--- a/middleware/service/include/service/manager/admin/model.h
+++ b/middleware/service/include/service/manager/admin/model.h
@@ -134,6 +134,8 @@ namespace casual
                platform::size::type hops{};
                platform::size::type order{};
 
+               inline friend bool operator == ( const Concurrent& lhs, common::process::compare_equal_to_handle auto rhs) { return lhs.process == rhs;}
+
                CASUAL_CONST_CORRECT_SERIALIZE(
                   CASUAL_SERIALIZE( process);
                   CASUAL_SERIALIZE( hops);


### PR DESCRIPTION
This patch fixes the unitttest:

test_gateway_discovery
A_to_B_C__C_is_down__expect_B___boot_C__expect_discovery_to_C__alternate_between_B_and_C

Before: We rely on timing and random/luck

Now: totally determnistic. We _pull fetch_ state until we get the expected result.