### PR TITLE
queue: default queue-group alias missing

### DIFF
--- a/middleware/configuration/source/model.cpp
+++ b/middleware/configuration/source/model.cpp
@@ -567,13 +567,18 @@ namespace casual
             algorithm::for_each( model.domain.servers, normalizer);
          }
 
+         // normalize alias for queue-group and queue-forward
          {
             state.count = {};
-            auto forward_alias = alias::normalize::mutator( state, []( auto&){ return "forward";});
 
-            algorithm::for_each( model.queue.forward.groups, [&forward_alias, &state]( auto& group)
+            auto group_normalizer = alias::normalize::mutator( state, []( auto& value){ return "group";});
+            algorithm::for_each( model.queue.groups, group_normalizer);
+
+            auto forward_normalizer = alias::normalize::mutator( state, []( auto&){ return "forward";});
+
+            algorithm::for_each( model.queue.forward.groups, [&forward_normalizer, &state]( auto& group)
             {
-               forward_alias( group);
+               forward_normalizer( group);
                
                // normalize the forwards
                auto normalizer = alias::normalize::mutator( state, []( auto& value){ return value.source;});
@@ -582,6 +587,7 @@ namespace casual
             });;
          }
 
+         // normalize alias for gateway
          {
             state.count = {};
             

--- a/middleware/queue/unittest/source/test_forward.cpp
+++ b/middleware/queue/unittest/source/test_forward.cpp
@@ -252,6 +252,42 @@ domain:
 
       }
 
+      TEST( casual_queue_forward, no_queue_forward_alias__expect__state__default_queue_forward_alias)
+      {
+         common::unittest::Trace trace;
+
+         auto domain = local::domain( R"(
+domain:
+   name: A
+   queue:
+      forward:
+         groups:
+            -  services:
+                  -  alias: foo
+                     source: a1
+                     target: 
+                        service: queue/unittest/service
+            -  services:
+                  -  alias: bar
+                     source: a2
+                     target: 
+                        service: queue/unittest/service
+            -  alias: C
+               services:
+                  -  alias: baz
+                     source: a3
+                     target: 
+                        service: queue/unittest/service
+)");
+         auto state = unittest::state();
+
+         ASSERT_TRUE( state.forward.groups.size() == 3) << CASUAL_NAMED_VALUE( state.forward.groups);
+         EXPECT_TRUE( state.forward.groups.at( 0).alias == "forward") << CASUAL_NAMED_VALUE( state.forward.groups);
+         EXPECT_TRUE( state.forward.groups.at( 1).alias == "forward.2") << CASUAL_NAMED_VALUE( state.forward.groups);
+         EXPECT_TRUE( state.forward.groups.at( 2).alias == "C") << CASUAL_NAMED_VALUE( state.forward.groups);
+      }
+      
+
       TEST( casual_queue_forward, scale_all_aliases_to_5_instances)
       {
          common::unittest::Trace trace;

--- a/middleware/queue/unittest/source/test_queue.cpp
+++ b/middleware/queue/unittest/source/test_queue.cpp
@@ -171,6 +171,33 @@ domain:
          EXPECT_TRUE( find_and_compare_queue( "b3", default_retry));
       }
 
+      TEST( casual_queue, no_queue_group_alias__expect__state__default_queue_group_alias)
+      {
+         common::unittest::Trace trace;
+
+         auto domain = local::domain( R"(
+domain:
+   name: A
+   queue:
+      groups:
+         -  queues:
+               -  name: a1
+         -  queues:
+               -  name: b1
+         -  alias: C
+            queues:
+               -  name: c1
+)");
+
+
+         auto state = unittest::state();
+
+         ASSERT_TRUE( state.groups.size() == 3) << CASUAL_NAMED_VALUE( state.groups);
+         EXPECT_TRUE( state.groups.at( 0).alias == "group") << CASUAL_NAMED_VALUE( state.groups);
+         EXPECT_TRUE( state.groups.at( 1).alias == "group.2") << CASUAL_NAMED_VALUE( state.groups);
+         EXPECT_TRUE( state.groups.at( 2).alias == "C") << CASUAL_NAMED_VALUE( state.groups);
+      }
+
 
       TEST( casual_queue, lookup_request_a1__expect_existence)
       {


### PR DESCRIPTION
Before: We didn't set a default queue-group alias if the user didn't provide one. This could give a whole bunch of problems. If you had two _unaliased_ queue group, both of them tries to create the queuebase file at the same path, since queuebase path is based on alias.

Now: we set a default `group`, `group.2`... `group.N`, as we do elsewhere.

resolves #474