### PR TITLE
queue: fix runtime configuration for (en|dis)able (en|de)queue

### DIFF
--- a/middleware/queue/source/manager/configuration.cpp
+++ b/middleware/queue/source/manager/configuration.cpp
@@ -243,12 +243,21 @@ namespace casual
 
                auto update_action = [ &state, shared, configuration = std::move( groups)]( task::unit::id)
                {
-                  Trace trace{ "queue::manager::configuration::conform groups shutdown_action"};
+                  Trace trace{ "queue::manager::configuration::conform::local::modified_groups update_action"};
 
                   for( auto& group : configuration)
                   {
                      if( auto found = algorithm::find( state.groups, group.alias))
                      {
+                        // TODO - the groups should have the responsibility for it's total configuration.
+                        //   I think we should move the configuration to the group, and let the group tell 
+                        //   us (the manager) what to do. This way we can have a more clear separation of
+                        //   concerns. The group should be the one that knows what queues it has and what 
+                        //   configuration they have.
+
+                        // set new configuration for the group
+                        found->configuration = group;
+
                         queue::ipc::message::group::configuration::update::Request request{ common::process::handle()};
                         request.model = group;
                         state.multiplex.send( found->process.ipc, request);

--- a/middleware/queue/source/manager/state.cpp
+++ b/middleware/queue/source/manager/state.cpp
@@ -90,40 +90,53 @@ namespace casual
          return nullptr;
       }
 
-      void State::update( queue::ipc::message::group::configuration::update::Reply reply)
+      void State::update( queue::ipc::message::group::configuration::update::Reply message)
       {
-         Trace trace{ "queue::manager::State::update"};
+         Trace trace{ "queue::manager::State::update configuration"};
 
          // we'll make it easy - first we remove all queues associated with the pid, then we'll add 
          // the 'configured' ones
 
-         remove_queues( reply.process.pid);
+         remove_queues( message.process.pid);
 
-         auto update_group = []( auto& state, auto& group, auto& reply)
+         auto update_group = []( auto& state, auto& group, auto& message)
          {
             group.state = decltype( group.state())::running;
 
-            for( auto& queue : reply.queues)
+            for( auto& queue : message.queues)
             {
                auto& instances = state.queues[ queue.name];
                {
-                  auto& instance = instances.emplace_back();
-                  instance.process = group.process;
-                  instance.queue = queue.id;
-                  
+                  auto instance = [ &]()
+                  {
+                     if( auto found = algorithm::find( instances, message.process.ipc))
+                        return found.data();
+                     return &instances.emplace_back();
+                     
+                  }();
+
+                  instance->process = group.process;
+                  instance->queue = queue.id;
+
+                  // TODO - the groups should have the responsibility for it's total configuration.
+                  //   I think we should move the configuration to the group, and let the group tell 
+                  //   us (the manager) what to do. This way we can have a more clear separation of
+                  //   concerns. The group should be the one that knows what queues it has and what 
+                  //   configuration they have.
+                  // 
                   // get the enable from configuration
                   if( auto found = algorithm::find( group.configuration.queues, queue.name))
-                     instance.enable = found->enable;
+                     instance->enable = found->enable;
                }
                
                algorithm::sort( instances);
             }
          };
 
-         if( auto found = algorithm::find( groups, reply.process.pid))
-            update_group( *this, *found, reply);
+         if( auto found = algorithm::find( groups, message.process.pid))
+            update_group( *this, *found, message);
          else
-            log::line( log::category::error, "failed to correlate group", reply.process, " - action: discard");
+            log::line( log::category::error, "failed to correlate group", message.process, " - action: discard");
             
       }
 

--- a/middleware/queue/unittest/source/test_queue.cpp
+++ b/middleware/queue/unittest/source/test_queue.cpp
@@ -31,10 +31,14 @@
 
 #include "domain/discovery/api.h"
 #include "domain/unittest/manager.h"
+#include "domain/unittest/configuration.h"
 
 #include "queue/manager/admin/services.h"
 #include "serviceframework/service/protocol.h"
 #include "serviceframework/service/protocol/call.h"
+
+#include "configuration/model/transform.h"
+#include "configuration/unittest/utility.h"
 
 #include <fstream>
 #include <future>
@@ -1457,6 +1461,42 @@ domain:
          EXPECT_TRUE( reply.code == decltype( reply.code)::no_queue) << CASUAL_NAMED_VALUE( reply);
       }
 
+      namespace local
+      {
+         namespace
+         {
+            auto error_code_enqueue( std::string name) -> std::error_code
+            {
+               try
+               {
+                  queue::Message message;
+                  queue::enqueue( name, message);
+                  return common::code::queue::ok;
+               }
+               catch( const std::system_error& error)
+               {
+                  return error.code();
+               }
+            };
+
+            auto error_code_dequeue( std::string name) -> std::error_code
+            {
+               try
+               {
+                  auto message = queue::dequeue( name);
+                  if( ! message.empty())
+                     return common::code::queue::ok;
+                  else 
+                     return common::code::queue::no_message;
+               }
+               catch( const std::system_error& error)
+               {
+                  return error.code();
+               }
+            };
+         } // <unnamed>
+      } // local
+
 
       TEST( casual_queue, enqueue_dequeue_enable)
       {
@@ -1482,47 +1522,87 @@ domain:
 
 )");
 
-         auto enqueue = []( std::string name) -> std::error_code
-         {
-            try
-            {
-               queue::Message message;
-               queue::enqueue( name, message);
-               return common::code::queue::ok;
-            }
-            catch( const std::system_error& error)
-            {
-               return error.code();
-            }
-         };
 
-         auto dequeue = []( std::string name) -> std::error_code
-         {
-            try
-            {
-               auto message = queue::dequeue( name);
-               if( ! message.empty())
-                  return common::code::queue::ok;
-               else 
-                  return common::code::queue::no_message;
-            }
-            catch( const std::system_error& error)
-            {
-               return error.code();
-            }
-         };
+         EXPECT_TRUE( local::error_code_enqueue( "a") == common::code::queue::no_queue);
+         EXPECT_TRUE( local::error_code_enqueue( "b") == common::code::queue::ok);
+         EXPECT_TRUE( local::error_code_enqueue( "c") == common::code::queue::no_queue);
+         EXPECT_TRUE( local::error_code_enqueue( "d") == common::code::queue::ok);
 
-
-         EXPECT_TRUE( enqueue( "a") == common::code::queue::no_queue);
-         EXPECT_TRUE( enqueue( "b") == common::code::queue::ok);
-         EXPECT_TRUE( enqueue( "c") == common::code::queue::no_queue);
-         EXPECT_TRUE( enqueue( "d") == common::code::queue::ok);
-
-         EXPECT_TRUE( dequeue( "a") == common::code::queue::no_message);
-         EXPECT_TRUE( dequeue( "b") == common::code::queue::no_queue);
-         EXPECT_TRUE( dequeue( "c") == common::code::queue::no_queue);
+         EXPECT_TRUE( local::error_code_dequeue( "a") == common::code::queue::no_message);
+         EXPECT_TRUE( local::error_code_dequeue( "b") == common::code::queue::no_queue);
+         EXPECT_TRUE( local::error_code_dequeue( "c") == common::code::queue::no_queue);
          // we've enqueued to d before
-         EXPECT_TRUE( dequeue( "d") == common::code::queue::ok);
+         EXPECT_TRUE( local::error_code_dequeue( "d") == common::code::queue::ok);
+      }
+
+      TEST( casual_queue, runtime_enqueue_dequeue_enable)
+      {
+         common::unittest::Trace trace;
+
+         auto a = local::domain( R"(
+domain:
+   name: A
+   queue:
+      groups:
+         -  alias: "QA"
+            queues:
+               -  name: a
+                  enable:
+                     enqueue: false
+               -  name: b
+                  enable:
+                     dequeue: false
+               -  name: c
+                  enable:
+                     enqueue: false
+                     dequeue: false
+         )");
+
+         constexpr std::string_view wanted = R"(
+domain:
+   name: A
+   queue:
+      groups:
+         -  alias: "QA"
+            queues:
+               -  name: a
+                  enable:
+                     dequeue: false
+               -  name: b
+                  enable:
+                     enqueue: false
+               -  name: c
+         )";
+         
+         // runtime update 
+         {
+            auto model = configuration::model::transform( domain::unittest::configuration::post( configuration::model::transform( configuration::unittest::load( local::configuration::servers, wanted))));
+
+            // check that the model is as expected
+            ASSERT_TRUE( model.queue.groups.size() == 1);
+            ASSERT_TRUE( model.queue.groups.at( 0).queues.size() == 3);
+            EXPECT_TRUE( model.queue.groups.at( 0).queues.at( 0).name == "a");
+            EXPECT_TRUE( model.queue.groups.at( 0).queues.at( 0).enable.enqueue == true);
+            EXPECT_TRUE( model.queue.groups.at( 0).queues.at( 0).enable.dequeue == false);
+            EXPECT_TRUE( model.queue.groups.at( 0).queues.at( 1).name == "b");
+            EXPECT_TRUE( model.queue.groups.at( 0).queues.at( 1).enable.enqueue == false);
+            EXPECT_TRUE( model.queue.groups.at( 0).queues.at( 1).enable.dequeue == true);
+            EXPECT_TRUE( model.queue.groups.at( 0).queues.at( 2).name == "c");
+            EXPECT_TRUE( model.queue.groups.at( 0).queues.at( 2).enable.enqueue == true);
+            EXPECT_TRUE( model.queue.groups.at( 0).queues.at( 2).enable.dequeue == true);
+         }
+
+         
+
+         EXPECT_TRUE( local::error_code_enqueue( "a") == common::code::queue::ok);
+         EXPECT_TRUE( local::error_code_dequeue( "a") == common::code::queue::no_queue);
+
+         EXPECT_TRUE( local::error_code_enqueue( "b") == common::code::queue::no_queue);
+         // enabled but nu message on the queue
+         EXPECT_TRUE( local::error_code_dequeue( "b") == common::code::queue::no_message);
+
+         EXPECT_TRUE( local::error_code_enqueue( "c") == common::code::queue::ok);
+         EXPECT_TRUE( local::error_code_dequeue( "c") == common::code::queue::ok);
 
       }
 


### PR DESCRIPTION
Before: We didn't update the enable/disable for enqueue/dequeue during runtime configuration update.

Now: We do.

resolves #464