### PR TITLE
discovery: remove invalid sanity check

### DIFF
--- a/middleware/domain/source/discovery/state.cpp
+++ b/middleware/domain/source/discovery/state.cpp
@@ -118,14 +118,9 @@ namespace casual
                   {
                      auto pending = heuristic.pending_requests();
 
-                     // sanity check. We should never have reach this with low in-flights
+                     // this may happen since we always accumulate topology requests
                      if( pending <= heuristic.in_flight_window)
-                     {
-                        log::line( log::category::error, code::casual::invalid_semantics, " unexpected inflight: ", pending);
-                        log::line( log::category::verbose::error, "heuristic: ", heuristic );
-
                         return common::signal::timer::Deadline{ heuristic.duration};
-                     }
 
                      auto load_level = pending / heuristic.in_flight_window;
                      log::line( verbose::log, "load_level: ", load_level);


### PR DESCRIPTION
Before: The accumulate functionality in casual-domain-discovery had a sanity check that would log an error invalid-semantics error if there were less pending than requests in-flight. This check did not account for the fact that topolygy requests are always accumulated, making this situation 'valid'.

Now: The check has been removed.

Resolves #443