### PR TITLE
service: fix routes dissapearing on config update

### DIFF
--- a/middleware/service/include/service/manager/admin/model.h
+++ b/middleware/service/include/service/manager/admin/model.h
@@ -214,6 +214,8 @@ namespace casual
          //! the actual invoked service
          std::string target;
 
+         inline friend bool operator == ( const Route& lhs, const Route& rhs) = default;
+
          CASUAL_CONST_CORRECT_SERIALIZE(
             CASUAL_SERIALIZE( service);
             CASUAL_SERIALIZE( target);

--- a/middleware/service/source/manager/configuration.cpp
+++ b/middleware/service/source/manager/configuration.cpp
@@ -68,8 +68,7 @@ namespace casual
                      state.routes.emplace( service.name, service.routes);
                   };
 
-                  algorithm::for_each( change.added, add_routes);
-                  algorithm::for_each( change.modified, add_routes);
+                  algorithm::for_each( wanted, add_routes);
                }
 
                auto remove = [ &state]( auto& service)


### PR DESCRIPTION
This commit fixes an issue where services that did not have their configuration changed would lose their routes when the service manager received a runtime configuration update.

Resolves #431