### PR TITLE
common: service::Lookup does not propagate (current) trid

### DIFF
--- a/middleware/common/include/common/service/lookup.h
+++ b/middleware/common/include/common/service/lookup.h
@@ -10,6 +10,7 @@
 
 #include "common/uuid.h"
 #include "common/message/service.h"
+#include "common/transaction/id.h"
 
 #include <optional>
 #include <string>
@@ -39,12 +40,14 @@ namespace casual
 
       struct Lookup
       {                        
-         //! Lookup an entry point for the @p service
-         Lookup( std::string service, std::optional< platform::time::point::type> deadline = {});
+         //! Lookup an entry point for the `service`. `trid` represent the current transaction to give
+         //! SM a chance to keep calls within the same transaction to end up at the same destination.
+         Lookup( std::string service, const common::transaction::ID& trid, std::optional< platform::time::point::type> deadline = {});
 
-         //! Lookup an entry point for the @p service
-         //! using a specific context
-         Lookup( std::string service, lookup::Context context, std::optional< platform::time::point::type> deadline = {});
+         //! Lookup an entry point for the `service`. `trid` represent the current transaction to give
+         //! SM a chance to keep calls within the same transaction to end up at the same destination.
+         //! `context` could be used for specific semantics.
+         Lookup( std::string service, const common::transaction::ID& trid, lookup::Context context, std::optional< platform::time::point::type> deadline = {});
 
          //! If pending lookup discard it.
          ~Lookup();

--- a/middleware/common/source/server/handle/policy.cpp
+++ b/middleware/common/source/server/handle/policy.cpp
@@ -206,6 +206,7 @@ namespace casual
 
                   common::service::Lookup lookup{
                      forward.parameter.service.name,
+                     {}, // nill trid
                      decltype( common::service::lookup::Context::semantic)::no_reply};
 
                   // TODO make this forward work without a copy of payload...

--- a/middleware/common/source/service/call/context.cpp
+++ b/middleware/common/source/service/call/context.cpp
@@ -82,7 +82,7 @@ namespace casual
                         if( flag::contains( flags, call::async::Flag::no_reply))
                            code::raise::error( code::xatmi::argument, "TPNOREPLY can only be used with TPNOTRAN");
 
-                        return service::Lookup{ std::move( service), context, current.deadline};
+                        return service::Lookup{ std::move( service), current.trid, context, current.deadline};
                      }
                   }
 
@@ -90,9 +90,9 @@ namespace casual
                   // will call it self with noreply, as poor mans polling mechanism. If we supply the deadline
                   // the server will eventually run out of time (if a timeout is set for the service).
                   if( context.semantic == Semantic::no_reply)
-                     return service::Lookup{ std::move( service), context, {}};
+                     return service::Lookup{ std::move( service), {}, context, {}};
                   else
