### PR TITLE
queue: fix unittest timing issue

### DIFF
--- a/middleware/queue/include/queue/group/queuebase/statement.h
+++ b/middleware/queue/include/queue/group/queuebase/statement.h
@@ -37,6 +37,8 @@ namespace casual
          sql::database::Statement commit3;
 
          sql::database::Statement rollback1;
+
+         //! arguments: gtrid, now
          sql::database::Statement rollback2;
          sql::database::Statement rollback3;
 

--- a/middleware/queue/source/group/queuebase.cpp
+++ b/middleware/queue/source/group/queuebase.cpp
@@ -646,11 +646,12 @@ namespace casual
       std::tuple< platform::size::type, std::vector< common::transaction::global::ID>> Queuebase::recovery_rollback( common::strong::queue::id queue, std::vector< common::transaction::global::ID> gtrids)
       {
          std::vector< platform::size::type> deleted_sizes{};
-         auto missing_message = [&]( auto& id)
+         
+         auto missing_message = [&, now = platform::time::clock::type::now()]( auto& id)
          {
             algorithm::container::append( sql::database::query::fetch( m_statement.rollback1.query( id.range()), local::transform::size()), deleted_sizes);
             const auto rollback1_affected = m_connection.affected();
-            m_statement.rollback2.execute( id.range());
+            m_statement.rollback2.execute( id.range(), now);
             const auto rollback2_affected = m_connection.affected();
             m_statement.rollback3.execute( id.range());
 
@@ -685,7 +686,7 @@ namespace casual
 
          auto sizes = sql::database::query::fetch( m_statement.rollback1.query( gtrid), local::transform::size());
 
-         m_statement.rollback2.execute( gtrid);
+         m_statement.rollback2.execute( gtrid, platform::time::clock::type::now());
          m_statement.rollback3.execute( gtrid);
 
          return std::reduce( std::begin( sizes), std::end( sizes));

--- a/middleware/queue/source/group/queuebase/statement.cpp
+++ b/middleware/queue/source/group/queuebase/statement.cpp
@@ -98,15 +98,15 @@ WHERE queue = :queue AND state = 2 AND properties = :properties AND available < 
 
             result.rollback1 = connection.precompile( "DELETE FROM message WHERE gtrid = :gtrid AND state = 1 RETURNING length( payload);");
 
-            // this only mutates if availiable has passed, otherwise state would not be 'dequeued' (3)
-            result.rollback2 = connection.precompile( 
-               "UPDATE message SET state = 2, redelivered = redelivered + 1,"
-               " available = ( SELECT CASE WHEN retry_delay = 0 THEN 0"  // no retry delay - we set 0
-                  // julianday('now') - 2440587.5) *86400.0 <- some magic that sqlite recommend for fraction of seconds
-                  // we multiply by 1'000'000 to get microseconds, and we add retry_delay which is in us already.
-                  " ELSE ( ( julianday('now') - 2440587.5) *86400 * 1000 * 1000) + retry_delay END" 
-                  " FROM queue WHERE id = message.queue)"
-               " WHERE gtrid = :gtrid AND state = 3");   
+            result.rollback2 = connection.precompile( R"(
+               UPDATE message SET state = 2, redelivered = redelivered + 1,
+                 available = ( 
+                    SELECT CASE WHEN retry_delay = 0 
+                       THEN 0                       /* no retry delay - we set 0 */
+                       ELSE ( ?2 + retry_delay )   /* otherwise we set the current time + retry delay */
+                     END 
+                    FROM queue WHERE id = message.queue)
+               WHERE gtrid = ?1 AND state = 3)");   
 
             // increment redelivered and "move" messages to error-queue iff we've passed retry_count and the queue has an error-queue.
             // also clear available iff message is moved to error-queue

--- a/middleware/queue/unittest/source/test_queue.cpp
+++ b/middleware/queue/unittest/source/test_queue.cpp
@@ -717,8 +717,8 @@ domain:
 
          auto message = queue::blocking::dequeue( name);
 
-         // we expect at least 100ms has passed, 
-         EXPECT_TRUE( platform::time::clock::type::now() - start > std::chrono::milliseconds{ 100});
+         // we expect at least 100ms has passed.
+         EXPECT_TRUE( platform::time::clock::type::now() - start >= std::chrono::milliseconds{ 100});
          EXPECT_TRUE( common::algorithm::equal( message.payload.data, payload));
       }
 


### PR DESCRIPTION
Before: we got 'now' from sqlite3 in a very confusing and magical way
  ( julianday('now') - 2440587.5) *86400 * 1000 * 1000)...

Now: we pass 'now' as a parameter (`chrono::time_point`) to the prepared
  statement _rollback2_. The SQL got a lot simpler and it's just an add
  of the provided 'now'

All this got our attention when a queue unittest failed due to not
accurate enough calculated _now_ with the crazy magic stuff before.

Resolves #497

Please review this "again"...
