### PR TITLE
xatmi: build-server uses [0,1] as values for service visibility

### DIFF
--- a/middleware/common/include/common/service/type.h
+++ b/middleware/common/include/common/service/type.h
@@ -55,7 +55,14 @@ namespace casual
 
          Type transform( std::string_view contract);
          std::string transform( Type contract);
-         Type transform( short mode);
+
+         namespace build
+         {
+            //! transform from Type to the _build-server_ generated representation
+            std::uint64_t transform( Type value);
+            //! transform from the _build-server_ generated representation to Type
+            Type transform( std::uint64_t value);
+         } // build
          
       } // visibility
 

--- a/middleware/common/source/server/start.cpp
+++ b/middleware/common/source/server/start.cpp
@@ -67,7 +67,7 @@ namespace casual
                   template< typename S>
                   void start( S services, std::vector< argument::transaction::Resource> resources, common::function<void()const> initialize)
                   {
-                     Trace trace{ "common::server::start"};
+                     Trace trace{ "common::server::local::start"};
                      log::line( verbose::log, "services: ", services);
 
                      auto& inbound = communication::ipc::inbound::device();

--- a/middleware/common/source/service/type.cpp
+++ b/middleware/common/source/service/type.cpp
@@ -13,6 +13,8 @@
 
 #include "casual/assert.h"
 
+#include "casual/xatmi/server.h"
+
 #include <map>
 #include <ostream>
 
@@ -54,12 +56,28 @@ namespace casual
             return std::string{ description( value)};
          }
 
-         Type transform( short value)
+         namespace build
          {
-            CASUAL_ASSERT( value >= std::to_underlying( Type::discoverable) && value <= std::to_underlying( Type::undiscoverable));
+            std::uint64_t transform( Type value)
+            {
+               switch( value)
+               {
+                  case Type::discoverable: return CASUAL_SERVICE_VISIBILITY_DISCOVERABLE;
+                  case Type::undiscoverable: return CASUAL_SERVICE_VISIBILITY_UNDISCOVERABLE;
+               }
+               code::raise::error( code::casual::invalid_configuration, "unexpected visibility value: ", value);
+            }
 
-            return static_cast< Type>( value);
-         }
+            Type transform( std::uint64_t value)
+            {
+               switch( value)
+               {
+                  case CASUAL_SERVICE_VISIBILITY_DISCOVERABLE: return Type::discoverable;
+                  case CASUAL_SERVICE_VISIBILITY_UNDISCOVERABLE: return Type::undiscoverable;
+               }
+               code::raise::error( code::casual::invalid_configuration, "unexpected visibility value: ", value);
+            }
+         } // build
          
       } // visibility
 

--- a/middleware/tools/include/tools/build/transform.h
+++ b/middleware/tools/include/tools/build/transform.h
@@ -12,43 +12,37 @@
 
 namespace casual
 {
-   namespace tools
+   namespace tools::build::transform
    {
-      namespace build
+
+      namespace paths
       {
-         namespace transform
-         {
-            namespace paths
-            {
-               std::vector< std::string> include( const std::vector< model::Resource>& resources);
-               std::vector< std::string> library( const std::vector< model::Resource>& resources);
+         std::vector< std::string> include( const std::vector< model::Resource>& resources);
+         std::vector< std::string> library( const std::vector< model::Resource>& resources);
 
-            } // paths
+      } // paths
 
-            std::vector< std::string> libraries( const std::vector< model::Resource>& resources);
+      std::vector< std::string> libraries( const std::vector< model::Resource>& resources);
 
-            
-
-            std::vector< model::Resource> resources( 
-               const std::vector< configuration::build::model::Resource>& resources, 
-               const std::vector< std::string>& keys,
-               const configuration::model::system::Model& system);
+      std::vector< model::Resource> resources( 
+         const std::vector< configuration::build::model::Resource>& resources, 
+         const std::vector< std::string>& keys,
+         const configuration::model::system::Model& system);
 
 
-            inline std::vector< model::Resource> resources( 
-               const configuration::build::server::Model& model, 
-               const std::vector< std::string>& keys,
-               const configuration::model::system::Model& system)
-            {
-               return resources( model.server.resources, keys, system);
-            }
+      inline std::vector< model::Resource> resources( 
+         const configuration::build::server::Model& model, 
+         const std::vector< std::string>& keys,
+         const configuration::model::system::Model& system)
+      {
+         return resources( model.server.resources, keys, system);
+      }
 
+      std::vector< model::Service> services( 
+         const configuration::build::server::Model& model, 
+         const std::vector< std::string>& names,
+         const std::string& transaction_mode);
+      
 
-            std::vector< model::Service> services( 
-               const configuration::build::server::Model& model, 
-               const std::vector< std::string>& names,
-               const std::string& transaction_mode);
-         } // transform
-      } // build
-   } // tools
+   } // tools::build::transform
 } // casual

