### PR TITLE
gateway: inbound fails to handle trids that is already branched

### DIFF
--- a/middleware/gateway/source/group/inbound/task/create.cpp
+++ b/middleware/gateway/source/group/inbound/task/create.cpp
@@ -37,15 +37,11 @@ namespace casual
                      return result_context::external;
                }
 
-
-               template< typename M>
-               void branch( State& state, strong::socket::id descriptor, const M& message)
+               void branch( State& state, const process::Handle& process, const strong::correlation::id& correlation, transaction::global::id::range gtrid)
                {
-                  auto gtrid = transaction::id::range::global( message.trid);
 
-                  common::message::transaction::inbound::branch::Request request{ state.connections.process_handle( descriptor)};
-                  request.correlation = message.correlation;
-                  request.execution = message.execution;
+                  common::message::transaction::inbound::branch::Request request{ process};
+                  request.correlation = correlation;
                   request.gtrid = gtrid;
 
                   state.multiplex.send( ipc::manager::transaction(), request);
@@ -222,19 +218,23 @@ namespace casual
 
                auto shared = std::make_shared< Shared>();
 
-               if( message.trid)
-               {
-                  shared->origin_trid = message.trid;
-
-                  if( auto found = state.transaction_cache.associate( message.trid, descriptor))
-                     message.trid = *found;
-                  else
-                     local::lookup::branch( state, descriptor, message);
-               }
-               
                shared->message = std::move( message);
+
                // make sure the ipc partner to the tcp socket gets the reply
                shared->message.process = state.connections.process_handle( descriptor);
+
+               if( shared->message.trid)
+               {
+                  // we use `origin_trid` to keep track of the original trid, and indicate that the call is in transaction
+                  // we reset `message.trid` to indicate that we've not yet got the branched trid
+                  shared->origin_trid = std::exchange( shared->message.trid, {});
+
+                  if( auto found = state.transaction_cache.associate( shared->origin_trid, descriptor))
+                     shared->message.trid = *found;
+                  else
+                     local::lookup::branch( state, shared->message.process, shared->message.correlation, transaction::id::range::global( shared->origin_trid));
+               }
+               
 
                return task_unit{ descriptor, message.correlation,
                   [ &state, shared]( common::message::service::lookup::Reply& reply, strong::socket::id descriptor) mutable
@@ -250,7 +250,7 @@ namespace casual
 
                            // If the call wasn't in transaction, or we've branched the trid already.
                            // If the call failed, we've "sent" the reply, 
-                           if( ! shared->origin_trid || shared->origin_trid != shared->message.trid)
+                           if( ! shared->origin_trid || shared->message.trid)
                               local::send::service_request( state, descriptor, *shared->lookup, shared->message);
 
                            break;
@@ -337,19 +337,21 @@ namespace casual
 
                auto shared = std::make_shared< Shared>();
 
-               if( message.trid)
-               {
-                  shared->origin_trid = message.trid;
-
-                  if( auto found = state.transaction_cache.associate( message.trid, descriptor))
-                     message.trid = *found;
-                  else
-                     local::lookup::branch( state, descriptor, message);
-               }
-               
                shared->message = std::move( message);
                // make sure the ipc partner to the tcp socket gets the reply
                shared->message.process = state.connections.process_handle( descriptor);
+
+               if( shared->message.trid)
+               {
+                  // we use `origin_trid` to keep track of the original trid, and indicate that the call is in transaction
+                  // we reset `message.trid` to indicate that we've not yet got the branched trid
+                  shared->origin_trid = std::exchange( shared->message.trid, {});
+
+                  if( auto found = state.transaction_cache.associate( shared->origin_trid, descriptor))
+                     shared->message.trid = *found;
+                  else
+                     local::lookup::branch( state, shared->message.process, shared->message.correlation, transaction::id::range::global( shared->origin_trid));
+               }
 
                return task_unit{ descriptor, message.correlation,
                   [ &state, shared]( common::message::service::lookup::Reply& reply, strong::socket::id descriptor) mutable
@@ -364,7 +366,7 @@ namespace casual
                            shared->lookup = std::move( reply);
 
                            // if the call wasn't in transaction, or we've branched the trid already
-                           if( ! shared->origin_trid || shared->origin_trid != shared->message.trid)
+                           if( ! shared->origin_trid || shared->message.trid)
                               local::send::service_request( state, descriptor, *shared->lookup, shared->message);
 
                            break;
@@ -455,21 +457,22 @@ namespace casual
 
                auto shared = std::make_shared< Shared>();
 
-               if( message.trid)
+               shared->message = std::move( message);
+               shared->message.process = state.connections.process_handle( descriptor);
+
+               if( shared->message.trid)
                {
-                  if( auto found = state.transaction_cache.associate( message.trid, descriptor))
+                  if( auto found = state.transaction_cache.associate( shared->message.trid, descriptor))
                   {
-                     message.trid = *found;
+                     shared->message.trid = *found;
                   }
                   else
                   {
                      shared->wait_for_branch = true;
-                     local::lookup::branch( state, descriptor,  message);
+                     local::lookup::branch( state, shared->message.process, shared->message.correlation, transaction::id::range::global( shared->message.trid));
                   }
                }
 
-               shared->message = std::move( message);
-               shared->message.process = state.connections.process_handle( descriptor);
 
                return task_unit{ descriptor, message.correlation,
                   [ &state, shared]( casual::queue::ipc::message::lookup::Reply& reply, strong::socket::id descriptor) mutable

--- a/middleware/gateway/unittest/source/protocol/1.4/test_manager.cpp
+++ b/middleware/gateway/unittest/source/protocol/1.4/test_manager.cpp
@@ -14,6 +14,8 @@
 
 #include "domain/unittest/manager.h"
 
+#include "service/unittest/utility.h"
+
 
 namespace casual
 {
@@ -96,7 +98,63 @@ domain:
          send_resource_message( common::message::transaction::resource::prepare::Request{});
          send_resource_message( common::message::transaction::resource::commit::Request{});
          send_resource_message( common::message::transaction::resource::rollback::Request{}); 
+      }
 
+      TEST( gateway_protocol_1_4_manager, service_call__with_exact_trid_that_is_already_branched)
+      {
+         common::unittest::Trace trace;
+
+         auto b = local::domain( R"(
+domain:
+   name: B
+   servers:
+      - path: bin/casual-gateway-manager
+        memberships: [ gateway]
+   gateway:
+      inbound:
+         groups:
+            -  connections: 
+                  -  address: 127.0.0.1:7010
+                     discovery: 
+                        forward: true
+         )");
+
+
+         casual::service::unittest::concurrent::advertise( {  "b"});
+
+        
+         auto device = unittest::tcp::connect::out( "127.0.0.1:7010", message::protocol::Version::v1_4);
+         EXPECT_TRUE( device.connector().socket());
+
+         const auto trid = common::transaction::id::create();
+
+         static constexpr auto send_call = []( auto& device, const auto& trid)
+         {
+            common::message::service::call::callee::Request request;
+            request.service.name = "b";
+            request.trid = trid;
+            request.correlation = common::strong::correlation::id::generate();
+            request.buffer.data = common::unittest::random::binary( 128);
+            request.buffer.type = "X_OCTET/";
+
+            return common::communication::device::blocking::send( device, request);
+         };
+
+         // send the first call to b with a new trid, via inbound
+         auto correlation_a = send_call( device, trid);
+         
+         // receive the call to a from within 'B' domain
+         auto request_a = communication::ipc::receive< common::message::service::call::callee::Request>( correlation_a);
+         // check that the gtrid are the same and the branch differs
+         EXPECT_TRUE( common::transaction::id::range::global( request_a.trid) == common::transaction::id::range::global( trid)) << CASUAL_NAMED_VALUE( request_a.trid) << '\n' << CASUAL_NAMED_VALUE( trid);
+         EXPECT_TRUE( common::transaction::id::range::branch( request_a.trid) != common::transaction::id::range::branch( trid)) << CASUAL_NAMED_VALUE( trid);
+
+         // send another call to b with the exact same branched trid.
+         auto correlation_b = send_call( device, request_a.trid);
+
+         // receive the call to b from within 'B' domain
+         auto request_b = communication::ipc::receive< common::message::service::call::callee::Request>( correlation_b);
+         EXPECT_TRUE( request_b.trid == request_a.trid) << CASUAL_NAMED_VALUE( request_b.trid);
       }
 
    } // gateway  


### PR DESCRIPTION
Before: When inbound is called with a trid that is exactly as an already branched trid, it was interpret as we're still waiting for the branched trid from TM -> we wait for ever.

Now: We accept exactly the same trid.

Resolves #533