### PR TITLE
common: fix common::file::permission::execution

### DIFF
--- a/middleware/administration/documentation/cli/gateway.operation.md
+++ b/middleware/administration/documentation/cli/gateway.operation.md
@@ -41,7 +41,7 @@ gateway [0..1]
            removed - use casual service --list-instances
 
       [deprecated] -lq, --list-queues [0..1]
-           removed - use casual queue --list-instance
+           removed - use casual queue --list-queue-instances
 
       [deprecated] --rediscover [0..1]
            moved to casual discover --rediscover

--- a/middleware/common/include/common/file.h
+++ b/middleware/common/include/common/file.h
@@ -166,6 +166,12 @@ namespace casual
 
       } // directory
 
+      namespace path
+      {
+         //! @returns true if the provided path has a parent path
+         bool has_parent( const std::filesystem::path& path);
+      }
+
    } // common
 } // casual
 

--- a/middleware/common/source/file.cpp
+++ b/middleware/common/source/file.cpp
@@ -194,7 +194,11 @@ namespace casual
             bool execution( const std::filesystem::path& path)
             {
                namespace fs = std::filesystem;
-               return ( fs::status( path).permissions() & fs::perms::owner_exec) != fs::perms::none;
+               auto status = fs::status( path);
+               if( status == fs::file_status( fs::file_type::not_found))
+                  return false;
+
+               return ( status.permissions() & fs::perms::owner_exec) == fs::perms::owner_exec;
             }
          } // permission
 
@@ -237,6 +241,14 @@ namespace casual
             }
          } // shared
       } // directory
+
+      namespace path
+      {
+         bool has_parent( const std::filesystem::path& path)
+         {
+            return path.has_parent_path();
+         }
+      }
 
    } // common
 } // casual

--- a/middleware/common/source/process.cpp
+++ b/middleware/common/source/process.cpp
@@ -270,10 +270,11 @@ namespace casual
                      path = environment::expand( std::move( path), environment);
                      environment::normalize( arguments, environment);
                      
+                     // if a path is provided (i.e. not a command like `sleep`)
                      // check if path exist and process has permission to execute it.
                      // could still go wrong, since we don't know if the path will actually execute,
                      // but we'll probably get rid of most of the errors (due to bad configuration and such)
-                     if( ! common::file::permission::execution( path))
+                     if( common::path::has_parent( path) && ! common::file::permission::execution( path))
                         code::raise::error( code::casual::invalid_path, "spawn failed - path: ", path);
 
                      log::line( log::debug, "process::spawn ", path, ' ', arguments);

--- a/middleware/domain/unittest/source/manager/test_manager.cpp
+++ b/middleware/domain/unittest/source/manager/test_manager.cpp
@@ -1561,7 +1561,7 @@ domain:
          dependencies: [ A]
    executables:
       -  alias: a
-         path: non-existent-path
+         path: non-existent-path/non-existent-executable
          arguments: [60]
          instances: 2
          memberships: [ A]


### PR DESCRIPTION
Before: we didnt check if the path existed before checking its premission, causing the function to always return true for non-existent paths.
Now: we return false if the path does not exist.