### PR TITLE
cli: improved --legend <option> to --legend --<option>

### DIFF
--- a/middleware/administration/documentation/cli/domain.operation.md
+++ b/middleware/administration/documentation/cli/domain.operation.md
@@ -72,12 +72,23 @@ domain [0..1]
       --instance-global-state [0..1]  (<pid>, [<format>]) [1..2]
            get the 'global state' for the provided pid
 
-      --legend [0..1]  (list-executables, list-servers, ping) [1]
+      --legend [0..1]
            the legend for the supplied option
            
            Documentation and description for abbreviations and acronyms used as columns in output
            
-           note: not all options has legend, use 'auto complete' to find out which legends are supported.
+           The following options has legend:
+
+         SUB OPTIONS:
+
+            --list-servers [0..1]
+                 list legend for --list-servers
+
+            --list-executables [0..1]
+                 list legend for --list-executables
+
+            --ping [0..1]
+                 list legend for --ping
 
       --information [0..1]
            collect aggregated general information about this domain

--- a/middleware/administration/documentation/cli/gateway.operation.md
+++ b/middleware/administration/documentation/cli/gateway.operation.md
@@ -28,12 +28,17 @@ gateway [0..1]
       --list-outbound-groups [0..1]
            list all outbound groups
 
-      --legend [0..1]  (list-connections) [1]
+      --legend [0..1]
            show legend for the output of the supplied option
            
            Documentation and description for abbreviations and acronyms used as columns in output
            
-           note: not all options has legend, use 'auto complete' to find out which legends are supported.                        
+           The following options has legend:                       
+
+         SUB OPTIONS:
+
+            --list-connections [0..1]
+                 list legend for --list-connections
 
       --state [0..1]  (json, yaml, xml, ini, line) [0..1]
            prints state in the provided format to stdout

--- a/middleware/administration/documentation/cli/queue.operation.md
+++ b/middleware/administration/documentation/cli/queue.operation.md
@@ -133,12 +133,29 @@ queue [0..1]
            Example:
            casual queue --metric-reset a b
 
-      --legend [0..1]  (list-queues, list-messages, list-forward-groups, list-forward-services, list-forward-queues) [1]
+      --legend [0..1]
            provide legend for the output for some of the options
            
-           to view legend for --list-queues use casual queue --legend list-queues, and so on.
+           to view legend for --list-queues use casual queue --legend --list-queues, and so on.
            
-           use auto-complete to help which options has legends
+           The following options has legend:
+
+         SUB OPTIONS:
+
+            --list-queues [0..1]
+                 list legend for --list-queues
+
+            --list-messages [0..1]
+                 list legend for --list-messages
+
+            --list-forward-groups [0..1]
+                 list legend for --list-forward-groups
+
+            --list-forward-services [0..1]
+                 list legend for --list-forward-services
+
+            --list-forward-queues [0..1]
+                 list legend for --list-forward-queues
 
       --information [0..1]
            collect aggregated information about queues in this domain

--- a/middleware/administration/documentation/cli/service.operation.md
+++ b/middleware/administration/documentation/cli/service.operation.md
@@ -27,12 +27,17 @@ service [0..1]
       -mr, --metric-reset [0..1]  (<service>...) [0..*]
            reset metrics for provided services, if no services provided, all metrics will be reset
 
-      --legend [0..1]  (<option>) [1]
+      --legend [0..1]
            the legend for the supplied option
            
            Documentation and description for abbreviations and acronyms used as columns in output
            
-           note: not all options has legend, use 'auto complete' to find out which legends are supported.
+           The following options has legend:
+
+         SUB OPTIONS:
+
+            --list-services [0..1]
+                 list legend for --list-services
 
       --information [0..1]
            collect aggregated information about known services

--- a/middleware/administration/documentation/cli/transaction.operation.md
+++ b/middleware/administration/documentation/cli/transaction.operation.md
@@ -59,12 +59,17 @@ transaction [0..1]
       -lp, --list-pending [0..1]
            list pending tasks
 
-      --legend [0..1]  (list-resources) [1]
+      --legend [0..1]
            the legend for the supplied option
            
            Documentation and description for abbreviations and acronyms used as columns in output
            
