### PR TITLE
common log: Activate log used in unittest

### DIFF
--- a/middleware/common/unittest/source/log/test_stream.cpp
+++ b/middleware/common/unittest/source/log/test_stream.cpp
@@ -86,7 +86,7 @@ namespace casual
 
          auto scope = local::log::scoped::path( path);
 
-         log::stream::activate( "casual.common.verbose");
+         log::stream::activate( "casual.debug");
 
          constexpr std::string_view token{ "c1e2b63a842049c496b0f476e5401621"};
          


### PR DESCRIPTION
A unit test logged to debug, but debug logging was not active. This resulted in not finding the logged data in the log and a failed unit test.
Before change "casual.common.verbose" was activated, now "common.debug" is activated. At one time the test logged to verbose but that was changed to debug some time ago.
 
Fixes issue #503