### PR TITLE
transaction: reopen resource on resource error

### DIFF
--- a/middleware/common/include/common/algorithm/compare.h
+++ b/middleware/common/include/common/algorithm/compare.h
@@ -14,10 +14,14 @@ namespace casual
       template< typename V, typename... Vs>
       constexpr bool any( V&& value, Vs&&... values)
       {
-         auto equal = []( auto&& l, auto& r){ return l == r;}; // to mitigate g++ 9.3.1 bug
-         return ( equal( value, values) || ... ); 
+         return ( ( value == values) || ... ); 
       }
 
+      template< typename V, typename... Vs>
+      constexpr bool none( V&& value, Vs&&... values)
+      {
+         return ( ( value != values) && ... );
+      }
 
    } // common::algorithm::compare
 } // casual

--- a/middleware/common/source/transaction/resource.cpp
+++ b/middleware/common/source/transaction/resource.cpp
@@ -10,6 +10,7 @@
 #include "common/transaction/resource.h"
 #include "common/transaction/id.h"
 #include "common/environment/expand.h"
+#include "common/algorithm/compare.h"
 
 #include "common/log/line.h"
 #include "common/flag.h"
@@ -238,7 +239,7 @@ namespace casual
       {
          auto result = functor();
 
-         if( result != code::xa::resource_fail)
+         if( algorithm::compare::none( result, code::xa::resource_fail, code::xa::resource_error))
             return result;
          
          log::error( result, "failed to interact with resource ", m_id, " - action: try to reopen the resource");

--- a/middleware/common/unittest/source/test_algorithm.cpp
+++ b/middleware/common/unittest/source/test_algorithm.cpp
@@ -566,6 +566,33 @@ namespace casual
          EXPECT_TRUE( algorithm::compare::any( 1, 5, 4, 3, 2, 1));
       }
 
+      TEST( common_algorithm_compare_none, value_1__to_2__expect_true)
+      {
+         common::unittest::Trace trace;
+
+         EXPECT_TRUE( algorithm::compare::none( 1, 2));
+      }
+
+      TEST( common_algorithm_compare_none, value_1__to_1__expect_false)
+      {
+         common::unittest::Trace trace;
+
+         EXPECT_FALSE( algorithm::compare::none( 1, 1));
+      }
+
+      TEST( common_algorithm_compare_none, value_1__to_5_3_2_0__expect_true)
+      {
+         common::unittest::Trace trace;
+
+         EXPECT_TRUE( algorithm::compare::none( 1, 5, 4, 3, 2, 0));
+      }
+
+      TEST( common_algorithm_compare_none, value_1__to_5_3_2_1__expect_false)
+      {
+         common::unittest::Trace trace;
+
+         EXPECT_FALSE( algorithm::compare::none( 1, 5, 4, 3, 2, 1));
+      }
 
       TEST( common_algorithm_remove, empty_empty__expect_empty)
       {


### PR DESCRIPTION
This commit changes the resource proxies to attempt to reopen the resource on XAER_RMERR, like they previously only did for XAER_RMFAIL. This allows the proxies to 'self-heal' in some situations where a resource temporarily becomes unavailable.

Resolves #476