### PR TITLE
service: always send metric event on server exit

### DIFF
--- a/middleware/service/source/manager/handle.cpp
+++ b/middleware/service/source/manager/handle.cpp
@@ -69,16 +69,28 @@ namespace casual
 
             namespace error
             {
-               auto reply( State& state, const state::instance::Caller& caller, common::code::xatmi code)
+               auto reply( State& state, const state::instance::Caller& caller, common::code::xatmi code, std::string_view service, const common::process::Handle& callee)
                {
                   Trace trace{ "service::manager::handle::local::error::reply"};
-                  log::line( verbose::log, "caller: ", caller, ", code: ", code);
+                  log::line( verbose::log, "caller: ", caller, ", code: ", code, ", service: ", service);
 
                   common::message::service::call::Reply message;
                   message.correlation = caller.correlation;
                   message.code.result = code; 
 
                   state.multiplex.send( caller.process.ipc, std::move( message));
+
+                  if( state.events.active< common::message::event::service::Calls>())
+                  {
+                     common::message::event::service::Metric metric;
+                     metric.code = code;
+                     metric.correlation = caller.correlation;
+                     metric.service = service;
+                     metric.process = callee;
+
+                     state.metric.add( metric);
+                     handle::metric::batch::send( state);
+                  }
                }
             } // error
 
@@ -179,7 +191,7 @@ namespace casual
                // keep track of instance until we get an ACK, or the server dies
                // We need to notify TM if this call was in transaction.
                state.timeout_instances.push_back( entry.target);
-               local::error::reply( state, caller, common::code::xatmi::timeout);
+               local::error::reply( state, caller, common::code::xatmi::timeout, entry.service->information.name, common::process::Handle{ entry.target});
                order_assassination( entry.target, contract, announcement);
             }
             else
@@ -266,7 +278,7 @@ namespace casual
 
                               log::line( common::log::category::verbose::error, "instance: ", instance);
 
-                              local::error::reply( state, instance.caller(), common::code::xatmi::service_error);
+                              local::error::reply( state, instance.caller(), common::code::xatmi::service_error, instance.reserved_service().value_or( "<unknown>"), instance.process);
                            }
                         }
 
@@ -782,7 +794,7 @@ namespace casual
                               // take care of failed, if any
                               for( auto& failed : failed)
                                  if( auto found = algorithm::find( instances, failed.id))
-                                    local::error::reply( state, found->caller(), code::xatmi::service_error);
+                                    local::error::reply( state, found->caller(), code::xatmi::service_error, found->reserved_service().value_or( "<unknown>"), found->process);
 
                               // take care of replies
                               algorithm::for_each( replies, [&]( auto& reply)

--- a/middleware/service/unittest/include/service/unittest/utility.h
+++ b/middleware/service/unittest/include/service/unittest/utility.h
@@ -9,6 +9,7 @@
 #include "common/unittest.h"
 
 #include "common/message/service.h"
+#include "common/process.h"
 #include "service/manager/admin/model.h"
 
 #include <string>
@@ -20,6 +21,9 @@ namespace casual
    {
       //! advertise `services` to service-manager as current process
       void advertise( std::vector< std::string> services);
+
+      //! advertise `services` to service-manager as provided process
+      void advertise( std::vector< std::string> services, const common::process::Handle& handle);
 
       //! unadvertise `services` to service-manager as current process
       void unadvertise( std::vector< std::string> services);

--- a/middleware/service/unittest/source/manager/test_manager.cpp
+++ b/middleware/service/unittest/source/manager/test_manager.cpp
@@ -1169,5 +1169,54 @@ domain:
          }
       }
 
+      TEST( service_manager, callee_dies_during_service_call__expect_metric)
+      {
+         common::unittest::Trace trace;
+
+         auto domain = local::domain();
+
+         // a fake process that advertises some arbitrary service
+         auto callee_inbound = common::communication::ipc::inbound::Device{};
+         auto callee = common::process::Handle{ common::strong::process::id{ -5}, callee_inbound.connector().handle().ipc()};
+         service::unittest::advertise( { "a"}, callee);
+
+         // reserve the service
+         {
+            auto service = common::service::Lookup{ "a"}();
+            EXPECT_TRUE( service.service.name == "a");
+            EXPECT_TRUE( service.process == callee);
+            EXPECT_TRUE( service.state == decltype( service.state)::idle);
+         }
+
+         // subscribe to metric event
+         common::message::event::service::Calls event;
+         common::event::subscribe( common::process::handle(), { event.type()});
+
+         // the callee dies
+         {
+            common::message::event::process::Exit message;
+            message.state.pid = callee.pid;
+            message.state.reason = decltype( message.state.reason)::core;
+
+            common::communication::device::blocking::send( 
+               common::communication::instance::outbound::service::manager::device(),
+               message);
+         }
+
+         // wait for event
+         {
+            common::communication::device::blocking::receive( 
+               common::communication::ipc::inbound::device(),
+               event);
+            
+            ASSERT_TRUE( event.metrics.size() == 1);
+            auto& metric = event.metrics.at( 0);
+            EXPECT_TRUE( metric.service == "a");
+            EXPECT_TRUE( metric.parent == "");
+            EXPECT_TRUE( metric.process == callee);
+            EXPECT_TRUE( metric.code == common::code::xatmi::service_error);
+         }
+      }
+
    } // service
 } // casual

--- a/middleware/service/unittest/source/utility.cpp
+++ b/middleware/service/unittest/source/utility.cpp
@@ -31,7 +31,12 @@ namespace casual
 
       void advertise( std::vector< std::string> services)
       {
-         message::service::Advertise message{ process::handle()};
+         advertise( services, process::handle());
+      }
+
+      void advertise( std::vector< std::string> services, const common::process::Handle& handle)
+      {
+         message::service::Advertise message{ handle};
          message.alias = instance::alias();
          message.services.add = algorithm::transform( services, []( auto& service)
          {


### PR DESCRIPTION
Before: if a server exited during a call and wasnt able to send an ACK, there would be no metric for the cancelled service call. Now: we always send a metric event if a server exits.

Resolves #486