-           note: not all options has legend, use 'auto complete' to find out which legends are supported.
+           The following options has legend:
+
+         SUB OPTIONS:
+
+            --list-resources [0..1]
+                 list legend for --list-resources
 
       --information [0..1]
            collect aggregated information about transactions in this domain

--- a/middleware/administration/unittest/source/cli/test_gateway.cpp
+++ b/middleware/administration/unittest/source/cli/test_gateway.cpp
@@ -64,7 +64,7 @@ domain:
       {
          common::unittest::Trace trace;
          
-         auto capture = administration::unittest::cli::command::execute( "casual gateway --legend list-connections");
+         auto capture = administration::unittest::cli::command::execute( "casual gateway --legend --list-connections");
 
          EXPECT_TRUE( capture.standard.out.size() > 30) << CASUAL_NAMED_VALUE( capture);
       }

--- a/middleware/administration/unittest/source/cli/test_transaction.cpp
+++ b/middleware/administration/unittest/source/cli/test_transaction.cpp
@@ -200,7 +200,7 @@ domain:
       {
          auto a = local::cli::domain();
 
-         const auto capture = administration::unittest::cli::command::execute( R"(casual transaction --legend list-resources)");
+         const auto capture = administration::unittest::cli::command::execute( R"(casual transaction --legend --list-resources)");
 
          using namespace std::literals;
 

--- a/middleware/configuration/documentation/sample/domain/queue.ini
+++ b/middleware/configuration/documentation/sample/domain/queue.ini
@@ -34,6 +34,7 @@ alias=forward-group-1
 
 [domain.queue.forward.groups.queues]
 alias=fwd-c1
+note=gets the alias 'c1'
 source=c1
 
 [domain.queue.forward.groups.queues.target]
@@ -55,6 +56,7 @@ service=casual/example/echo
 alias=forward-group-2
 
 [domain.queue.forward.groups.services]
+alias=bar
 note=will get alias b2
 source=b2
 

--- a/middleware/configuration/documentation/sample/domain/queue.json
+++ b/middleware/configuration/documentation/sample/domain/queue.json
@@ -121,6 +121,7 @@
                             {
                                 "alias": "fwd-c1",
                                 "source": "c1",
+                                "note": "gets the alias 'c1'",
                                 "target": {
                                     "queue": "a4"
                                 }
@@ -131,6 +132,7 @@
                         "alias": "forward-group-2",
                         "services": [
                             {
+                                "alias": "bar",
                                 "source": "b2",
                                 "note": "will get alias b2",
                                 "target": {

--- a/middleware/configuration/documentation/sample/domain/queue.xml
+++ b/middleware/configuration/documentation/sample/domain/queue.xml
@@ -122,6 +122,7 @@
       <element>
        <alias>fwd-c1</alias>
        <source>c1</source>
+       <note>gets the alias 'c1'</note>
        <target>
         <queue>a4</queue>
        </target>
@@ -132,6 +133,7 @@
      <alias>forward-group-2</alias>
      <services>
       <element>
+       <alias>bar</alias>
        <source>b2</source>
        <note>will get alias b2</note>
        <target>

--- a/middleware/configuration/documentation/sample/domain/queue.yaml
+++ b/middleware/configuration/documentation/sample/domain/queue.yaml
@@ -69,11 +69,13 @@ domain:
           queues:
             - alias: "fwd-c1"
               source: "c1"
+              note: "gets the alias 'c1'"
               target:
                 queue: "a4"
         - alias: "forward-group-2"
           services:
-            - source: "b2"
+            - alias: "bar"
+              source: "b2"
               note: "will get alias b2"
               target:
                 service: "casual/example/echo"

--- a/middleware/domain/source/manager/admin/cli.cpp
+++ b/middleware/domain/source/manager/admin/cli.cpp
@@ -1110,34 +1110,33 @@ note: some aliases are unrestartable
 
                auto legend()
                {
-                  static const std::map< std::string, std::string_view> legends{
-                     { "list-servers", option::list::servers_legend},
-                     { "list-executables", option::list::executables_legend},
-                     { "ping", action::ping::legend},
+
+                  auto legend_option = []( std::string key, std::string_view legend)
+                  {
+                     return argument::Option{ [ key, legend]()
+                        {
+                           std::cout << legend;
+                        },
+                        { key},
+                        string::compose( "list legend for ", key)
+                     };
                   };
                                     
-                  auto invoke = []( const std::string& option)
-                  {
-                     if( auto found = algorithm::find( legends, option))
-                        std::cout << found->second;
-                  };
-
-                  auto complete = []( bool help, auto values)
-                  {
-                     return algorithm::transform( legends, []( auto& pair){ return pair.first;});
-                  };
 
                   return argument::Option{
-                     std::move( invoke),
-                     std::move( complete),
+                     [](){},
                      { "--legend"},
                      R"(the legend for the supplied option
 
 Documentation and description for abbreviations and acronyms used as columns in output
 
-note: not all options has legend, use 'auto complete' to find out which legends are supported.
+The following options has legend:
 )"
-                  };
+                  }({
+                     legend_option( "--list-servers", option::list::servers_legend),
+                     legend_option( "--list-executables", option::list::executables_legend),
+                     legend_option( "--ping", action::ping::legend),
+                  });
                }
 
             } // option

--- a/middleware/gateway/source/manager/admin/cli.cpp
+++ b/middleware/gateway/source/manager/admin/cli.cpp
@@ -526,29 +526,29 @@ created
 
                   auto create()
                   {
-                     auto invoke = []( const std::string& option)
+                     auto legend_option = [](  std::string key, std::string_view legend)
                      {
-                        if( auto found = algorithm::find( legend::legends, option))
-                           std::cout << found->second;
-                        else
-                           code::raise::error( code::casual::invalid_argument, "not a valid argument to --legend: ", option);
-                     };
-
-                     auto complete = []( auto values, auto help)
-                     {
-                        return algorithm::transform( legends, []( auto& pair){ return std::string{ pair.first};});
+                        return argument::Option{ [ key, legend]()
+                           {
+                              std::cout << legend;
+                           },
+                           { key},
+                           string::compose( "list legend for ", key)
+                        };
                      };
 
                      return argument::Option{ 
-                        std::move( invoke),
-                        complete,
+                        [](){},
                         { "--legend"}, 
                         R"(show legend for the output of the supplied option
 
 Documentation and description for abbreviations and acronyms used as columns in output
 
-note: not all options has legend, use 'auto complete' to find out which legends are supported.                        
-)"};
+The following options has legend:                       
+)"
+                        }({
+                           legend_option( "--list-connections", option::list::connections::legend)
+                        });
                   }
 
                } // legend

