### PR TITLE
queue: fix forwards ignoring group memberships

### DIFF
--- a/middleware/administration/unittest/source/cli/test_queue.cpp
+++ b/middleware/administration/unittest/source/cli/test_queue.cpp
@@ -614,5 +614,148 @@ domain:
          }
       }
 
+      TEST( cli_queue, enable_forward_group_membership__expect_enabled)
+      {
+         common::unittest::Trace trace;
+
+         auto domain = local::domain( R"(
+domain:
+   groups:
+      -  name: disabled-group
+         dependencies: [ queue]
+         enabled: false
+
+   queue:
+      forward:
+         groups:
+            -  alias: forward-group
+               memberships:
+                  - disabled-group
+               services:
+                  -  alias: disabled-forward-service
+                     instances: 1
+                     memberships:
+                        -  disabled-group
+                     source: some-queue
+                     target:
+                        service: some-service
+               queues:
+                  -  alias: disabled-forward-queue
+                     instances: 1
+                     memberships:
+                        -  disabled-group
+                     source: some-other-queue
+                     target:
+                        queue: yet-another-queue
+)");
+
+         // forward group
+         {
+            auto capture = local::execute( R"(casual queue --list-forward-groups --porcelain true | awk -F'|' '{printf $8}')");
+            EXPECT_EQ( capture.standard.out, "D") << CASUAL_NAMED_VALUE( capture);
+         }
+
+         // forward service
+         {
+            auto capture = local::execute( R"(casual queue --list-forward-services --porcelain true | awk -F'|' '{printf $12}')");
+            EXPECT_EQ( capture.standard.out, "D") << CASUAL_NAMED_VALUE( capture);
+         }
+
+         // forward queue
+         {
+            auto capture = local::execute( R"(casual queue --list-forward-queues --porcelain true | awk -F'|' '{printf $11}')");
+            EXPECT_EQ( capture.standard.out, "D") << CASUAL_NAMED_VALUE( capture);
+         }
+
+         // enable the group
+         {
+            auto capture = administration::unittest::cli::command::execute( "casual configuration --enable-groups disabled-group");
+            EXPECT_TRUE( capture.exit == 0);
+         }
+
+         // forward group
+         {
+            auto capture = local::execute( R"(casual queue --list-forward-groups --porcelain true | awk -F'|' '{printf $8}')");
+            EXPECT_EQ( capture.standard.out, "E") << CASUAL_NAMED_VALUE( capture);
+         }
+
+         // forward service
+         {
+            auto capture = local::execute( R"(casual queue --list-forward-services --porcelain true | awk -F'|' '{printf $12}')");
+            EXPECT_EQ( capture.standard.out, "E") << CASUAL_NAMED_VALUE( capture);
+         }
+
+         // forward queue
+         {
+            auto capture = local::execute( R"(casual queue --list-forward-queues --porcelain true | awk -F'|' '{printf $11}')");
+            EXPECT_EQ( capture.standard.out, "E") << CASUAL_NAMED_VALUE( capture);
+         }
+      }
+
+
+      TEST( cli_queue, enable_forward_service_queue_membership__expect_enabled)
+      {
+         common::unittest::Trace trace;
+
+         auto domain = local::domain( R"(
+domain:
+   groups:
+      -  name: disabled-group
+         dependencies: [ queue]
+         enabled: false
+
+   queue:
+      forward:
+         groups:
+            -  alias: forward-group
+               services:
+                  -  alias: disabled-forward-service
+                     instances: 1
+                     memberships:
+                        -  disabled-group
+                     source: some-queue
+                     target:
+                        service: some-service
+               queues:
+                  -  alias: disabled-forward-queue
+                     instances: 1
+                     memberships:
+                        - disabled-group
+                     source: some-other-queue
+                     target:
+                        queue: yet-another-queue
+)");
+
+         // forward service
+         {
+            auto capture = local::execute( R"(casual queue --list-forward-services --porcelain true | awk -F'|' '{printf $12}')");
+            EXPECT_EQ( capture.standard.out, "D") << CASUAL_NAMED_VALUE( capture);
+         }
+
+         // forward queue
+         {
+            auto capture = local::execute( R"(casual queue --list-forward-queues --porcelain true | awk -F'|' '{printf $11}')");
+            EXPECT_EQ( capture.standard.out, "D") << CASUAL_NAMED_VALUE( capture);
+         }
+
+         // enable the group
+         {
+            auto capture = administration::unittest::cli::command::execute( "casual configuration --enable-groups disabled-group");
+            EXPECT_TRUE( capture.exit == 0);
+         }
+
+         // forward service
+         {
+            auto capture = local::execute( R"(casual queue --list-forward-services --porcelain true | awk -F'|' '{printf $12}')");
+            EXPECT_EQ( capture.standard.out, "E") << CASUAL_NAMED_VALUE( capture);
+         }
+
+         // forward queue
+         {
+            auto capture = local::execute( R"(casual queue --list-forward-queues --porcelain true | awk -F'|' '{printf $11}')");
+            EXPECT_EQ( capture.standard.out, "E") << CASUAL_NAMED_VALUE( capture);
+         }
+      }
+
    } // administration
 } // casual

--- a/middleware/configuration/include/configuration/model.h
+++ b/middleware/configuration/include/configuration/model.h
@@ -677,6 +677,7 @@ namespace casual::configuration
                std::string source;
                platform::size::type instances = 1;
                std::string note;
+               bool enabled = true;
                std::vector< std::string> memberships;
 
                friend auto operator <=> ( const forward_base&, const forward_base&) = default;