-                     return service::Lookup{ std::move( service), context, deadline};
+                     return service::Lookup{ std::move( service), {}, context, deadline};
                }
 
                inline Reply message(

--- a/middleware/common/source/service/conversation/context.cpp
+++ b/middleware/common/source/service/conversation/context.cpp
@@ -267,11 +267,22 @@ namespace casual
             {
                Trace trace{ "common::service::conversation::Context::connect"};
 
+               auto create_lookup = []( const auto& service, auto flags, const auto& trid)
+               {
+                  if( flag::contains( flags, connect::Flag::no_transaction))
+                     return service::Lookup{ service, {}};
+                  else
+                     return service::Lookup{ service, trid};
+               };
+
                local::validate::flags( flags);
 
-               service::Lookup lookup{ service};
                log::line( log::debug, "service: ", service, " buffer: ", buffer, " flags: ", flags);
 
+               auto& transaction = common::transaction::context().current();
+
+               auto lookup = create_lookup( service, flags, transaction.trid);
+              
 
                auto start = platform::time::clock::type::now();
 
@@ -306,8 +317,6 @@ namespace casual
                   message.parent.span = common::execution::context::get().span;
                   message.parent.service = common::execution::context::get().service;
                   message.duplex = local::duplex::invert( value.duplex);
-
-                  auto& transaction = common::transaction::context().current();
 
                   if( ! flag::contains( flags, connect::Flag::no_transaction) && transaction)
                   {

--- a/middleware/common/source/service/lookup.cpp
+++ b/middleware/common/source/service/lookup.cpp
@@ -91,7 +91,7 @@ namespace casual
   
       } // lookup
 
-      Lookup::Lookup( std::string service, lookup::Context context, std::optional< platform::time::point::type> deadline)
+      Lookup::Lookup( std::string service, const common::transaction::ID& trid, lookup::Context context, std::optional< platform::time::point::type> deadline)
          : m_service( std::move( service))
       {
          Trace trace{ "common::service::Lookup"};
@@ -99,13 +99,14 @@ namespace casual
          message::service::lookup::Request request{ process::handle()};
          request.requested = m_service;
          request.context = context;
+         request.trid = trid;
          request.deadline = std::move( deadline);
 
          m_correlation = communication::device::blocking::send( communication::instance::outbound::service::manager::device(), request);
       }
 
-      Lookup::Lookup( std::string service, std::optional< platform::time::point::type> deadline) 
-         : Lookup( std::move( service), lookup::Context{}, std::move( deadline)) 
+      Lookup::Lookup( std::string service, const common::transaction::ID& trid, std::optional< platform::time::point::type> deadline) 
+         : Lookup( std::move( service), trid, lookup::Context{}, std::move( deadline)) 
       {}
 
       Lookup::~Lookup()

--- a/middleware/service/unittest/source/manager/test_manager.cpp
+++ b/middleware/service/unittest/source/manager/test_manager.cpp
@@ -303,7 +303,7 @@ domain:
 
          auto state = unittest::state();
 
-         auto service = common::service::lookup::reply( common::service::Lookup{ "B"});
+         auto service = common::service::lookup::reply( common::service::Lookup{ "B", {}});
          // we expect the 'real-name' of the service to be replied
          EXPECT_TRUE( service.service.name == "A");
 
@@ -334,7 +334,7 @@ domain:
 
          service::unittest::advertise( { "a"});
 
-         auto service = common::service::lookup::reply( common::service::Lookup{ "a"});
+         auto service = common::service::lookup::reply( common::service::Lookup{ "a", {}});
          ASSERT_TRUE( ! service.absent());
 
          auto reply = common::communication::ipc::receive< common::message::service::call::Reply>();
@@ -368,11 +368,11 @@ domain:
 
          // reserve
          {
-            common::service::lookup::reply( common::service::Lookup{ "a"});
+            common::service::lookup::reply( common::service::Lookup{ "a", {}});
          }
 
          EXPECT_CODE( 
-            common::service::lookup::reply( common::service::Lookup{ "a"});
+            common::service::lookup::reply( common::service::Lookup{ "a", {}});
          ,common::code::xatmi::timeout);
 
          // the first reserve should give timeout reply
@@ -402,9 +402,9 @@ domain:
 
           service::unittest::advertise( { "a", "b"});
 
-         auto lookup_a = common::service::Lookup{ "a"};
+         auto lookup_a = common::service::Lookup{ "a", {}};
          // 'b' does not have any timeout
-         auto lookup_b = common::service::Lookup{ "b"};
+         auto lookup_b = common::service::Lookup{ "b", {}};
          
          auto lookup_reply_a= common::service::lookup::reply( std::move( lookup_a));
          EXPECT_TRUE( lookup_reply_a.state == decltype( lookup_reply_a.state)::idle);
@@ -648,11 +648,11 @@ domain:
          }
 
          EXPECT_CODE({
-            auto service = common::service::lookup::reply( common::service::Lookup{ "service1"});
+            auto service = common::service::lookup::reply( common::service::Lookup{ "service1", {}});
          }, common::code::xatmi::no_entry);
 
          EXPECT_CODE({
-            auto service = common::service::lookup::reply( common::service::Lookup{ "service2"});
+            auto service = common::service::lookup::reply( common::service::Lookup{ "service2", {}});
          }, common::code::xatmi::no_entry);
       }
 
@@ -665,7 +665,7 @@ domain:
          service::unittest::advertise( { "service1", "service2"});
 
          {
-            auto service = common::service::lookup::reply( common::service::Lookup{ "service1"});
+            auto service = common::service::lookup::reply( common::service::Lookup{ "service1", {}});
             EXPECT_TRUE( service.service.name == "service1");
             EXPECT_TRUE( service.process == common::process::handle());
             EXPECT_TRUE( service.state == decltype( service.state)::idle);
@@ -673,7 +673,7 @@ domain:
 
          {
             // we only have one instance, we expect lookup to not get "the reply"
-            auto lookup = common::service::Lookup{ "service2"};
+            auto lookup = common::service::Lookup{ "service2", {}};
             EXPECT_TRUE( ! common::service::lookup::non::blocking::reply( lookup));
          }
       }
