### PR TITLE
field buffer: explicitly ignore intentionally unused return value.

### DIFF
--- a/middleware/buffer/source/field.cpp
+++ b/middleware/buffer/source/field.cpp
@@ -38,7 +38,7 @@
 #include <regex>
 #include <iostream>
 #include <sstream>
-
+#include <tuple>
 namespace casual
 {
    namespace buffer::field
@@ -571,7 +571,7 @@ namespace casual
                   const auto& buffer = pool_type::pool().get( common::buffer::handle::type{ handle});
 
                   // Just to force an exception if not present
-                  buffer.index.at( id).at( occurrence);
+                  std::ignore = buffer.index.at( id).at( occurrence);
 
                   return CASUAL_FIELD_SUCCESS;
                }


### PR DESCRIPTION
Added assignment to std::ignore to supress a warning. Seems as if gcc-14 has added a [[nodiscard]] attribute to at().

      // Just to force an exception if not present
      std::ignore = buffer.index.at( id).at( occurrence);

Also added #include <tuple> that contains std::ignore (as I understand various C++ standard documents the plan is to also have it in <utility> in C++-26). The file compiles without this, Probably because some other included header includes <tuple>. (I have not tried to find wich one) 

Resolves #519 