### PR TITLE
gateway: fix timing issue in unittest

### DIFF
--- a/middleware/common/include/common/unittest.h
+++ b/middleware/common/include/common/unittest.h
@@ -184,6 +184,21 @@ namespace casual
                return state;
             };
          }
+
+         namespace message::counter
+         {
+            template< typename D, typename F>
+            auto until( D&& device, F predicate)
+            {
+               auto fetcher = fetch::until( [ &device]
+               {
+                  return communication::ipc::call( std::forward< D>( device), common::message::counter::Request{ common::process::handle()});
+               });
+
+               return fetcher( predicate);
+            }
+         } // message::counter
+
       } // fetch
 
       namespace regex

--- a/middleware/gateway/unittest/source/test_manager.cpp
+++ b/middleware/gateway/unittest/source/test_manager.cpp
@@ -1487,6 +1487,18 @@ domain:
          unittest::fetch::until( unittest::fetch::predicate::outbound::connected());
       
          const auto payload = common::unittest::random::binary( 128);
+
+         // we wait until the SM has received the fetch known request that casual-domain-discovery sends upon receiving the connection to B
+         {
+            auto received_fetch_known = []( auto& reply)
+            {
+               auto found = algorithm::find( reply.entries, common::message::Type::domain_discovery_fetch_known_request);
+               return found && found->received == 1;
+            };
+
+            common::unittest::fetch::message::counter::until( communication::instance::outbound::service::manager::device(), received_fetch_known);
+         }
+
          const auto correlation = common::unittest::service::send( "b", payload);
 
          b.activate();
@@ -1541,7 +1553,7 @@ domain:
                EXPECT_TRUE( found->received == 1) << CASUAL_NAMED_VALUE( *found);
             }
          });
-         
+
          // act a server and reply
          {
             EXPECT_TRUE( casual::service::unittest::server::echo( correlation));


### PR DESCRIPTION
Before: One of the gateway unittests had an issue where the accumulate mechanism in casual-domain-discovery could cause an additional discovery to be sent, contrary to the assumptions of the test.

Now: We wait for the accumulate to time out, ensuring that only the service call will trigger a discovery.

Resolves #449