### PR TITLE
common: use std::format for time-points based on __cpp_lib_format_path

### DIFF
--- a/middleware/common/source/chronology.cpp
+++ b/middleware/common/source/chronology.cpp
@@ -16,13 +16,29 @@
 #include <functional>
 #include <algorithm>
 
+
 namespace casual
 {
    namespace common::chronology
    {
 
-// os x doesn't have  std::chrono::zoned_time yet, we keep the old crap until we get it
-#ifdef __APPLE__
+// we use std::format if the compiler supports it, otherwise we use the extremely convoluted way.
+#if defined( __cpp_lib_format_path) && __cpp_lib_format_path >= 202403L
+
+      namespace utc
+      {
+         std::string offset( platform::time::point::type timepoint)
+         {
+            return std::format("{:%FT%T%Ez}", std::chrono::zoned_time{ std::chrono::current_zone(), std::chrono::floor< std::chrono::microseconds>( timepoint)});
+         }
+
+         void offset( std::ostream& out, platform::time::point::type timepoint)
+         {
+            out << offset( timepoint);
+         }
+      } // utc
+
+#else
 
       namespace local
       {
@@ -112,20 +128,6 @@ namespace casual
          }
       } // utc
 
-#else
-      namespace utc
-      {
-         std::string offset( platform::time::point::type timepoint)
-         {
-            return std::format("{:%FT%T%Ez}", std::chrono::zoned_time{ std::chrono::current_zone(), std::chrono::floor< std::chrono::microseconds>( timepoint)});
-         }
-
-         void offset( std::ostream& out, platform::time::point::type timepoint)
-         {
-            out << offset( timepoint);
-         }
-      } // utc
-           
 #endif
 
       namespace from


### PR DESCRIPTION
Before: we used the macro `__APPLE__` to treat only _apple_ different

Now: we use the test macro `__cpp_lib_format_path` to decide if we're using std::format for std::chrono::time_point.

Resolves #512

We only merge this if we get som more fixes for 1.7. 