### PR TITLE
queue: reset queue group metric on startup

### DIFF
--- a/middleware/queue/include/queue/group/queuebase/schema.h
+++ b/middleware/queue/include/queue/group/queuebase/schema.h
@@ -61,7 +61,7 @@ CREATE INDEX IF NOT EXISTS i_message_available ON message ( available ASC);
 CREATE INDEX IF NOT EXISTS i_gtrid_message  ON message ( gtrid, state);
 )";
             } // index
-         } // inline v2_0
+         } // inline v3_0
       } // table
 
       inline namespace v3_0
@@ -139,7 +139,7 @@ DROP TRIGGER IF EXISTS delete_message;
 )";
          } // drop
          
-      } // inline v2_0
+      } // inline v3_0
 
    } // queue::group::queuebase::schema
 } // casual

--- a/middleware/queue/include/queue/group/queuebase/statement.h
+++ b/middleware/queue/include/queue/group/queuebase/statement.h
@@ -93,5 +93,12 @@ namespace casual
 
       Statement statement( sql::database::Connection& connection);
 
+      namespace metric
+      {
+         //! @return an sql statement that resets the metric counters for all queues
+         std::string_view reset();
+         
+      } // metric
+
    } // queue::group::queuebase
 } // casual

--- a/middleware/queue/source/group/handle.cpp
+++ b/middleware/queue/source/group/handle.cpp
@@ -660,6 +660,10 @@ namespace casual
                         if( ! message.model.queuebase.empty())
                            return group::Queuebase{ message.model.queuebase};
 
+                        // sanity check
+                        if( message.model.alias.empty())
+                           common::event::error::raise( common::code::casual::internal_unexpected_value, "queuebase alias is empty");
+
                         if( ! message.model.directory.empty())
                            return group::Queuebase{ message.model.directory + "/" + message.model.alias + ".qb"};
                         

--- a/middleware/queue/source/group/queuebase.cpp
+++ b/middleware/queue/source/group/queuebase.cpp
@@ -237,6 +237,11 @@ namespace casual
          // Precompile all other statements
          m_statement = queuebase::statement( m_connection);
 
+         {
+            Trace trace{ "queue::group::Queuebase::Queuebase reset metrics"};
+            m_connection.statement( queuebase::metric::reset());
+         }
+
          // start transaction
          m_connection.exclusive_begin();
       }

--- a/middleware/queue/source/group/queuebase/statement.cpp
+++ b/middleware/queue/source/group/queuebase/statement.cpp
@@ -293,5 +293,15 @@ WHERE queue = :queue AND state = 2 AND timestamp > :timestamp AND available < :a
          return result;
       }
 
+      namespace metric
+      {
+         std::string_view reset()
+         {
+            return R"( 
+            UPDATE queue
+            SET metric_dequeued = 0, metric_enqueued = 0; )";
+         }
+      } // metric
+
    } // queue::group::queuebase
 } // casual

--- a/middleware/queue/unittest/include/queue/unittest/utility.h
+++ b/middleware/queue/unittest/include/queue/unittest/utility.h
@@ -19,7 +19,7 @@ namespace casual
       namespace fetch
       {
          constexpr auto until = common::unittest::fetch::until( &unittest::state);
-      }
+      } // fetch
 
       std::vector< manager::admin::model::Message> messages( const std::string& queue);
 

--- a/middleware/queue/unittest/source/test_queue.cpp
+++ b/middleware/queue/unittest/source/test_queue.cpp
@@ -198,6 +198,58 @@ domain:
          EXPECT_TRUE( state.groups.at( 2).alias == "C") << CASUAL_NAMED_VALUE( state.groups);
       }
 
+      TEST( casual_queue, enqueue_to_persistent_group__shutdown__boot_same_persistent_group__expect_metrics_reset)
+      {
+         common::unittest::Trace trace;
+
+         auto queuebase = common::unittest::file::temporary::name( ".qb"); 
+
+         auto guard = common::unittest::environment::scoped::variable( "CASUAL_TEST_QUEUEBASE", queuebase.string());
+
+         constexpr std::string_view queue_configuration = R"(
+domain:
+   name: A
+   queue:
+      groups:
+         -  queuebase: ${CASUAL_TEST_QUEUEBASE}
+            queues:
+               -  name: a
+)";
+         
+         {
+            auto domain = local::domain( queue_configuration);
+
+            // enqueue and dequeue a few times
+            common::algorithm::for_n< 5>( []()
+            {
+               queue::Message message;
+               queue::enqueue( "a", message);
+               std::ignore = queue::dequeue( "a");
+            });
+
+            auto state = unittest::state();
+
+            // expect 2 queues, a and a.error
+            ASSERT_TRUE( state.queues.size() == 2) << CASUAL_NAMED_VALUE( state.queues);
+            EXPECT_TRUE( state.queues.at( 1).name == "a");
+            EXPECT_TRUE( state.queues.at( 1).metric.enqueued == 5) << CASUAL_NAMED_VALUE( state.queues);
+            EXPECT_TRUE( state.queues.at( 1).metric.dequeued == 5) << CASUAL_NAMED_VALUE( state.queues);
+         }
+
+         {
+            auto domain = local::domain( queue_configuration);
+
+            auto state = unittest::state();
+
+            // expect 2 queues, a and a.error
+            ASSERT_TRUE( state.queues.size() == 2) << CASUAL_NAMED_VALUE( state.queues);
+            EXPECT_TRUE( state.queues.at( 1).name == "a");
+            // expect metrics to be reset
+            EXPECT_TRUE( state.queues.at( 1).metric.enqueued == 0) << CASUAL_NAMED_VALUE( state.queues);
+            EXPECT_TRUE( state.queues.at( 1).metric.dequeued == 0) << CASUAL_NAMED_VALUE( state.queues);
+         }
+      }
+
 
       TEST( casual_queue, lookup_request_a1__expect_existence)
       {

--- a/thirdparty/database/include/sql/database.h
+++ b/thirdparty/database/include/sql/database.h
@@ -551,9 +551,9 @@ namespace sql
             query( statement, std::forward< Params>( params)...).execute();
          }
 
-         inline void statement( const char* sql)
+         inline void statement( std::string_view sql)
          {
-            if( auto code = code::make( sqlite3_exec( m_handle.get(), sql, nullptr, nullptr, nullptr)))
+            if( auto code = code::make( sqlite3_exec( m_handle.get(), sql.data(), nullptr, nullptr, nullptr)))
                code::raise( code, m_handle);
          }
 


### PR DESCRIPTION
The metric for totally enqueued and dequeued committed messages is kept in the `qeueue` table. Hence the metrics are persistent (if the queue-group is persistent).

* This behavior is not coherent with the rest of casual metrics
* Users has requested metrics not to be persistent

This patch resets the metrics for enqueued/dequeued to `0` during startup.

resolves #469