### PR TITLE
service: discovery fetch known only discoverable

### DIFF
--- a/middleware/service/source/manager/handle.cpp
+++ b/middleware/service/source/manager/handle.cpp
@@ -904,7 +904,7 @@ namespace casual
                         reply.content.services = algorithm::accumulate( state.services, std::move( reply.content.services), []( auto result, auto& pair)
                         {
                            const auto& [ name, service] = pair;
-                           if( ! service.is_sequential())
+                           if( ! service.is_sequential() && service.is_discoverable())
                               result.push_back( name);
 
                            return result;

--- a/middleware/service/unittest/source/manager/test_manager.cpp
+++ b/middleware/service/unittest/source/manager/test_manager.cpp
@@ -472,6 +472,32 @@ domain:
          }
       }
 
+      TEST( service_manager, concurrent_advertise_a_b___b_undiscoverable__fetch_known__expect_a)
+      {
+         common::unittest::Trace trace;
+
+         constexpr auto configuration = R"(
+domain:
+   services:
+      -  name: a
+         visibility: discoverable
+      -  name: b
+         visibility: undiscoverable
+)";
+
+         auto domain = local::domain( configuration);
+         service::unittest::concurrent::advertise( { "a", "b"});
+
+         // emulate a fetch known from discovery
+         {            
+            domain::message::discovery::fetch::known::Request request{ common::process::handle()};
+            auto reply = common::communication::ipc::call( common::communication::instance::outbound::service::manager::device(), request);
+            
+            ASSERT_TRUE( reply.content.services.size() == 1) << CASUAL_NAMED_VALUE( reply);
+            EXPECT_TRUE( reply.content.services.at( 0) == "a") << CASUAL_NAMED_VALUE( reply);
+         }
+      }
+
       TEST( service_manager, advertise_2_services_for_1_server)
       {
          common::unittest::Trace trace;


### PR DESCRIPTION
This patch:
Excludes services that is _undiscoverable_ for the discovery::fetch::known::Reply

Resolves #454