### PR TITLE
cli: better error if lookup fails on (en|de)queue

### DIFF
--- a/middleware/queue/source/api/queue.cpp
+++ b/middleware/queue/source/api/queue.cpp
@@ -38,6 +38,11 @@ namespace casual
             namespace
             {
 
+               bool is_error( common::code::queue code)
+               {
+                  return code != common::code::queue::ok;
+               }
+
                template< typename M>
                common::Uuid enqueue( const queue::Lookup& lookup, M&& message)
                {
@@ -75,15 +80,14 @@ namespace casual
 
                   common::log::line( verbose::log, "request: ", request);
 
-                  auto id = common::communication::ipc::call( group.process.ipc, request).id;
+                  auto reply = common::communication::ipc::call( group.process.ipc, request);
 
-                  // a 'nil' queue id indicate error...
-                  if( ! id)
-                     common::code::raise::error( common::code::queue::no_queue, "failed to lookup queue: ", lookup.name());
+                  if( is_error( reply.code))
+                     common::code::raise::error( reply.code, "failed to enqeue to queue: ", lookup.name());
 
-                  common::log::line( queue::event::log, "enqueue|", id);
+                  common::log::line( queue::event::log, "enqueue|", reply.id);
 
-                  return id;
+                  return reply.id;
                }
 
                namespace dequeue
@@ -138,6 +142,14 @@ namespace casual
                            group.process.ipc,  
                            dequeue::request( group, selector, transaction.trid, false));
 
+                        if( is_error( reply.code))
+                        {
+                           if( reply.code == common::code::queue::no_message)
+                              return {};
+                           else
+                              common::code::raise::error( reply.code);
+                        }
+
                         if( reply.message)
                         {
                            if( transaction)
@@ -184,6 +196,9 @@ namespace casual
                      {
                         Trace trace{ "casual::queue::local::dequeue::blocking handler - dequeue::Reply"};
                         common::log::line( verbose::log, "message: ", message);
+
+                        if( is_error( message.code))
+                           common::code::raise::error( message.code);
 
                         if( message.message)
                         {

--- a/middleware/queue/source/manager/admin/cli.cpp
+++ b/middleware/queue/source/manager/admin/cli.cpp
@@ -33,6 +33,7 @@
 #include "serviceframework/log.h"
 
 #include <iostream>
+#include <string_view>
 
 namespace casual
 {
@@ -166,6 +167,19 @@ namespace casual
                      std::move( directive)).extract< std::vector< common::transaction::global::ID>>();
                }
             } // call
+
+            namespace lookup
+            {
+               auto queue( std::string_view queue, queue::Lookup::Action action)
+               {
+                  auto result = queue::Lookup{ queue, action}();
+
+                  if( ! result.process.ipc)
+                     code::raise::error( code::queue::no_queue, "failed to lookup queue: ", queue);
+
+                  return result;
+               }
+            }
 
 
             namespace format
@@ -1162,12 +1176,12 @@ The following options has legend:
 
                auto option()
                {
-                  auto invoke = []( std::string name)
+                  auto invoke = []( std::string queue)
                   {
                      Trace trace{ "queue::local::enqueue::invoke"};
 
                      pipe::State state;
-                     state.destination = queue::Lookup{ name, queue::Lookup::Action::enqueue}();
+                     state.destination = lookup::queue( queue, queue::Lookup::Action::enqueue);
 
                      auto handler = casual::cli::message::dispatch::create( 
                         casual::cli::pipe::forward::handle::defaults(),
@@ -1250,7 +1264,7 @@ cat somefile.bin | casual queue --enqueue <queue-name>
                      Trace trace{ "queue::local::dequeue::invoke"};
 
                      pipe::State state;
-                     state.destination = queue::Lookup{ std::move( queue), queue::Lookup::Action::dequeue}();
+                     state.destination = lookup::queue( queue, queue::Lookup::Action::enqueue);
 
                      auto handler = casual::cli::message::dispatch::create(
                         casual::cli::pipe::forward::handle::defaults(),
@@ -1317,7 +1331,7 @@ casual queue --dequeue <queue> <id> <id> <id> <id> | <some other part in casual-
                      Trace trace{ "queue::local::consume::invoke"};
 
                      pipe::State state;
-                     state.destination = queue::Lookup{ std::move( queue), queue::Lookup::Action::dequeue}();
+                     state.destination = lookup::queue( queue, queue::Lookup::Action::enqueue);
 
                      auto handler = casual::cli::message::dispatch::create(
                         casual::cli::pipe::forward::handle::defaults(),


### PR DESCRIPTION
Before: if the user tried to en/dequeue from a nonexisting/disabled queue with the cli they would receive a cryptic error message about "communication unavailable".
Now: we return "no_queue" if the lookup fails which is clearer and more in line with the c api as well.

Resolves #463