--- a/middleware/queue/source/manager/admin/cli.cpp
+++ b/middleware/queue/source/manager/admin/cli.cpp
@@ -898,35 +898,33 @@ namespace casual
 
                auto option()
                {
-                  auto invoke = []( const std::string& option)
+                  auto legend_option = [](  std::string key, std::string_view legend)
                   {
-                     if( option == "list-queues")
-                        std::cout << legend::list::queues;
-                     else if( option == "list-messages")
-                        std::cout << legend::list::messages;
-                     else if( option == "list-forward-groups")
-                        std::cout << legend::list::forward::groups;
-                     else if( option == "list-forward-services")
-                        std::cout << legend::list::forward::services;
-                     else if( option == "list-forward-queues")
-                        std::cout << legend::list::forward::queues;
-                  };
-
-                  auto complete = []( bool help, auto values) -> std::vector< std::string>
-                  {     
-                     return { "list-queues", "list-messages", "list-forward-groups", "list-forward-services", "list-forward-queues"};
+                     return argument::Option{ [ key, legend]()
+                        {
+                           std::cout << legend;
+                        },
+                        { key},
+                        string::compose( "list legend for ", key)
+                     };
                   };
 
                   return argument::Option{
-                     std::move( invoke),
-                     complete,
+                     [](){},
                      { "--legend"},
                      R"(provide legend for the output for some of the options
 
-to view legend for --list-queues use casual queue --legend list-queues, and so on.
+to view legend for --list-queues use casual queue --legend --list-queues, and so on.
 
-use auto-complete to help which options has legends)"
-                  };
+The following options has legend:
+)"
+                  }({
+                     legend_option( "--list-queues", legend::list::queues),
+                     legend_option( "--list-messages", legend::list::messages),
+                     legend_option( "--list-forward-groups", legend::list::forward::groups),
+                     legend_option( "--list-forward-services", legend::list::forward::services),
+                     legend_option( "--list-forward-queues", legend::list::forward::queues),
+                  });
                }
 
             } // legend 

