### PR TITLE
buffer: simplify the handling of the special 'inbound' buffer

### DIFF
--- a/middleware/buffer/source/string.cpp
+++ b/middleware/buffer/source/string.cpp
@@ -96,12 +96,12 @@ namespace casual
                   return buffer.payload.handle();
                }
 
-               common::buffer::handle::mutate::type insert( common::buffer::Payload payload)
+               auto& insert( common::buffer::Payload payload)
                {
                   // Validate it before we move it
                   local::validate( payload);
 
-                  return allocator_base::emplace_back( std::move( payload)).payload.handle();
+                  return allocator_base::emplace_back( std::move( payload));
                }
 
             };

--- a/middleware/buffer/unittest/source/test_field_buffer.cpp
+++ b/middleware/buffer/unittest/source/test_field_buffer.cpp
@@ -1420,8 +1420,8 @@ namespace casual
 
          auto handle = common::buffer::pool::holder().adopt( { CASUAL_FIELD "/", 0l});
 
-         // holder().inbound() keeps track of the _special_ buffer.
-         EXPECT_TRUE( common::buffer::pool::holder().inbound() == handle);
+         // verify that we keep track of the _special_ buffer.
+         EXPECT_TRUE( common::buffer::pool::holder().inbound( handle));
 
          auto buffer = handle.raw();
 
@@ -1438,18 +1438,18 @@ namespace casual
          
          // the above should have expanded the buffer.
          EXPECT_TRUE( buffer != handle.raw());
-         EXPECT_TRUE( common::buffer::pool::holder().inbound() != handle);
+         EXPECT_TRUE( ! common::buffer::pool::holder().inbound( handle));
 
          // inbound "tracker" should correlate to the auto expanded buffer
-         EXPECT_TRUE( common::buffer::pool::holder().inbound().raw() == buffer);
+         EXPECT_TRUE( common::buffer::pool::holder().inbound( common::buffer::handle::type{ buffer}));
 
          buffer = ::tprealloc( buffer, 512);
-         EXPECT_TRUE( common::buffer::pool::holder().inbound().raw() == buffer);
+         EXPECT_TRUE( common::buffer::pool::holder().inbound( common::buffer::handle::type{ buffer}));
          
          // this should be a 'no-op' according to the spec...
          tpfree( buffer);
 
-         EXPECT_TRUE( common::buffer::pool::holder().inbound().raw() == buffer);
+         EXPECT_TRUE( common::buffer::pool::holder().inbound( common::buffer::handle::type{ buffer}));
 
          {
             short value{};

--- a/middleware/common/include/common/buffer/type.h
+++ b/middleware/common/include/common/buffer/type.h
@@ -30,7 +30,6 @@ namespace casual
 {
    namespace common::buffer
    {
-
       namespace handle
       {
          namespace detail
@@ -172,7 +171,12 @@ namespace casual
 
       struct Buffer
       {
+         // A tag for construction to indicate that the buffer is an "inbound"
+         struct Inbound {};
+
          Buffer( Payload payload);
+         //! construct an "inbound buffer".
+         Buffer( Payload payload, Inbound);
          Buffer( string::Argument type, platform::binary::size::type size);
 
          Buffer( Buffer&&) noexcept;
@@ -184,13 +188,15 @@ namespace casual
          inline buffer::handle::type handle() const noexcept { return payload.handle();}
          inline buffer::handle::mutate::type handle() noexcept { return payload.handle();}
 
-         //inline friend bool operator == ( const Buffer& lhs, buffer::handle::type rhs) { return lhs.handle() == rhs;}
+         bool inbound() const { return m_inbound;}
 
          CASUAL_LOG_SERIALIZE(
             CASUAL_SERIALIZE( payload);
          )
 
          Payload payload;
+      private:
+         bool m_inbound = false;
       };
 
    } // common::buffer

--- a/middleware/common/source/buffer/type.cpp
+++ b/middleware/common/source/buffer/type.cpp
@@ -87,6 +87,10 @@ namespace casual
          static_assert( concepts::nothrow::movable< Buffer>);
          static_assert( ! concepts::copyable< Buffer>);
 
+         Buffer::Buffer( Payload payload, Inbound)
+            : payload( std::move( payload)), m_inbound{ true}
+         {}
+
          Buffer::Buffer( Payload payload) : payload( std::move( payload)) {}
 
          Buffer::Buffer( string::Argument type, platform::binary::size::type size)


### PR DESCRIPTION
This patch simplifies keeping track of the special 'inbound' buffer. We now keep track of 'inbound' for all our current known buffers.

Resolves #411