### PR TITLE
unittest: make a gateway unittest more deterministic

### DIFF
--- a/middleware/common/include/common/unittest.h
+++ b/middleware/common/include/common/unittest.h
@@ -54,7 +54,8 @@ namespace casual
          unittest::Message size( platform::size::type size);
          
       } // message::transport
-
+      
+      //! @todo This should not be in common -> move to service unittest utility
       namespace service
       {
          [[nodiscard]] strong::correlation::id send( std::string service, platform::binary::type payload, const transaction::ID& trid);

--- a/middleware/gateway/unittest/source/test_manager.cpp
+++ b/middleware/gateway/unittest/source/test_manager.cpp
@@ -1485,20 +1485,15 @@ domain:
       
          const auto payload = common::unittest::random::binary( 128);
 
-         // we wait until the SM has received the fetch known request that casual-domain-discovery sends upon receiving the connection to B
-         {
-            auto received_fetch_known = []( auto& reply)
-            {
-               auto found = algorithm::find( reply.entries, common::message::Type::domain_discovery_fetch_known_request);
-               return found && found->received == 1;
-            };
-
-            common::unittest::fetch::message::counter::until( communication::instance::outbound::service::manager::device(), received_fetch_known);
-         }
-
-         const auto correlation = common::unittest::service::send( "b", payload);
+         
+         // the service call request will wait until the `b` is available.
+         const auto correlation = casual::service::unittest::send::wait::request( "b", payload);
 
          b.activate();
+
+         // make sure we receive the service call request, to guarantee that the call is in flight
+         const auto b_request = communication::ipc::receive< common::message::service::call::callee::Request>( correlation);
+
 
          const auto inbound = unittest::inbound::group( unittest::state(), "in-b").value();
 
@@ -1511,7 +1506,7 @@ domain:
 
          a.activate();
 
-         // we need to wait/verify that A has got the disconnect information from B.
+         // Wait/verify that the outbound has received the disconnect message
          {
             auto disconnecting_mode = []( auto& state)
             {
@@ -1520,42 +1515,23 @@ domain:
 
             unittest::fetch::until( disconnecting_mode);
          }
-         
 
-         // send direct::Explore to outbound-connection, outbound should not send discovery to
-         // B since B is in disconnect mode.
+         // lookup for 'x' should be absent
          {
-            casual::domain::message::discovery::topology::direct::Explore request;
-            request.content.services = { "b", "x", "y"};
-            auto connections = unittest::state().connections;
-            ASSERT_TRUE( connections.size() == 1);
-            auto ipc = connections.at( 0).ipc;
-
-            EXPECT_TRUE( common::communication::device::non::blocking::send( ipc, request));
+            auto reply = casual::service::unittest::lookup( "x");
+            EXPECT_TRUE( reply.absent());
          }
-
+         
          b.activate();
 
-         // verify that B has not got any (more) discoveries. We need to verify the absent of 
-         // a discovery request. Sadly, we need to loop a while.
-         algorithm::for_n< 5>( [ &inbound]()
+         // send the reply from B to A
          {
-            common::process::sleep( std::chrono::milliseconds{ 1});
-
-            // we expect the inbound to have received 1 discovery_request for the call to "b", it should not 
-            // get any more.
-            auto reply = communication::ipc::call( inbound.process.ipc, common::message::counter::Request{ common::process::handle()});
-            if( auto found = algorithm::find( reply.entries, common::message::Type::domain_discovery_request))
-            {
-               EXPECT_TRUE( found->received == 1) << CASUAL_NAMED_VALUE( *found);
-            }
-         });
-
-         // act a server and reply
-         {
-            EXPECT_TRUE( casual::service::unittest::server::echo( correlation));
+            auto reply = common::message::reverse::type( b_request);
+            reply.buffer = b_request.buffer;
+            communication::device::blocking::send( b_request.process.ipc, reply);
          }
 
+    
          // for good measure, receive the reply
          {
             a.activate();

--- a/middleware/service/unittest/include/service/unittest/utility.h
+++ b/middleware/service/unittest/include/service/unittest/utility.h
@@ -8,9 +8,11 @@
 
 #include "common/unittest.h"
 
+#include "service/manager/admin/model.h"
+
 #include "common/message/service.h"
 #include "common/process.h"
-#include "service/manager/admin/model.h"
+#include "common/service/lookup.h"
 
 #include <string>
 #include <vector>
@@ -37,8 +39,19 @@ namespace casual
          void unadvertise( std::vector< std::string> services);
       } // concurrent
 
+      common::message::service::lookup::Reply lookup( std::string service);
+
       namespace send
       {
+         namespace wait
+         {
+            //! sends lookup with _wait_ that will block until the service is available, then 
+            //! sends a request to the service.
+            [[nodiscard]] auto request( std::string service, platform::binary::type payload) -> common::strong::correlation::id;
+            
+         } // wait
+         
+
          //! sends ack to service-manager
          //! @{ 
          void ack( const common::message::service::call::callee::Request& request);

--- a/middleware/service/unittest/source/utility.cpp
+++ b/middleware/service/unittest/source/utility.cpp
@@ -77,6 +77,18 @@ namespace casual
          }
       } // concurrent
 
+
+      common::message::service::lookup::Reply lookup( std::string service)
+      {
+         Trace trace{ "service::unittest::lookup"};
+
+         common::message::service::lookup::Request lookup{ process::handle()};
+         lookup.requested = std::move( service);
+         lookup.context.semantic = decltype( lookup.context.semantic)::regular;
+         
+         return communication::ipc::call( local::ipc::manager(), lookup);
+      }
+
       manager::admin::model::State state()
       {
          common::unittest::service::wait::until::advertised( manager::admin::service::name::state);
@@ -90,6 +102,35 @@ namespace casual
 
       namespace send
       {
+         namespace wait
+         {
+            auto request( std::string service, platform::binary::type payload) -> common::strong::correlation::id
+            {
+               Trace trace{ "service::unittest::send::wait::request"};
+
+               common::message::service::lookup::Request lookup{ process::handle()};
+               lookup.requested = std::move( service);
+               lookup.context.semantic = decltype( lookup.context.semantic)::wait;
+
+               auto lookup_reply = communication::ipc::call( local::ipc::manager(), lookup);
+
+               if( lookup_reply.state != decltype( lookup_reply.state)::idle)
+                  code::raise::error( code::casual::internal_unexpected_value, "failed to lookup service: ", lookup.requested, " - ", lookup_reply.state);
+
+               {
+                  message::service::call::callee::Request message{ process::handle()};
+                  message.correlation = lookup_reply.correlation;
+                  message.service = std::move( lookup_reply.service);
+                  message.buffer.data = std::move( payload);
+                  message.buffer.type = common::buffer::type::x_octet;
+
+                  return communication::device::blocking::send( lookup_reply.process.ipc, message);
+               }
+
+            }
+            
+         } // wait
+
          void ack( const message::service::call::callee::Request& request)
          {
             message::service::call::ACK message;


### PR DESCRIPTION
The actual unittest that is fixed to be more deterministic:

gateway_manager.A_B__pending_call_A_to_B__shutdown_B__send_implicit_update_to_A_outbound__expect_direct_reply__not_over_to_inbound

Resolves #522