@@ -690,7 +690,7 @@ domain:
          // echo server has unadvertise this service. The service is
          // still "present" in service-manager with no instances. Hence it's absent
          EXPECT_CODE({
-            common::service::lookup::reply( common::service::Lookup{ "service2"});
+            common::service::lookup::reply( common::service::Lookup{ "service2", {}});
          }, common::code::xatmi::no_entry);
       }
 
@@ -705,7 +705,7 @@ domain:
          service::unittest::advertise( { "service1", "service2"});
 
          EXPECT_CODE({
-            common::service::lookup::reply( common::service::Lookup{ "non-existent-service"});
+            common::service::lookup::reply( common::service::Lookup{ "non-existent-service", {}});
          }, common::code::xatmi::no_entry);
       }
 
@@ -719,13 +719,13 @@ domain:
          service::unittest::advertise( { "service1", "service2"});
 
          {
-            auto service = common::service::lookup::reply( common::service::Lookup{ "service1"});
+            auto service = common::service::lookup::reply( common::service::Lookup{ "service1", {}});
             EXPECT_TRUE( service.service.name == "service1");
             EXPECT_TRUE( service.process == common::process::handle());
             EXPECT_TRUE( service.state == decltype( service.state)::idle);
          }
 
-         common::service::Lookup lookup{ "service2"};
+         common::service::Lookup lookup{ "service2", {}};
          {
             // we only have one instance, we expect this to be busy
             EXPECT_TRUE( ! common::service::lookup::non::blocking::reply( lookup));
@@ -761,7 +761,7 @@ domain:
          auto forward = common::communication::instance::fetch::handle( forward::instance::identity.id);
 
          {
-            auto service = common::service::lookup::reply( common::service::Lookup{ "service1"});
+            auto service = common::service::lookup::reply( common::service::Lookup{ "service1", {}});
             EXPECT_TRUE( service.service.name == "service1");
             EXPECT_TRUE( service.process == common::process::handle());
             EXPECT_TRUE( service.state == decltype( service.state)::idle);
@@ -769,7 +769,7 @@ domain:
 
 
          {
-            auto service = common::service::lookup::reply( common::service::Lookup{ "service1", decltype( common::service::lookup::Context::semantic)::no_reply});
+            auto service = common::service::lookup::reply( common::service::Lookup{ "service1", {}, decltype( common::service::lookup::Context::semantic)::no_reply});
             EXPECT_TRUE( service.service.name == "service1");
 
             // service-manager will let us think that the service is idle, and send us the process-handle to the forward-cache
@@ -854,7 +854,7 @@ domain:
 
          auto correlation = []()
          {
-            auto service = common::service::lookup::reply( common::service::Lookup{ "service1"});
+            auto service = common::service::lookup::reply( common::service::Lookup{ "service1", {}});
             EXPECT_TRUE( service.service.name == "service1");
             EXPECT_TRUE( service.process == common::process::handle());
             EXPECT_TRUE( service.state == decltype( service.state)::idle);
@@ -912,7 +912,7 @@ domain:
 
          {
             // we expect service 'a' to be absent.
-            auto lookup = common::service::Lookup{ "a"};
+            auto lookup = common::service::Lookup{ "a", {}};
             EXPECT_CODE( common::service::lookup::reply( std::move( lookup)), common::code::xatmi::no_entry);
          }
       }
@@ -926,7 +926,7 @@ domain:
          service::unittest::advertise( { "a"});
 
          // 'emulate' that a call is in progress (more like consuming the lookup reply...)
-         const auto service = common::service::lookup::reply( common::service::Lookup{ "a"});
+         const auto service = common::service::lookup::reply( common::service::Lookup{ "a", {}});
 
          EXPECT_TRUE( service.state == decltype( service.state)::idle);
 
@@ -952,7 +952,7 @@ domain:
 
          {
             // we expect service 'a' to be absent.
-            auto absent = common::service::Lookup{ "a"};
+            auto absent = common::service::Lookup{ "a", {}};
             EXPECT_CODE( common::service::lookup::reply( std::move( absent)), common::code::xatmi::no_entry);
          }
       }
@@ -965,9 +965,13 @@ domain:
 
          service::unittest::advertise( { "a", "b", "c", "d"});
 
-         auto idle = common::service::lookup::reply( common::service::Lookup{ "a"});
+         auto idle = common::service::lookup::reply( common::service::Lookup{ "a", {}});
 
-         auto lookups = common::algorithm::container::emplace::initialize< std::vector< common::service::Lookup>>(  "b", "c", "d");
+         auto lookups = common::algorithm::container::emplace::initialize< std::vector< common::service::Lookup>>(
+            common::service::Lookup{ "b", {}},
+            common::service::Lookup{ "c", {}},
+            common::service::Lookup{ "d", {}}
+         );
 
          EXPECT_TRUE( idle.state == decltype( idle.state)::idle);
 
@@ -1038,8 +1042,8 @@ domain:
          // we reserve (lock) our instance to the 'call', via the route
          struct 
          {
-            common::service::Lookup first{ "B"};
-            common::service::Lookup second{ "B"};
+            common::service::Lookup first{ "B", {}};
+            common::service::Lookup second{ "B", {}};
          } lookup;
 
          using State =  common::service::lookup::State;
@@ -1071,7 +1075,7 @@ domain:
          auto end = start + std::chrono::milliseconds{ 2};
 
          {
-            auto service = common::service::lookup::reply( common::service::Lookup{ "service1"});
+            auto service = common::service::lookup::reply( common::service::Lookup{ "service1", {}});
             EXPECT_TRUE( service.service.name == "service1");
             EXPECT_TRUE( service.process == common::process::handle());
             EXPECT_TRUE( service.state == decltype( service.state)::idle);
@@ -1230,13 +1234,13 @@ domain:
 
          // we reserve ourselves
          {
-            auto service = common::service::lookup::reply( common::service::Lookup{ "local-service"});
+            auto service = common::service::lookup::reply( common::service::Lookup{ "local-service", {}});
             EXPECT_TRUE( service.service.name == "local-service");
             EXPECT_TRUE( service.state == decltype( service.state)::idle);
          }
 
          // lookup 'local-service' again
-         common::service::Lookup lookup{ "local-service"};
+         common::service::Lookup lookup{ "local-service", {}};
 
          // some unrelated concurrent services are advertised while our second lookup is pending
          service::unittest::concurrent::advertise( { "some-remote-service", "some-other-remote-service"});
@@ -1271,13 +1275,13 @@ domain:
 
          // we reserve ourselves
          {
-            auto service = common::service::lookup::reply( common::service::Lookup{ "local-service"});
+            auto service = common::service::lookup::reply( common::service::Lookup{ "local-service", {}});
             EXPECT_TRUE( service.service.name == "local-service");
             EXPECT_TRUE( service.state == decltype( service.state)::idle);
          }
 
          // lookup 'local-service' again
-         common::service::Lookup lookup{ "local-service"};
+         common::service::Lookup lookup{ "local-service", {}};
 
          // meanwhile, some process dies
          {
@@ -1358,7 +1362,7 @@ domain:
 
          // reserve the service
          {
-            auto service = common::service::lookup::reply( common::service::Lookup{ "a"});
+            auto service = common::service::lookup::reply( common::service::Lookup{ "a", {}});
             EXPECT_TRUE( service.service.name == "a");
             EXPECT_TRUE( service.process == callee);
             EXPECT_TRUE( service.state == decltype( service.state)::idle);
@@ -1393,6 +1397,82 @@ domain:
             EXPECT_TRUE( metric.code.result == common::code::xatmi::service_error);
             EXPECT_TRUE( metric.trid == common::transaction::context().current().trid);
          }
+      }
+
+      namespace local
+      {
+         namespace
+         {
+            auto advertise( const std::vector< std::string>& services, auto& device)
+            {
+               common::message::service::concurrent::Advertise message;
+               message.process.pid = common::process::id();
+               message.process.ipc = device.connector().handle().ipc();
+
+               for( auto& service : services)
+               {
+                  message.services.add.push_back( { 
+                     .name = std::move( service), 
+                     .transaction = common::service::transaction::Type::automatic, 
+                     .visibility = common::service::visibility::Type::discoverable});
+               }
+
+               common::communication::device::blocking::send( common::communication::instance::outbound::service::manager::device(), message);
+            }
+
+            auto lookup( std::string service, const auto& trid)
+            {
+               return common::service::lookup::reply( common::service::Lookup{ 
+                  std::move( service),
+                  trid,
+                  common::message::service::lookup::request::context::Semantic::wait
+               });
+            }
+            
+         } // <unnamed>
+      } // local
+
+
+      TEST( service_manager, advertise_concurrent_services_with_10_ipc__lookup_with_gtrid__expect_same_ipc)
+      {
+         common::unittest::Trace trace;
+
+         auto const services = std::vector< std::string>{ "a", "b", "c"};
+
+         auto domain = local::domain();
+
+         std::array< common::communication::ipc::inbound::Device, 10> devices;
+
+         common::algorithm::for_each( devices, [ &services]( auto& device)
+         {
+            local::advertise( services, device);
+         });
+
+         // create a lot of gtrid state for the SM
+         common::algorithm::for_n< 10>( [ &services]()
+         {
+            for( auto& service : services)
+            {
+               auto reply = local::lookup( service, common::transaction::id::create());
+               EXPECT_TRUE( reply.process.ipc);
+            }
+         });
+
+         auto trid = common::transaction::id::create();
+
+         auto first_lookup = local::lookup( "a", trid);
+
+         EXPECT_TRUE( first_lookup.process.ipc);
+
+         // lookup all 3 services 10 more times, we should get the same ipc
+         common::algorithm::for_n< 10>( [&]()
+         {
+            for( auto& service : services)
+            {
+               auto reply = local::lookup( service, trid);
+               EXPECT_TRUE( reply.process.ipc == first_lookup.process.ipc) << CASUAL_NAMED_VALUE( reply);
+            }
+         });
       }
 
    } // service

--- a/test/unittest/source/test_gateway.cpp
+++ b/test/unittest/source/test_gateway.cpp
@@ -1649,6 +1649,60 @@ domain:
          EXPECT_TRUE( domains[ "D"] > 0) << CASUAL_NAMED_VALUE( domains);
       }
 
+      TEST( test_gateway, domain_A_to__B_C_D__call_domain_name_in_transaction___expect_all_calls_to_go_to_one_domain)
+      {
+         common::unittest::Trace trace;
+
+         // sink child signals 
+         signal::callback::registration< code::signal::child>( [](){});
+
+         auto b = local::example::domain( "B", "7001");
+         auto c = local::example::domain( "C", "7002");
+         auto d = local::example::domain( "D", "7003");
+
+         auto a = local::domain( R"(
+domain: 
+   name: A
+  
+   gateway:
+      outbound:
+         groups:
+            -  connections:
+                  -  address: 127.0.0.1:7001
+                  -  address: 127.0.0.1:7002
+                  -  address: 127.0.0.1:7003
+)");
+
+         gateway::unittest::fetch::until( gateway::unittest::fetch::predicate::outbound::connected( 3));
+         
+         // discover a service that we know exists in B, C and D
+         {
+            auto services = casual::domain::unittest::discover::services( { "casual/example/domain/name"});
+            EXPECT_TRUE( services.at( 0) == "casual/example/domain/name");
+         }
+
+         // start a transaction
+         EXPECT_TRUE( ::tx_begin() == TX_OK);
+
+         std::map< std::string, int> domains;
+
+         constexpr int count = 20;
+
+         algorithm::for_n< count>( [ &domains]() mutable
+         {
+            auto buffer = local::call( "casual/example/domain/name");
+            domains[ buffer.get()]++;
+         });
+
+         // commit the transaction
+         EXPECT_TRUE( ::tx_commit() == TX_OK);
+
+         // should only be one domain that got all calls
+         ASSERT_TRUE( domains.size() == 1) << CASUAL_NAMED_VALUE( domains);
+         EXPECT_TRUE( std::begin( domains)->second == count) << CASUAL_NAMED_VALUE( domains);
+      }
+
+
       TEST( test_gateway, domains_A_B__B_has_echo__call_echo_from_A__expect_discovery__shutdown_B__expect_no_ent__boot_B__expect_discovery)
       {
          common::unittest::Trace trace;
@@ -3759,7 +3813,7 @@ domain:
          auto lookup = []()
          {
             auto context = common::service::lookup::Context{ common::message::service::lookup::request::context::Semantic::wait};
-            return common::service::Lookup{ "casual/example/echo", context};
+            return common::service::Lookup{ "casual/example/echo", {}, context};
          }();
 
          // expect no service to be found

--- a/test/unittest/source/test_service.cpp
+++ b/test/unittest/source/test_service.cpp
@@ -404,7 +404,7 @@ domain:
 )");
 
          // lookup / reserve the instance
-         auto lookup = common::service::lookup::reply( common::service::Lookup{ "casual/example/echo"});
+         auto lookup = common::service::lookup::reply( common::service::Lookup{ "casual/example/echo", {}});
 
          communication::ipc::inbound::Device inbound;
 


### PR DESCRIPTION
Before: service::Lookup dit not take nor propagate (current) trid to SM. This totally circumvent the load balancing gtrid correlation that SM tries to do.

Now: service::Lookup takes a trid, and propagate this in the lookup request.

Resolves #557