### PR TITLE
xatmi: expose c-api to set/get execution (parent) span

### DIFF
--- a/middleware/common/include/common/execution/context.h
+++ b/middleware/common/include/common/execution/context.h
@@ -92,7 +92,7 @@ namespace casual
 
             namespace span
             {
-               void set( strong::execution::span::id id);
+               strong::execution::span::id set( strong::execution::span::id id);
             } // span
             
          } // parent

--- a/middleware/common/source/execution/context.cpp
+++ b/middleware/common/source/execution/context.cpp
@@ -123,9 +123,9 @@ namespace casual
 
             namespace span
             {
-               void set( strong::execution::span::id id)
+               strong::execution::span::id set( strong::execution::span::id id)
                {
-                  local::context().parent.span = id;
+                  return std::exchange( local::context().parent.span, id);
                }
             } // span
             

--- a/middleware/xatmi/include/casual/xatmi/extended.h
+++ b/middleware/xatmi/include/casual/xatmi/extended.h
@@ -8,6 +8,7 @@
 
 #include <stdarg.h>
 #include <uuid/uuid.h>
+#include <stdint.h>
 
 
 #define CASUAL_BUFFER_BINARY_TYPE ".binary"
@@ -38,6 +39,14 @@ extern int casual_user_log( const char* category, const char* const message);
 extern void casual_execution_id_set( const uuid_t* id);
 extern const uuid_t* casual_execution_id_get();
 extern const uuid_t* casual_execution_id_reset();
+
+//! set the execution span id, @return the previous value
+extern uint64_t casual_execution_span_id_set( uint64_t id);
+extern uint64_t casual_execution_span_id_get();
+
+//! set the execution parent span id, @return the previous value
+extern uint64_t casual_execution_parent_span_id_set( uint64_t id);
+extern uint64_t casual_execution_parent_span_id_get();
 
 /**
  * @returns the name of current execution service name

--- a/middleware/xatmi/source/xatmi/extended.cpp
+++ b/middleware/xatmi/source/xatmi/extended.cpp
@@ -150,6 +150,50 @@ const uuid_t* casual_execution_id_reset()
    return casual_execution_id_get();
 }
 
+
+namespace local
+{
+   namespace
+   {
+      casual::common::strong::execution::span::id transform( uint64_t id)
+      {
+         std::array< std::byte, 8> bytes;
+         casual::common::algorithm::copy( std::as_bytes( std::span{ &id, 1}), bytes);
+         return casual::common::strong::execution::span::id{ bytes};
+      }
+
+      uint64_t transform( casual::common::strong::execution::span::id id)
+      {
+         uint64_t result{};
+         casual::common::algorithm::copy( id.underlying(), std::as_writable_bytes( std::span{ &result, 1}));
+         return result;
+      }  
+      
+   } // <unnamed>
+} // local
+
+
+uint64_t casual_execution_span_id_set( uint64_t id)
+{
+   return local::transform( casual::common::execution::context::span::set( local::transform( id)));
+}
+
+uint64_t casual_execution_span_id_get()
+{
+   return local::transform( casual::common::execution::context::get().span);
+}
+
+uint64_t casual_execution_parent_span_id_set( uint64_t id)
+{
+   return local::transform( casual::common::execution::context::parent::span::set( local::transform( id)));
+}
+
+uint64_t casual_execution_parent_span_id_get()
+{
+   return local::transform( casual::common::execution::context::get().parent.span);
+}
+
+
 void casual_instance_browse_services( casual_instance_browse_callback callback, void* context)
 {
    using namespace casual;

--- a/middleware/xatmi/unittest/source/test_xatmi.cpp
+++ b/middleware/xatmi/unittest/source/test_xatmi.cpp
@@ -53,6 +53,35 @@ namespace casual
 
          EXPECT_NE( uuid::string( uuid), uuid::string( *reset_id));
       }
+
+      TEST( xatmi_execution, execution_span_id_get_set)
+      {
+         common::unittest::Trace trace;
+
+         constexpr std::uint64_t id = 42;
+
+         casual_execution_span_id_set( id);
+
+         EXPECT_EQ( casual_execution_span_id_get(), id);
+
+         // clear context for good measure
+         common::execution::context::clear();
+      }
+
+      TEST( xatmi_execution, execution_parent_span_id_get_set)
+      {
+         common::unittest::Trace trace;
+
+         constexpr std::uint64_t id = 42;
+
+         casual_execution_parent_span_id_set( id);
+
+         EXPECT_EQ( casual_execution_parent_span_id_get(), id);
+
+         // clear context for good measure
+         common::execution::context::clear();
+      }
+
    } // common
 } // casual
 


### PR DESCRIPTION
This patch: exposes c-api for users to set/get execution span and execution parent span.

Resolves #550