--- a/middleware/tools/source/build/generate.cpp
+++ b/middleware/tools/source/build/generate.cpp
@@ -87,7 +87,7 @@ namespace casual
                   for( auto& service : services)
                   {
                      out << R"(
-      {&)" << service.function << R"(, ")" << service.name << R"(", ")" << service.category << R"(", )" << std::to_underlying( service.transaction) << R"(, )" << std::to_underlying( service.visibility) << "},";
+      {&)" << service.function << R"(, ")" << service.name << R"(", ")" << service.category << R"(", )" << std::to_underlying( service.transaction) << R"(, )" << common::service::visibility::build::transform( service.visibility) << "},";
                   }
 
                   out << R"(

--- a/middleware/xatmi/include/casual/xatmi/server.h
+++ b/middleware/xatmi/include/casual/xatmi/server.h
@@ -19,6 +19,9 @@ extern "C" {
 #endif
 
 
+#define CASUAL_SERVICE_VISIBILITY_DISCOVERABLE 0
+#define CASUAL_SERVICE_VISIBILITY_UNDISCOVERABLE 1
+
 struct casual_service_definition
 {
    tpservice function_pointer;
@@ -30,7 +33,10 @@ struct casual_service_definition
    /* transaction policy */
    uint64_t transaction;
 
-   /* service visibilit*/
+   //! service visibility
+   //! 0 = discoverable
+   //! 1 = undiscoverable
+   //! @note these values does not directly map to the casual::common::service::visibility::Type 
    uint64_t visibility;
 };
 

--- a/middleware/xatmi/source/xatmi/server.cpp
+++ b/middleware/xatmi/source/xatmi/server.cpp
@@ -36,18 +36,22 @@ namespace casual
          {
             namespace transform
             {
-               template< typename S>
-               auto visibility( S& service, common::traits::priority::tag< 1>) -> decltype( common::service::visibility::transform( service.visibility))
+
+               common::service::visibility::Type visibility( const casual_service_definition& service)
                {
-                  return common::service::visibility::transform( service.visibility);
+                  return common::service::visibility::build::transform( service.visibility);
                }
 
-               template< typename S>
-               auto visibility( S&, common::traits::priority::tag< 0>) { return common::service::visibility::Type::discoverable;}
+               common::service::visibility::Type visibility( const casual_service_name_mapping& service)
+               {
+                  return common::service::visibility::Type::discoverable;
+               }
 
                template< typename A>
                auto services( A& value)
                {
+                  casual::xatmi::Trace trace{ "casual::xatmi::server::local::transform::services"};
+
                   std::vector< common::server::argument::xatmi::Service> result;
 
                   auto service = value.services;
@@ -58,8 +62,8 @@ namespace casual
                         service->name,
                         service->function_pointer,
                         common::service::transaction::mode( service->transaction),
-                        transform::visibility( *service, common::traits::priority::tag< 1>{}),
-                        service->category);
+                        transform::visibility( *service),
+                        service->category ? service->category : "");
                   }
 
                   return result;

--- a/test/unittest/source/xatmi/test_start.cpp
+++ b/test/unittest/source/xatmi/test_start.cpp
@@ -41,6 +41,11 @@ namespace casual
                global::done = true;
             }
 
+            extern "C" void xatmi_echo( TPSVCINFO* info)
+            {
+               tpreturn( TPSUCCESS, 0, info->data, info->len, 0);
+            }
+
             auto domain()
             {
                return casual::domain::unittest::manager(
@@ -127,6 +132,36 @@ domain:
          };
    
          casual_run_server( &arguments);         
+         EXPECT_FALSE( local::global::done);
+      }
+
+      TEST( test_xatmi_start, casual_run_server_v2_visibility_0)
+      {
+         common::unittest::Trace trace;
+         
+         auto domain = local::domain();
+
+         local::global::init = false;
+         local::global::done = false;
+
+         // prepare the shutdown, since we block in casual_run_server
+         common::communication::ipc::inbound::device().push( common::message::shutdown::Request{ process::handle()});
+
+         casual_service_definition service_mapping[] = { 
+            { .function_pointer = &local::xatmi_echo, .name = "xatmi_echo", .category = "", .transaction = 0, .visibility = 0},
+            { 0, 0, 0, 0, 0}};
+
+         casual_xa_switch_map xa_mapping[] = {{ 0, 0, 0}};
+         casual_server_arguments_v2 arguments{
+            service_mapping,
+            nullptr,
+            &local::server_done,
+            0,
+            nullptr,
+            xa_mapping
+         };
+   
+         casual_run_server_v2( &arguments);         
          EXPECT_FALSE( local::global::done);
       }
 


### PR DESCRIPTION
Before: The genereated _build-server-main_ source file used the underlying values of `visibility::Type` directly. In 1.7 these values has been "shifted", 1 for discoverable, and 2 for undiscoverable.

Now: We transform to and from the build-server representation of visibility.
* `0` -> `visibility::Type::discoverable`
* `1` -> `visibility::Type::undiscoverable`

Resolves #506