--- a/middleware/service/source/manager/admin/cli.cpp
+++ b/middleware/service/source/manager/admin/cli.cpp
@@ -550,37 +550,27 @@ namespace casual
                {
                   auto option()
                   {
-                     static const std::map< std::string, std::string_view> legends{
-                        { "list-services", list::services::legend},
-                        { "list-admin-services", list::services::legend},
-                     };
-
-                     auto invoke = []( const std::string& value)
+                     auto legend_option = [](  std::string key, std::string_view legend)
                      {
-                        if( auto found = algorithm::find( legends, value))
-                           std::cout << found->second;
-                        else
-                           code::raise::error( code::casual::invalid_argument, "not a valid argument to --legend: ", value);
+                        return argument::Option{ [ key, legend]()
+                           {
+                              std::cout << legend;
+                           },
+                           { key},
+                           string::compose( "list legend for ", key)
+                        };
                      };
 
-                     auto completer = []( bool help, auto values) -> std::vector< std::string>
-                     {
-                        if( help)
-                           return { "<option>"};
-
-                        return algorithm::transform( legends, []( auto& pair){ return pair.first;});
-                     };
-                     
                      return argument::Option{ 
-                        invoke,
-                        completer,
+                        [](){},
                         { "--legend"}, 
                          R"(the legend for the supplied option
 
 Documentation and description for abbreviations and acronyms used as columns in output
 
-note: not all options has legend, use 'auto complete' to find out which legends are supported.
-)"};
+The following options has legend:
+)"
+                     }( { legend_option( "--list-services", list::services::legend)});
                   }
                   
                } // legend

--- a/middleware/transaction/source/manager/admin/cli.cpp
+++ b/middleware/transaction/source/manager/admin/cli.cpp
@@ -931,33 +931,29 @@ External resources only have one instance, hence resources and resource-instance
             {
                auto option()
                {
-                  static const std::map< std::string, std::string_view> legends{
-                     { "list-resources", local::format::resource_proxy_legend},
-                  };
-
-                  auto invoke = []( const std::string& option)
+                  auto legend_option = [](  std::string key, std::string_view legend)
                   {
-                     if( auto found = algorithm::find( legends, option))
-                        std::cout << found->second;
-                     else
-                        code::raise::error( code::casual::invalid_argument, "not a valid argument to --legend: ", option);
-                  };
-
-                  auto complete = []( auto values, auto help)
-                  {
-                     return algorithm::transform( legends, []( auto& pair){ return pair.first;});
+                     return argument::Option{ [ key, legend]()
+                        {
+                           std::cout << legend;
+                        },
+                        { key},
+                        string::compose( "list legend for ", key)
+                     };
                   };
 
                   return argument::Option{
-                     std::move( invoke),
-                     std::move( complete),
+                     [](){},
                      { "--legend"},
                      R"(the legend for the supplied option
 
 Documentation and description for abbreviations and acronyms used as columns in output
 
-note: not all options has legend, use 'auto complete' to find out which legends are supported.
-)"};
+The following options has legend:
+)"
+                  }({
+                     legend_option( "--list-resources", local::format::resource_proxy_legend)
+                  });
                }
 
             } // legend


### PR DESCRIPTION
Before: --legend had to be invoked with a different name than the actual option name. This to prevent the parsing to interpret the passed value as an actual invocation of the value as the option. `casual service --legend list-services`

Now: We use suboptions for --legend with the name of the actual option `casual service --legend --list-services`

As of now, we can't force at least one suboption to be passed -> user could get completion for other actual options that does not have legends. This could happen _before_ also.

It would be nice to have `at_least_one( subopt1, subopt2, ..., suboptN), but I'm not sure how that would work in all situations.