@@ -687,6 +688,7 @@ namespace casual::configuration
                   CASUAL_SERIALIZE( instances);
                   CASUAL_SERIALIZE( note);
                   CASUAL_SERIALIZE( memberships);
+                  CASUAL_SERIALIZE( enabled);
                )
             };
 
@@ -749,6 +751,7 @@ namespace casual::configuration
                std::vector< forward::Queue> queues;
                std::string note;
                std::vector< std::string> memberships;
+               bool enabled = true;
 
                Group set_union( Group lhs, Group rhs);
                Group set_difference( Group lhs, Group rhs);
@@ -764,6 +767,7 @@ namespace casual::configuration
                   CASUAL_SERIALIZE( queues);
                   CASUAL_SERIALIZE( note);
                   CASUAL_SERIALIZE( memberships);
+                  CASUAL_SERIALIZE( enabled);
                )
             };
          } // forward

--- a/middleware/configuration/source/model.cpp
+++ b/middleware/configuration/source/model.cpp
@@ -637,6 +637,16 @@ namespace casual
 
             algorithm::for_each( model.gateway.outbound.groups, update_connections);
             algorithm::for_each( model.gateway.inbound.groups, update_connections);
+
+            auto update_forward_groups = [ &]( auto& group)
+            {
+               update_enabled( group);
+
+               algorithm::for_each( group.services, update_enabled);
+               algorithm::for_each( group.queues, update_enabled);
+            };
+
+            algorithm::for_each( model.queue.forward.groups, update_forward_groups);
          }
 
          return model;

--- a/middleware/queue/include/queue/forward/state.h
+++ b/middleware/queue/include/queue/forward/state.h
@@ -20,8 +20,6 @@
 #include "common/communication/select.h"
 #include "common/communication/ipc/send.h"
 
-#include "configuration/group.h"
-
 #include <vector>
 #include <string>
 #include <iosfwd>
@@ -446,7 +444,7 @@ namespace casual
 
          std::vector< std::string> memberships;
 
-         configuration::group::Coordinator group_coordinator;
+         bool enabled;
 
          //! we're done when we're in shutdown mode
          //! and all forwards has no concurrent stuff in flight.

--- a/middleware/queue/source/forward/handle.cpp
+++ b/middleware/queue/source/forward/handle.cpp
@@ -32,23 +32,24 @@ namespace casual
       {
          namespace
          {
+            namespace detail::forward
+            {
+               template< typename F>
+               bool enabled( State& state, const F& forward)
+               {
+                  return state.enabled && forward.enabled;
+               }
+            } // detail::forward
+
             namespace transform::forward
             {
-               namespace detail::forward
-               {
-                  bool enabled( State& state, const std::vector< std::string>& forward_memberships)
-                  {
-                     return state.group_coordinator.enabled( state.memberships) && state.group_coordinator.enabled( forward_memberships);
-                  }
-               } // detail::forward
-
                auto service( State& state)
                {
                   return [ &]( auto& service)
                   {
                      state::forward::Service result;
                      result.alias = service.alias;
-                     result.enabled = detail::forward::enabled( state, service.memberships);
+                     result.enabled = detail::forward::enabled( state, service);
                      result.source.queue = service.source;
                      
                      if( service.reply)
@@ -70,7 +71,7 @@ namespace casual
                   {
                      state::forward::Queue result;
                      result.alias = queue.alias;
-                     result.enabled = detail::forward::enabled( state, queue.memberships);
+                     result.enabled = detail::forward::enabled( state, queue);
                      result.source.queue = queue.source;
 
                      result.target.queue = queue.target.queue;
@@ -430,19 +431,24 @@ namespace casual
 
                         state.alias = message.model.alias;
                         state.memberships = message.model.memberships;
-                        state.group_coordinator = { message.groups};
+                        state.enabled = message.model.enabled;
 
                         // TODO maintenance we only update instances
-                        auto add_or_update = []( auto& source, auto& target, auto transform)
+                        auto add_or_update = [ &state]( auto& source, auto& target, auto transform)
                         {
                            auto handle_source = [&]( auto& forward)
                            {
-                              auto is_alias = [&alias = forward.alias]( auto& forward){ return forward.alias == alias;};
+                              auto is_alias = [ &alias = forward.alias]( auto& forward){ return forward.alias == alias;};
 
                               if( auto found = algorithm::find_if( target, is_alias))
+                              {
                                  found->instances.configured = forward.instances;
+                                 found->enabled = detail::forward::enabled( state, forward);
+                              }
                               else
+                              {
                                  target.push_back( transform( forward));
+                              }
                            };
 
                            algorithm::for_each( source, handle_source);
@@ -935,7 +941,7 @@ namespace casual
 
                         auto reply = common::message::reverse::type( message, process::handle());
                         reply.alias = state.alias;
-                        reply.enabled = state.group_coordinator.enabled( state.memberships);
+                        reply.enabled = state.enabled;
                         reply.services = algorithm::transform( state.forward.services, transform_service);
                         reply.queues = algorithm::transform( state.forward.queues, transform_queue);
 

--- a/middleware/queue/source/manager/configuration.cpp
+++ b/middleware/queue/source/manager/configuration.cpp
@@ -294,7 +294,7 @@ namespace casual
 
                   for( auto& group : configuration)
                   {
-                     if( auto found = algorithm::find( state.groups, group.alias))
+                     if( auto found = algorithm::find( state.forward.groups, group.alias))
                      {
                         queue::ipc::message::forward::group::configuration::update::Request request{ common::process::handle()};
                         request.model = group;


### PR DESCRIPTION
This commit fixes an issue where forwards would not receive configuration updates when their group memberships changed. This made it so that enabling or disabling groups that a forward was dependent on would not affect the forward.

Resolves #465