### PR TITLE
Feature/1.8/new casual make model

### DIFF
--- a/.casual-make/configuration.json
+++ b/.casual-make/configuration.json
@@ -1,0 +1,448 @@
+{ 
+  "configuration" : 
+  {
+    "version" : 1.0,
+    "system":
+    [
+      {
+        "name" : "Linux",
+        "compiler" : "g++",
+        "profile" : 
+        [
+          { 
+            "name" : "normal",
+            "cpp_standard" : 
+            {
+              "directive" : [ "-std=c++2b"]
+            },
+            "dependency": 
+            { 
+              "command" : [ "g++"],
+              "directive" : [ "-E", "-MMD"]
+            },
+            "compile" : 
+            {
+              "command" : ["g++"],
+              "directive" :
+              [ 
+                "-c",
+                "-O3",
+                "-fPIC",
+                "-pthread"
+              ],
+              "warning" : 
+              {
+                "directive":
+                [
+                  "-Wall",
+                  "-Wextra",
+                  "-Werror",
+                  "-Wsign-compare",
+                  "-Wuninitialized",
+                  "-Winit-self",
+                  "-Wno-unused-parameter",
+                  "-Wno-missing-declarations",
+                  "-Wno-noexcept-type",
+                  "-Wno-implicit-fallthrough",
+                  "-Wno-missing-field-initializers",
+                  "-Wno-dangling-reference",
+                  "-Wno-unknown-warning-option"                ]
+              }
+            },
+            "link" : 
+            {
+              "executable" :
+              {
+                "command" : ["g++"],
+                "directive" :
+                [
+                  "-pthread",
+                  "-O3",
+                  "-fPIC"
+                ]
+              },
+              "library" :
+              {
+                "command" : ["g++"],
+                "directive" :
+                [
+                  "-pthread", 
+                  "-shared",
+                  "-O3",
+                  "-fPIC"
+                ]
+              },
+              "archive" : 
+              {
+                "command" : [ "ar", "rcs"],
+                "directive" :
+                [
+                ]
+              }
+            }
+          },
+          { 
+            "name" : "debug",
+            "cpp_standard" : 
+            {
+              "directive" : [ "-std=c++2b"]
+            },
+            "dependency": 
+            { 
+              "command" : [ "g++"],
+              "directive" : [ "-E", "-MMD"]
+            },
+            "compile" : 
+            {
+              "command" : ["g++"],
+              "directive" :
+              [ 
+                "-ggdb",
+                "-c",
+                "-fPIC"
+              ],
+              "warning" : 
+              {
+                "directive" :
+                [
+                  "-Wall",
+                  "-Wextra",
+                  "-Werror",
+                  "-Wsign-compare",
+                  "-Wuninitialized",
+                  "-Winit-self",
+                  "-Wno-unused-parameter",
+                  "-Wno-missing-declarations",
+                  "-Wno-noexcept-type",
+                  "-Wno-implicit-fallthrough",
+                  "-Wno-missing-field-initializers",
+                  "-Wno-dangling-reference"
+                ]
+              }
+            },
+            "link" : 
+            {
+              "executable" :
+              {
+                "command" : ["g++"],
+                "directive" :
+                [
+                  "-g",
+                  "-pthread",
+                  "-fPIC"
+                ]
+              },
+              "library" :
+              {
+                "command" : ["g++"],
+                "directive" :
+                [
+                  "-g",
+                  "-pthread", 
+                  "-shared",
+                  "-fPIC"
+                ]
+              },
+              "archive" : 
+              {
+                "command" : [ "ar", "rcs"],
+                "directive" :
+                [
+                ]
+              }
+            }
+          },
+          { 
+            "name" : "analyze",
+            "cpp_standard" : 
+            {
+              "directive" : [ "-std=c++2b"]
+            },
+            "dependency": 
+            { 
+              "command" : [ "g++"],
+              "directive" : [ "-E", "-MMD"]
+            },
+            "compile" : 
+            {
+              "command" : ["g++"],
+              "directive" :
+              [ 
+                "-ggdb",
+                "-c",
+                "-fPIC",
+                "-fprofile-arcs", 
+                "-ftest-coverage"
+              ],
+              "warning" : 
+              {
+                "directive":
+                [
+                  "-Wall",
+                  "-Wextra",
+                  "-Werror",
+                  "-Wsign-compare",
+                  "-Wuninitialized",
+                  "-Winit-self",
+                  "-Wno-unused-parameter",
+                  "-Wno-missing-declarations",
+                  "-Wno-noexcept-type",
+                  "-Wno-implicit-fallthrough",
+                  "-Wno-missing-field-initializers",
+                  "-Wno-dangling-reference"
+                ]
+              }
+            },
+            "link" : 
+            {
+              "executable" :
+              {
+                "command" : ["g++"],
+                "directive" :
+                [
+                  "-g",
+                  "-pthread",
+                  "-fPIC",
+                  "-O0", 
+                  "-coverage"
+                ]
+              },
+              "library" :
+              {
+                "command" : ["g++"],
+                "directive" :
+                [
+                  "-g",
+                  "-pthread", 
+                  "-shared",
+                  "-fPIC",
+                  "-O0", 
+                  "-coverage"
+                ]
+              },
+              "archive" : 
+              {
+                "command" : [ "ar", "rcs"],
+                "directive" :
+                [
+                ]
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name" : "Darwin",
+        "compiler" : "g++",
+        "profile" : 
+        [
+          { 
+            "name" : "normal",
+            "cpp_standard" : 
+            {
+              "directive" : [ "-std=c++2b"]
+            },
+            "dependency": 
+            { 
+              "command" : [ "g++"],
+              "directive" : [ "-E", "-MMD"]
+            },
+            "compile" : 
+            {
+              "command" : ["g++"],
+              "directive" :
+              [ 
+                "-c",
+                "-O3",
+                "-fPIC",
+                "-pthread"
+              ],
+              "warning" : 
+              {
+                "directive":
+                [
+                  "-Wall",
+                  "-Wextra",
+                  "-Werror",
+                  "-Wsign-compare",
+                  "-Wuninitialized",
+                  "-Winit-self",
+                  "-Wno-unused-parameter",
+                  "-Wno-missing-declarations",
+                  "-Wno-noexcept-type",
+                  "-Wno-implicit-fallthrough",
+                  "-Wno-missing-field-initializers",
+                  "-Wno-deprecated-declarations"
+                ]
+              }
+            },
+            "link" : 
+            {
+              "executable" :
+              {
+                "command" : ["g++"],
+                "directive" :
+                [
+                  "-O3"
+                ]
+              },
+              "library" :
+              {
+                "command" : ["g++"],
+                "directive" :
+                [
+                  "-O3",
+                  "-dynamiclib"
+                ]
+              },
+              "archive" : 
+              {
+                "command" : [ "ar", "rcs"],
+                "directive" :
+                [
+                ]
+              }
+            }
+          },
+          { 
+            "name" : "debug",
+            "cpp_standard" : 
+            {
+              "directive" : [ "-std=c++2b"]
+            },
+            "dependency": 
+            { 
+              "command" : [ "g++"],
+              "directive" : [ "-E", "-MMD"]
+            },
+            "compile" : 
+            {
+              "command" : ["g++"],
+              "directive" :
+              [ 
+                "-ggdb",
+                "-c",
+                "-fPIC"
+              ],
+              "warning" : 
+              {
+                "directive" :
+                [
+                  "-Wall",
+                  "-Wextra",
+                  "-Werror",
+                  "-Wsign-compare",
+                  "-Wuninitialized",
+                  "-Winit-self",
+                  "-Wno-unused-parameter",
+                  "-Wno-missing-declarations",
+                  "-Wno-noexcept-type",
+                  "-Wno-implicit-fallthrough",
+                  "-Wno-missing-field-initializers"
+                ]
+              }
+            },
+            "link" : 
+            {
+              "executable" :
+              {
+                "command" : ["g++"],
+                "directive" :
+                [
+                  "-ggdb"
+                ]
+              },
+              "library" :
+              {
+                "command" : ["g++"],
+                "directive" :
+                [
+                  "-ggdb", 
+                  "-dynamiclib"
+                ]
+              },
+              "archive" : 
+              {
+                "command" : [ "ar", "rcs"],
+                "directive" :
+                [
+                ]
+              }
+            }
+          },
+          { 
+            "name" : "analyze",
+            "cpp_standard" : 
+            {
+              "directive" : [ "-std=c++2b"]
+            },
+            "dependency": 
+            { 
+              "command" : [ "g++"],
+              "directive" : [ "-E", "-MMD"]
+            },
+            "compile" : 
+            {
+              "command" : ["g++"],
+              "directive" :
+              [ 
+                "-ggdb",
+                "-c",
+                "-fPIC",
+                "-fprofile-arcs", 
+                "-ftest-coverage"
+              ],
+              "warning" : 
+              {
+                "directive" :
+                [
+                  "-Wall",
+                  "-Wextra",
+                  "-Werror",
+                  "-Wsign-compare",
+                  "-Wuninitialized",
+                  "-Winit-self",
+                  "-Wno-unused-parameter",
+                  "-Wno-missing-declarations",
+                  "-Wno-noexcept-type",
+                  "-Wno-implicit-fallthrough",
+                  "-Wno-missing-field-initializers"
+                ]
+              }
+            },
+            "link" : 
+            {
+              "executable" :
+              {
+                "command" : ["g++"],
+                "directive" :
+                [
+                  "-ggdb",
+                  "-lgcov", 
+                  "-fprofile-arcs"
+                ]
+              },
+              "library" :
+              {
+                "command" : ["g++"],
+                "directive" :
+                [
+                  "-ggdb", 
+                  "-dynamiclib",
+                  "-fprofile-arcs"
+                ]
+              },
+              "archive" : 
+              {
+                "command" : [ "ar", "rcs"],
+                "directive" :
+                [
+                ]
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/casual-build-alpha.yaml
+++ b/.github/workflows/casual-build-alpha.yaml
@@ -202,7 +202,7 @@ jobs:
 
       - name: Build
         run: |
-          docker run --rm -v ${{ github.workspace }}:/git/casual:Z -i ${{ env.suse_image}}:${{ needs.calculate-version.outputs.major_minor }}
+          docker run --pull always --rm -v ${{ github.workspace }}:/git/casual:Z -i ${{ env.suse_image}}:${{ needs.calculate-version.outputs.major_minor }}
 
       - name: Logpublisher
         if: ${{ failure() || cancelled() }}

--- a/.github/workflows/casual-build-alpha.yaml
+++ b/.github/workflows/casual-build-alpha.yaml
@@ -98,7 +98,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: 'casualcore/casual-make'
-          ref: ${{ needs.calculate-version.outputs.major_minor }}
+          ref: 'feature/1.8/new-configuration-model'
           path: 'casual-make'
 
       - name: prepare build-script
@@ -174,7 +174,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: 'casualcore/casual-make'
-          ref: ${{ needs.calculate-version.outputs.major_minor }}
+          ref: 'feature/1.8/new-configuration-model'
           path: 'casual-make'
 
       - name: prepare build-script

--- a/make/casual/middleware/make/api.py
+++ b/make/casual/middleware/make/api.py
@@ -59,7 +59,7 @@ def paths():
             ]
             self.gtest = [ thirdparty + '/googletest/bin']
 
-      library = Library( thirdparty)
+      library = Library( common.use_build_directory( thirdparty))
 
    paths.state = Paths()
    return paths.state
@@ -90,8 +90,8 @@ def LinkServer( name, objects, libraries, serverdefinition, resources=None, conf
    makefile = caller()
    directory, dummy = os.path.split( makefile.filename())
 
-   full_executable_name = selector.expanded_executable_name(name, directory)
-   executable_target = model.register( full_executable_name, full_executable_name, makefile = makefile.filename())
+   full_executable_name = common.create_absolute_filename( selector.expanded_executable_name(name), directory, common.FileType.DESTINATION)
+   executable_target = model.register( 'link-executable' + full_executable_name, full_executable_name, makefile = makefile.filename())
 
    directive = []
    if resources:
@@ -170,7 +170,7 @@ def GenerateDocumentation( path, dependencies=[], generator_function=default_gen
    directory, dummy = os.path.split( makefile.filename())
 
    full_path_name = os.path.abspath( os.path.join( directory, path))
-   documentation_target = model.register( 'documentation' + full_path_name, 'documentation' + full_path_name, makefile = makefile.filename())
+   documentation_target = model.register( 'documentation' + full_path_name, full_path_name, makefile = makefile.filename())
 
    if dependencies:
       for dependency in dependencies:

--- a/make/casual/middleware/make/api.py
+++ b/make/casual/middleware/make/api.py
@@ -147,13 +147,13 @@ def link_server( input):
    library_paths = input['library_paths']
    include_paths = input['include_paths']
 
-   BUILDSERVER = [ BUILD_SERVER(), "-c"] + selector.build_configuration['executable_linker']
+   BUILDSERVER = [ BUILD_SERVER(), "-c"] + selector.configuration.link.executable.command
 
    cmd = BUILDSERVER + \
          ['-o', destination.filename()] + directive + ['-f'] + [" ".join( objects)] + \
          selector.library_directive(libraries) +  \
          selector.library_paths_directive( library_paths) + \
-         selector.build_configuration['link_directives_exe'] + \
+         selector.configuration.link.executable.directive + \
          common.add_item_to_list( include_paths, '-I')
 
    executor.command( cmd, destination, context_directory)

--- a/middleware/administration/unittest/source/build/test_rm.cpp
+++ b/middleware/administration/unittest/source/build/test_rm.cpp
@@ -32,14 +32,14 @@ system:
                -  "${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/include"
                -  "${CASUAL_MAKE_SOURCE_ROOT}/middleware/xatmi/include"
             library: 
-               -  "${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin"
-               -  "${CASUAL_MAKE_SOURCE_ROOT}/middleware/common/bin"
-               -  "${CASUAL_MAKE_SOURCE_ROOT}/middleware/xatmi/bin"
+               -  "${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin"
+               -  "${CASUAL_MAKE_BUILD_ROOT}/middleware/common/bin"
+               -  "${CASUAL_MAKE_BUILD_ROOT}/middleware/xatmi/bin"
 )");
          
          auto output = common::unittest::file::temporary::name( ".exe");
 
-         auto build_rm_path = "${CASUAL_MAKE_SOURCE_ROOT}/middleware/tools/bin/casual-build-resource-proxy";
+         auto build_rm_path = "${CASUAL_MAKE_BUILD_ROOT}/middleware/tools/bin/casual-build-resource-proxy";
          
          auto capture = administration::unittest::cli::command::execute(
             build_rm_path, " --output ", output.string(), " --resource-key rm-mockup --system-configuration ", system.string(), " --compile-directives -O3");

--- a/middleware/administration/unittest/source/cli/command.cpp
+++ b/middleware/administration/unittest/source/cli/command.cpp
@@ -45,7 +45,7 @@ namespace casual
             Trace trace{ "administration::unittest::cli::command::execute"};
 
             // make sure we've got casual stuff in the path
-            auto path = string::compose( "PATH=", environment::expand( "${CASUAL_MAKE_SOURCE_ROOT}/middleware/administration/bin:${PATH}")); 
+            auto path = string::compose( "PATH=", environment::expand( "${CASUAL_MAKE_BUILD_ROOT}/middleware/administration/bin:${PATH}")); 
 
             // ignore child signals
             auto guard = local::signal::handler();

--- a/middleware/administration/unittest/source/cli/configuration/test_runtime.cpp
+++ b/middleware/administration/unittest/source/cli/configuration/test_runtime.cpp
@@ -44,9 +44,9 @@ domain:
          dependencies: [ user]
    
    servers:
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/service/bin/casual-service-manager"
         memberships: [ base]
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/casual-transaction-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/casual-transaction-manager"
         memberships: [ base]
 )";
             } // configuration
@@ -83,7 +83,7 @@ domain:
    name: A
    servers:
       -  alias: xxx
-         path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+         path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
          memberships: [ user]
          instances: 1
 )");
@@ -112,7 +112,7 @@ domain:
    name: A
    servers:
       -  alias: xxx
-         path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+         path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
          memberships: [ user]
          instances: 1
 )");

--- a/middleware/administration/unittest/source/cli/configuration/test_set_operations.cpp
+++ b/middleware/administration/unittest/source/cli/configuration/test_set_operations.cpp
@@ -25,7 +25,7 @@ namespace casual::administration
 system:
    resources:
       -  key: rm-mockup
-         server: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/rm-proxy-casual-mockup"
+         server: "${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/rm-proxy-casual-mockup"
          xa_struct_name: casual_mockup_xa_switch_static
          libraries:
             -  casual-mockup-rm
@@ -41,11 +41,11 @@ domain:
          dependencies: [ user]
    
    servers:
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/service/bin/casual-service-manager"
         memberships: [ base]
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/casual-transaction-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/casual-transaction-manager"
         memberships: [ base]
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/gateway/bin/casual-gateway-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/gateway/bin/casual-gateway-manager"
         memberships: [ gateway]
 )";
          

--- a/middleware/administration/unittest/source/cli/test_call.cpp
+++ b/middleware/administration/unittest/source/cli/test_call.cpp
@@ -33,7 +33,7 @@ namespace casual
 system:
    resources:
       -  key: rm-mockup
-         server: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/rm-proxy-casual-mockup"
+         server: "${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/rm-proxy-casual-mockup"
          xa_struct_name: casual_mockup_xa_switch_static
          libraries:
             -  casual-mockup-rm
@@ -49,11 +49,11 @@ domain:
          dependencies: [ user]
    
    servers:
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/service/bin/casual-service-manager"
         memberships: [ base]
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/casual-transaction-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/casual-transaction-manager"
         memberships: [ base]
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/gateway/bin/casual-gateway-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/gateway/bin/casual-gateway-manager"
         memberships: [ gateway]
 )";
             } // configuration
@@ -92,7 +92,7 @@ domain:
          auto domain = local::domain( R"(
 domain:
    servers:
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
         memberships: [ user]
         arguments: [ --sleep, 10ms]
 )");
@@ -109,7 +109,7 @@ domain:
          auto domain = local::domain( R"(
 domain:
    servers:
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
         memberships: [ user]
         arguments: [ --sleep, 10ms]
 )");
@@ -138,7 +138,7 @@ casual
          auto domain = local::domain( R"(
 domain:
    servers:
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
         memberships: [ user]
         arguments: [ --sleep, 10ms]
 )");
@@ -154,7 +154,7 @@ domain:
          auto domain = local::domain( R"(
 domain:
    servers:
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-error-server"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-error-server"
         memberships: [ user]
         arguments: [ --sleep, 10ms]
 )");

--- a/middleware/administration/unittest/source/cli/test_casual.cpp
+++ b/middleware/administration/unittest/source/cli/test_casual.cpp
@@ -40,7 +40,7 @@ domain:
          dependencies: [ user]
    
    servers:
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/service/bin/casual-service-manager"
          memberships: [ base]
 )";
 

--- a/middleware/administration/unittest/source/cli/test_discovery.cpp
+++ b/middleware/administration/unittest/source/cli/test_discovery.cpp
@@ -39,13 +39,13 @@ domain:
          dependencies: [ user]
    
    servers:
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/service/bin/casual-service-manager"
         memberships: [ base]
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/casual-transaction-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/casual-transaction-manager"
         memberships: [ base]
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/queue/bin/casual-queue-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/queue/bin/casual-queue-manager"
         memberships: [ queue]
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/gateway/bin/casual-gateway-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/gateway/bin/casual-gateway-manager"
         memberships: [ gateway]
 )";
             } // configuration
@@ -68,7 +68,7 @@ domain:
    name: B
    servers:
       -  alias: example-server
-         path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+         path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
          memberships: [ user]
          instances: 1
    gateway:
@@ -152,7 +152,7 @@ domain:
    name: B
    servers:
       -  alias: example-server
-         path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+         path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
          memberships: [ user]
          instances: 1
    gateway:

--- a/middleware/administration/unittest/source/cli/test_domain.cpp
+++ b/middleware/administration/unittest/source/cli/test_domain.cpp
@@ -31,7 +31,7 @@ namespace casual
 system:
    resources:
       -  key: rm-mockup
-         server: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/rm-proxy-casual-mockup"
+         server: "${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/rm-proxy-casual-mockup"
          xa_struct_name: casual_mockup_xa_switch_static
          libraries:
             -  casual-mockup-rm
@@ -47,11 +47,11 @@ domain:
          dependencies: [ user]
    
    servers:
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/service/bin/casual-service-manager"
         memberships: [ base]
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/casual-transaction-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/casual-transaction-manager"
         memberships: [ base]
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/gateway/bin/casual-gateway-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/gateway/bin/casual-gateway-manager"
         memberships: [ gateway]
 )";
             } // configuration
@@ -88,12 +88,12 @@ domain:
          dependencies: [ B]      
    servers:
       -  alias: a
-         path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+         path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
          memberships: [ A]
          instances: 2
          restart: true
       -  alias: b
-         path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+         path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
          memberships: [ B]
          instances: 2
       -  alias: c
@@ -128,14 +128,14 @@ domain:
 /*
 alias                       CI  I  state     restart  #r  path                                                                              
 --------------------------  --  -  --------  -------  --  ----------------------------------------------------------------------------------
-a                            2  2  enabled      true   0  "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"  
-b                            2  0  disabled    false   0  "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"  
+a                            2  2  enabled      true   0  "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"  
+b                            2  0  disabled    false   0  "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"  
 c                            2  0  error       false   0  "/non/existent/path"                                                              
 casual-domain-discovery      1  1  enabled      true   0  "/Users/lazan/git/casual/1.7/casual/middleware/domain/bin/casual-domain-discovery"
 casual-domain-manager        1  1  enabled     false   0  "casual-domain-manager"                                                           
-casual-gateway-manager       1  1  enabled     false   0  "${CASUAL_MAKE_SOURCE_ROOT}/middleware/gateway/bin/casual-gateway-manager"        
-casual-service-manager       1  1  enabled     false   0  "${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager"        
-casual-transaction-manager   1  1  enabled     false   0  "${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/casual-transaction-manager"
+casual-gateway-manager       1  1  enabled     false   0  "${CASUAL_MAKE_BUILD_ROOT}/middleware/gateway/bin/casual-gateway-manager"        
+casual-service-manager       1  1  enabled     false   0  "${CASUAL_MAKE_BUILD_ROOT}/middleware/service/bin/casual-service-manager"        
+casual-transaction-manager   1  1  enabled     false   0  "${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/casual-transaction-manager"
 */
             auto lines = local::execute_get_lines(  "casual --header false --color false domain --list-servers");
 
@@ -220,7 +220,7 @@ z       2  0  error       false   0  "/non/existent/path"
 domain:
    servers:
       -  alias: example-server
-         path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+         path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
          memberships: [ user]
          instances: 1
 )");
@@ -249,7 +249,7 @@ domain:
 domain:
    servers:
       -  alias: example-server
-         path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+         path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
          memberships: [ user]
          instances: 5
 )");
@@ -325,7 +325,7 @@ domain:
 domain:
    servers:
       - alias: echo-server
-        path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+        path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
         memberships: [ user]
         instances: 1
 )");
@@ -347,7 +347,7 @@ domain:
 domain:
    servers:
       - alias: echo-server
-        path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+        path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
         memberships: [ user]
         instances: 5
 )");
@@ -369,7 +369,7 @@ domain:
 domain:
    servers:
       - alias: echo-server
-        path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+        path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
         memberships: [ user]
         instances: 1
 )");
@@ -429,7 +429,7 @@ domain:
 domain:
    servers:
       - alias: echo-server
-        path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+        path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
         memberships: [ user]
         instances: 1
 )");

--- a/middleware/administration/unittest/source/cli/test_gateway.cpp
+++ b/middleware/administration/unittest/source/cli/test_gateway.cpp
@@ -36,11 +36,11 @@ domain:
          dependencies: [ user]
    
    servers:
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/service/bin/casual-service-manager"
         memberships: [ base]
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/casual-transaction-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/casual-transaction-manager"
         memberships: [ base]
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/gateway/bin/casual-gateway-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/gateway/bin/casual-gateway-manager"
         memberships: [ gateway]
 )";
             } // configuration

--- a/middleware/administration/unittest/source/cli/test_internal.cpp
+++ b/middleware/administration/unittest/source/cli/test_internal.cpp
@@ -34,7 +34,7 @@ domain:
          dependencies: [ base]
    
    servers:
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/service/bin/casual-service-manager"
         memberships: [ base]
 
 )";
@@ -58,7 +58,7 @@ domain:
 domain:
    servers:
       -  alias: example-server
-         path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+         path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
          memberships: [ user]
          instances: 1
 )");

--- a/middleware/administration/unittest/source/cli/test_pipe.cpp
+++ b/middleware/administration/unittest/source/cli/test_pipe.cpp
@@ -37,13 +37,13 @@ domain:
          dependencies: [ queue]
    
    servers:
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/service/bin/casual-service-manager"
          memberships: [ base]
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/casual-transaction-manager"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/casual-transaction-manager"
          memberships: [ base]
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/queue/bin/casual-queue-manager"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/queue/bin/casual-queue-manager"
          memberships: [ queue]
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
          memberships: [ user]
 )";
             } // configuration
@@ -156,7 +156,7 @@ domain:
 domain:
    name: A
    servers:
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-error-server"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-error-server"
          memberships: [ user]
    queue:
       groups:

--- a/middleware/administration/unittest/source/cli/test_queue.cpp
+++ b/middleware/administration/unittest/source/cli/test_queue.cpp
@@ -44,11 +44,11 @@ domain:
          dependencies: [ queue]
    
    servers:
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/service/bin/casual-service-manager"
         memberships: [ base]
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/casual-transaction-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/casual-transaction-manager"
         memberships: [ base]
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/queue/bin/casual-queue-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/queue/bin/casual-queue-manager"
         memberships: [ queue]
 )";
             } // configuration
@@ -405,7 +405,7 @@ domain:
          dependencies: [ user]
    
    servers:
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/gateway/bin/casual-gateway-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/gateway/bin/casual-gateway-manager"
         memberships: [ gateway]
 )";
          } // <unnamed>

--- a/middleware/administration/unittest/source/cli/test_service.cpp
+++ b/middleware/administration/unittest/source/cli/test_service.cpp
@@ -42,7 +42,7 @@ domain:
          dependencies: [ user]
    
    servers:
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/service/bin/casual-service-manager"
          memberships: [ base]
 )";
 
@@ -337,9 +337,9 @@ domain:
          constexpr auto base = R"(
 domain:
    servers:
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/casual-transaction-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/casual-transaction-manager"
         memberships: [ base]
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/gateway/bin/casual-gateway-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/gateway/bin/casual-gateway-manager"
         memberships: [ gateway]
 )";
 

--- a/middleware/administration/unittest/source/cli/test_transaction.cpp
+++ b/middleware/administration/unittest/source/cli/test_transaction.cpp
@@ -43,13 +43,13 @@ domain:
       -  name: gateway
          dependencies: [ user]
    servers:
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/service/bin/casual-service-manager"
          memberships: [ base]
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/casual-transaction-manager"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/casual-transaction-manager"
          memberships: [ base]
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/queue/bin/casual-queue-manager"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/queue/bin/casual-queue-manager"
          memberships: [ base]
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/gateway/bin/casual-gateway-manager"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/gateway/bin/casual-gateway-manager"
          memberships: [ gateway]
 
 )";
@@ -84,7 +84,7 @@ domain:
 domain: 
    name: domain-B
    servers:
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
          memberships: [ user]
    gateway:
       inbound:
@@ -131,7 +131,7 @@ domain:
 system:
    resources:
       -  key: rm-mockup
-         server: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/rm-proxy-casual-mockup
+         server: ${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/rm-proxy-casual-mockup
          xa_struct_name: casual_mockup_xa_switch_static
          libraries:
             -  casual-mockup-rm
@@ -146,7 +146,7 @@ domain:
             instances: 1
 
    servers:
-      -  path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-resource-server
+      -  path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-resource-server
          memberships: [ user]
 )");
          EXPECT_TRUE( administration::unittest::cli::command::execute( R"(casual transaction --list-transactions --porcelain true)").standard.out.empty());
@@ -217,7 +217,7 @@ domain:
 system:
    resources:
       -  key: rm-mockup
-         server: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/rm-proxy-casual-mockup
+         server: ${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/rm-proxy-casual-mockup
          xa_struct_name: casual_mockup_xa_switch_static
          libraries:
             -  casual-mockup-rm
@@ -231,7 +231,7 @@ domain:
             instances: 1
 
    servers:
-      -  path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-resource-server
+      -  path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-resource-server
          memberships: [ user]
          arguments: [ --nested-calls, casual/example/resource/echo]
          instances: 4
@@ -301,7 +301,7 @@ domain:
 system:
    resources:
       -  key: rm-mockup
-         server: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/rm-proxy-casual-mockup
+         server: ${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/rm-proxy-casual-mockup
          xa_struct_name: casual_mockup_xa_switch_static
 domain: 
    name: domain-A

--- a/middleware/common/unittest/source/test_buffer.cpp
+++ b/middleware/common/unittest/source/test_buffer.cpp
@@ -1,4 +1,4 @@
-//! 
+   //! 
 //! Copyright (c) 2015, The casual project
 //!
 //! This software is licensed under the MIT license, https://opensource.org/licenses/MIT

--- a/middleware/common/unittest/source/test_process.cpp
+++ b/middleware/common/unittest/source/test_process.cpp
@@ -7,6 +7,8 @@
 
 #include "common/unittest.h"
 
+#include "common/unittest/environment.h"
+
 #include "common/process.h"
 
 #include "common/code/signal.h"
@@ -22,11 +24,21 @@ namespace casual
       {
          namespace
          {
+            namespace build
+            {
+               auto root()
+               {
+                  if( auto value = environment::variable::get< std::filesystem::path>( "CASUAL_MAKE_BUILD_ROOT"))
+                     return *value;
+
+                  code::raise::error( code::casual::invalid_argument, "CASUAL_MAKE_BUILD_ROOTs has to be set");
+               }
+            } // build
             namespace process
             {
                auto path()
                {
-                  return std::filesystem::path{ "./bin/simple_process"};
+                  return build::root() / "middleware/common/bin/simple_process";
                }
             } // process
 

--- a/middleware/domain/unittest/source/manager.cpp
+++ b/middleware/domain/unittest/source/manager.cpp
@@ -69,16 +69,16 @@ namespace casual
 
             } // configuration
 
-            namespace repository
+            namespace build
             {
                auto root()
                {
-                  if( auto value = environment::variable::get< std::filesystem::path>( "CASUAL_MAKE_SOURCE_ROOT"))
+                  if( auto value = environment::variable::get< std::filesystem::path>( "CASUAL_MAKE_BUILD_ROOT"))
                      return *value;
 
-                  code::raise::error( code::casual::invalid_argument, "CASUAL_MAKE_SOURCE_ROOT has to be set");
+                  code::raise::error( code::casual::invalid_argument, "CASUAL_MAKE_BUILD_ROOTs has to be set");
                }
-            } // repository
+            } // build
             
             namespace instance::devices
             {
@@ -319,7 +319,7 @@ namespace casual
 
             // spawn the domain-manager
             manager = local::Manager{ 
-               local::repository::root() / "middleware/domain/bin/casual-domain-manager",
+               local::build::root() / "middleware/domain/bin/casual-domain-manager",
                local::configuration::arguments( files, tasks.front())};
 
             common::message::dispatch::relaxed::pump( 

--- a/middleware/domain/unittest/source/manager/test_api.cpp
+++ b/middleware/domain/unittest/source/manager/test_api.cpp
@@ -56,7 +56,7 @@ namespace casual
 domain:
   name: simple-server
   servers:
-    - path: ./bin/test-simple-server
+    - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/domain/bin/test-simple-server
       instances: 1
 
 )";

--- a/middleware/domain/unittest/source/manager/test_manager.cpp
+++ b/middleware/domain/unittest/source/manager/test_manager.cpp
@@ -397,7 +397,7 @@ domain:
 domain:
    name: simple-server
    servers:
-      -  path: ./bin/test-simple-server
+      -  path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/domain/bin/test-simple-server
          instances: 1
 
 )";
@@ -445,7 +445,7 @@ domain:
 domain:
    name: simple-server
    servers:
-      -  path: ./bin/test-simple-server
+      -  path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/domain/bin/test-simple-server
          alias: foo
          instances: 1
 )";
@@ -470,7 +470,7 @@ domain:
 domain:
    name: simple-server
    servers:
-      -  path: ./bin/test-simple-server
+      -  path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/domain/bin/test-simple-server
          alias: foo
          instances: 10
 )";
@@ -503,7 +503,7 @@ domain:
 domain:
    name: simple-server
    servers:
-      -  path: ./bin/test-simple-server
+      -  path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/domain/bin/test-simple-server
          instances: 1
          environment:
             variables: 
@@ -538,7 +538,7 @@ domain:
 domain:
    name: simple-server
    servers:
-      -  path: ./bin/test-simple-server
+      -  path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/domain/bin/test-simple-server
          instances: 1
 )";
 
@@ -581,7 +581,7 @@ domain:
 domain:
    name: simple-server
    servers:
-      -  path: ./bin/test-simple-server
+      -  path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/domain/bin/test-simple-server
          instances: 1
 )";
 
@@ -626,7 +626,7 @@ domain:
 domain:
    name: simple-server
    servers:
-      -  path: ./bin/test-simple-server
+      -  path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/domain/bin/test-simple-server
          alias: foo
          instances: 1
 )";
@@ -673,7 +673,7 @@ domain:
 domain:
    name: simple-server
    servers:
-      -  path: ./bin/test-simple-server
+      -  path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/domain/bin/test-simple-server
          alias: foo
          instances: 1
 )";
@@ -714,7 +714,7 @@ domain:
    name: simple-server
    servers:
       -  alias: foo
-         path: ./bin/test-simple-server
+         path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/domain/bin/test-simple-server
          instances: 2
 )";
 
@@ -1018,7 +1018,7 @@ domain:
 domain:
    name: simple-server
    servers:
-      -  path: ./bin/test-simple-server
+      -  path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/domain/bin/test-simple-server
          alias: foo
          instances: 2
 
@@ -1056,7 +1056,7 @@ domain:
          dependencies: [ B]
 
    servers:
-      -  path: ./bin/test-simple-server
+      -  path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/domain/bin/test-simple-server
          alias: foo
          instances: 2
          memberships: [ A]
@@ -1108,7 +1108,7 @@ domain:
          dependencies: [ B]
 
    servers:
-      -  path: ./bin/test-simple-server
+      -  path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/domain/bin/test-simple-server
          alias: simple-server
          instances: 2
          memberships: [ A]
@@ -1162,7 +1162,7 @@ domain:
          dependencies: [ B]
 
    servers:
-      -  path: ./bin/test-simple-server
+      -  path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/domain/bin/test-simple-server
          alias: simple-server
          instances: 2
          memberships: [ A]
@@ -1212,7 +1212,7 @@ domain:
          dependencies: [ B]
 
    servers:
-      -  path: ./bin/test-simple-server
+      -  path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/domain/bin/test-simple-server
          alias: simple-server
          instances: 2
          memberships: [ A]
@@ -1263,7 +1263,7 @@ domain:
          dependencies: [ B]
 
    servers:
-      -  path: ./bin/test-simple-server
+      -  path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/domain/bin/test-simple-server
          alias: simple-server
          instances: 2
          memberships: [ A]
@@ -1340,7 +1340,7 @@ domain:
       -  name: A
 
    servers:
-      -  path: ./bin/test-simple-server
+      -  path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/domain/bin/test-simple-server
          alias: simple-server
          instances: 2
          memberships: [ A]
@@ -1368,11 +1368,11 @@ domain:
          dependencies: [ B]
 
    servers:
-      -  path: ./bin/test-simple-server
+      -  path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/domain/bin/test-simple-server
          alias: simple-server
          instances: 1
          memberships: [ X]
-      -  path: ./bin/test-simple-server
+      -  path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/domain/bin/test-simple-server
          alias: simple-server-added
          instances: 1
          memberships: [ X]
@@ -1409,7 +1409,7 @@ domain:
    groups:
       -  name: A
    servers:
-      -  path: ./bin/test-simple-server
+      -  path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/domain/bin/test-simple-server
          alias: simple-server
          instances: 2
          memberships: [ A]
@@ -1431,7 +1431,7 @@ domain:
       -  name: B
          dependencies: [ A]
    servers:
-      -  path: ./bin/test-simple-server
+      -  path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/domain/bin/test-simple-server
          alias: replaced-server
          instances: 3
          memberships: [ B]
@@ -1767,7 +1767,7 @@ domain:
          instances: 1
          restart: true
    servers:
-      -  path: ./bin/test-simple-server
+      -  path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/domain/bin/test-simple-server
          alias: simple-server
          instances: 1
          restart: true

--- a/middleware/event/unittest/source/service/test_log.cpp
+++ b/middleware/event/unittest/source/service/test_log.cpp
@@ -37,7 +37,7 @@ domain:
       - name: second
         dependencies: [ first]
    servers:
-      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/service/bin/casual-service-manager
         memberships: [ first]        
 )";
             } // configuration
@@ -67,7 +67,7 @@ domain:
          auto domain = domain::unittest::manager( local::configuration::base, R"(
 domain:
    executables:
-      - path: bin/casual-event-service-log
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/event/bin/casual-event-service-log
         arguments: [ --file, "${SERVICE_LOG_FILE}"]
         memberships: [ second]
 )");
@@ -114,7 +114,7 @@ domain:
          auto domain = domain::unittest::manager( local::configuration::base, R"(
 domain:
    executables:
-      - path: bin/casual-event-service-log
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/event/bin/casual-event-service-log
         arguments: [ --file, "${SERVICE_LOG_FILE}"]
         memberships: [ second]   
 )");
@@ -181,7 +181,7 @@ domain:
          auto domain = domain::unittest::manager( local::configuration::base, R"(
 domain:
    executables:
-      - path: bin/casual-event-service-log
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/event/bin/casual-event-service-log
         arguments: [ --file, "${SERVICE_LOG_FILE}", --filter-exclusive, '^[.].*$']
         memberships: [ second]
 )");
@@ -210,7 +210,7 @@ domain:
          auto domain = domain::unittest::manager( local::configuration::base, R"(
 domain:
    executables:
-      - path: bin/casual-event-service-log
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/event/bin/casual-event-service-log
         arguments: [ --file, "${SERVICE_LOG_FILE}", --filter-inclusive, '^[.].*$']
         memberships: [ second]   
 )");
@@ -235,7 +235,7 @@ domain:
          auto domain = domain::unittest::manager( local::configuration::base, R"(
 domain:
    executables:
-      - path: bin/casual-event-service-log
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/event/bin/casual-event-service-log
         arguments: [ --file, "${SERVICE_LOG_FILE}", --filter-inclusive, '.*state', --filter-exclusive, ".*foo.*"]
         memberships: [ second]
 )");
@@ -261,11 +261,11 @@ domain:
 domain:
    name: A
    servers:
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
         memberships: [ second]
         arguments: [ --forward, casual/example/echo]
         instances: 2
-      - path: bin/casual-event-service-log
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/event/bin/casual-event-service-log
         arguments: [ --file, "${SERVICE_LOG_FILE}"]
         memberships: [ second]
 )");

--- a/middleware/event/unittest/source/test_dispatch.cpp
+++ b/middleware/event/unittest/source/test_dispatch.cpp
@@ -33,7 +33,7 @@ domain:
    name: service-domain
 
    servers:
-      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/service/bin/casual-service-manager
 )";
 
 

--- a/middleware/example/makefile.cmk
+++ b/middleware/example/makefile.cmk
@@ -1,4 +1,5 @@
 import casual.make.api as make
+from casual.make.platform.common import use_build_directory
 import casual.middleware.make.api as dsl
 import os
 
@@ -12,26 +13,27 @@ make.IncludePaths( ['server/include',
     )
 
 
-library_paths = [ 'server/bin',
-    '../common/bin',
-    '../buffer/bin',
-    '../configuration/bin',
-    '../domain/bin',
-    '../gateway/bin',
-    '../service/bin',
-    '../serviceframework/bin',
-    '../xatmi/bin'] + make.optional_library_paths() + dsl.paths().library.gtest
+library_paths = [ make.build_root() + '/server/bin',
+    make.build_root() + '/middleware/common/bin',
+    make.build_root() + '/middleware/buffer/bin',
+    make.build_root() + '/middleware/configuration/bin',
+    make.build_root() + '/middleware/domain/bin',
+    make.build_root() + '/middleware/gateway/bin',
+    make.build_root() + '/middleware/service/bin',
+    make.build_root() + '/middleware/serviceframework/bin',
+    make.build_root() + '/middleware/xatmi/bin'] + make.optional_library_paths() + dsl.paths().library.gtest
 
 
 make.LibraryPaths( library_paths)
 
 install_bin = []
 
-casual_middleware_path = make.source_root() + '/middleware'
+casual_middleware_build_path = make.build_root() + '/middleware'
+casual_middleware_source_path = make.source_root() + '/middleware'
 
 
 # make sure we use the tools we've built
-make.Environment( 'PATH', casual_middleware_path + '/tools/bin' + os.pathsep + os.getenv('PATH'))
+make.Environment( 'PATH', use_build_directory( casual_middleware_build_path) + '/tools/bin' + os.pathsep + os.getenv('PATH'))
 make.Environment( 'LD_LIBRARY_PATH', os.pathsep.join( library_paths) + os.pathsep + os.getenv('LD_LIBRARY_PATH', ''))
 
 target = dsl.LinkServer( 'server/bin/casual-example-server',
@@ -48,7 +50,7 @@ target = dsl.LinkServer( 'server/bin/casual-example-server',
 install_bin.append( target)
 
 # make sure we got a resource property file available when we build with a resource 
-make.Environment( 'CASUAL_RESOURCE_CONFIGURATION_FILE', casual_middleware_path + '/example/resources/resources.yaml')
+make.Environment( 'CASUAL_RESOURCE_CONFIGURATION_FILE', casual_middleware_source_path + '/example/resources/resources.yaml')
 
 resource_objects = [ make.Compile( 'server/source/example/resource.cpp')]
 

--- a/middleware/example/server/unittest/source/test_example.cpp
+++ b/middleware/example/server/unittest/source/test_example.cpp
@@ -25,7 +25,7 @@ namespace casual
 system:
    resources:
       -  key: rm-mockup
-         server: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/rm-proxy-casual-mockup"
+         server: "${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/rm-proxy-casual-mockup"
          xa_struct_name: casual_mockup_xa_switch_static
          libraries:
             -  casual-mockup-rm
@@ -41,13 +41,13 @@ domain:
          dependencies: [ user]
    
    servers:
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/service/bin/casual-service-manager"
         memberships: [ base]
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/casual-transaction-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/casual-transaction-manager"
         memberships: [ base]
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/gateway/bin/casual-gateway-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/gateway/bin/casual-gateway-manager"
         memberships: [ gateway]
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
         memberships: [ user]
         arguments: [ --work, 10ms]
 )";

--- a/middleware/file/unittest/source/resource/test_resource.cpp
+++ b/middleware/file/unittest/source/resource/test_resource.cpp
@@ -42,11 +42,11 @@ domain:
         dependencies: [ base]
 
    servers:
-      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/service/bin/casual-service-manager
         memberships: [ base]
-      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/casual-transaction-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/casual-transaction-manager
         memberships: [ base]
-      - path: bin/casual-file-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/file/bin/casual-file-manager
         memberships: [ file]
 )";
 

--- a/middleware/gateway/unittest/source/protocol/1.0/test_manager.cpp
+++ b/middleware/gateway/unittest/source/protocol/1.0/test_manager.cpp
@@ -45,9 +45,9 @@ domain:
         dependencies: [ user]
    
    servers:
-      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/service/bin/casual-service-manager
         memberships: [ base]
-      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/casual-transaction-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/casual-transaction-manager
         memberships: [ base]
 )";
      
@@ -76,7 +76,7 @@ domain:
 domain:
    name: A
    servers:
-      - path: bin/casual-gateway-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/gateway/bin/casual-gateway-manager
         memberships: [ gateway]
    gateway:
       reverse:
@@ -162,7 +162,7 @@ domain:
 domain:
    name: A
    servers:
-      - path: bin/casual-gateway-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/gateway/bin/casual-gateway-manager
         memberships: [ gateway]
    gateway:
       inbound:

--- a/middleware/gateway/unittest/source/protocol/1.2/test_manager.cpp
+++ b/middleware/gateway/unittest/source/protocol/1.2/test_manager.cpp
@@ -45,9 +45,9 @@ domain:
         dependencies: [ user]
    
    servers:
-      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/service/bin/casual-service-manager
         memberships: [ base]
-      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/casual-transaction-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/casual-transaction-manager
         memberships: [ base]
 )";
      
@@ -70,7 +70,7 @@ domain:
 domain: 
    name: B
    servers:
-      -  path: bin/casual-gateway-manager
+      -  path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/gateway/bin/casual-gateway-manager
          memberships: [ gateway]
          environment:
             variables:
@@ -88,7 +88,7 @@ domain:
 domain: 
    name: A
    servers:
-      - path: bin/casual-gateway-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/gateway/bin/casual-gateway-manager
         memberships: [ gateway]
    gateway:
       outbound:
@@ -114,14 +114,14 @@ domain:
 domain: 
    name: B
    servers:
-      -  path: bin/casual-gateway-manager
+      -  path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/gateway/bin/casual-gateway-manager
          memberships: [ gateway]
          environment:
             variables:
                -  key: CASUAL_INTERNAL_GATEWAY_PROTOCOL_VERSION
                   value: 1002
 
-      -  path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/queue/bin/casual-queue-manager
+      -  path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/queue/bin/casual-queue-manager
          memberships: [ base]
    queue:
       groups:
@@ -140,9 +140,9 @@ domain:
 domain: 
    name: A
    servers:
-      - path: bin/casual-gateway-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/gateway/bin/casual-gateway-manager
         memberships: [ gateway]
-      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/queue/bin/casual-queue-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/queue/bin/casual-queue-manager
         memberships: [ base]
    gateway:
       outbound:
@@ -174,9 +174,9 @@ domain:
 domain: 
    name: B
    servers:
-      - path: bin/casual-gateway-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/gateway/bin/casual-gateway-manager
         memberships: [ gateway]
-      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/queue/bin/casual-queue-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/queue/bin/casual-queue-manager
         memberships: [ base]
    queue:
       groups:
@@ -195,14 +195,14 @@ domain:
 domain: 
    name: A
    servers:
-      -  path: bin/casual-gateway-manager
+      -  path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/gateway/bin/casual-gateway-manager
          memberships: [ gateway]
          environment:
             variables:
                -  key: CASUAL_INTERNAL_GATEWAY_PROTOCOL_VERSION
                   value: 1002
 
-      -  path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/queue/bin/casual-queue-manager
+      -  path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/queue/bin/casual-queue-manager
          memberships: [ base]
    gateway:
       outbound:
@@ -234,9 +234,9 @@ domain:
 domain:
    name: B
    servers:
-      - path: bin/casual-gateway-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/gateway/bin/casual-gateway-manager
         memberships: [ gateway]
-      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server
         memberships: [ user]
    gateway:
       inbound:
@@ -270,9 +270,9 @@ domain:
 domain:
    name: B
    servers:
-      - path: bin/casual-gateway-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/gateway/bin/casual-gateway-manager
         memberships: [ gateway]
-      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server
         memberships: [ user]
    gateway:
       inbound:
@@ -316,9 +316,9 @@ domain:
 domain:
    name: B
    servers:
-      - path: bin/casual-gateway-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/gateway/bin/casual-gateway-manager
         memberships: [ gateway]
-      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server
         memberships: [ user]
    gateway:
       inbound:
@@ -358,9 +358,9 @@ domain:
 domain:
    name: B
    servers:
-      - path: bin/casual-gateway-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/gateway/bin/casual-gateway-manager
         memberships: [ gateway]
-      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server
         memberships: [ user]
    gateway:
       inbound:

--- a/middleware/gateway/unittest/source/protocol/1.4/test_manager.cpp
+++ b/middleware/gateway/unittest/source/protocol/1.4/test_manager.cpp
@@ -41,9 +41,9 @@ domain:
         dependencies: [ user]
    
    servers:
-      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/service/bin/casual-service-manager
         memberships: [ base]
-      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/casual-transaction-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/casual-transaction-manager
         memberships: [ base]
 )";
      
@@ -67,9 +67,9 @@ domain:
 domain:
    name: B
    servers:
-      - path: bin/casual-gateway-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/gateway/bin/casual-gateway-manager
         memberships: [ gateway]
-      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server
         memberships: [ user]
    gateway:
       inbound:
@@ -108,7 +108,7 @@ domain:
 domain:
    name: B
    servers:
-      - path: bin/casual-gateway-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/gateway/bin/casual-gateway-manager
         memberships: [ gateway]
    gateway:
       inbound:

--- a/middleware/gateway/unittest/source/test_manager.cpp
+++ b/middleware/gateway/unittest/source/test_manager.cpp
@@ -64,11 +64,11 @@ domain:
         dependencies: [ user]
    
    servers:
-      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/service/bin/casual-service-manager
         memberships: [ base]
-      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/casual-transaction-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/casual-transaction-manager
         memberships: [ base]
-      - path: bin/casual-gateway-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/gateway/bin/casual-gateway-manager
         memberships: [ gateway]
 )";
 
@@ -694,7 +694,7 @@ domain:
          constexpr auto queue_manager = R"(
 domain: 
    servers:
-      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/queue/bin/casual-queue-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/queue/bin/casual-queue-manager
         memberships: [ base]
 )";
          constexpr auto queue_configuration = R"(
@@ -739,7 +739,7 @@ domain:
          constexpr auto queue_manager = R"(
 domain:
    servers:
-      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/queue/bin/casual-queue-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/queue/bin/casual-queue-manager
         memberships: [ base]
         restart: true
 )";
@@ -1555,7 +1555,7 @@ domain:
          dependencies: [ base]
    
    servers:
-      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server
         memberships: [ user]
 
    gateway:
@@ -1613,7 +1613,7 @@ domain:
 system:
    resources:
       -  key: rm-mockup
-         server: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/rm-proxy-casual-mockup"
+         server: "${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/rm-proxy-casual-mockup"
          xa_struct_name: casual_mockup_xa_switch_static
          libraries:
             -  casual-mockup-rm
@@ -1628,7 +1628,7 @@ domain:
             key: rm-mockup
             instances: 1
    servers:
-   -  path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-resource-server
+   -  path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-resource-server
       arguments: [ --nested-calls, x ]
       memberships: [ user]
    gateway:
@@ -1652,7 +1652,7 @@ domain:
             instances: 1
    servers:
       -  alias: a-forward
-         path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-resource-server
+         path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-resource-server
          arguments: [ --nested-calls, casual/example/resource/nested/calls/B, casual/example/resource/nested/calls/B]
          memberships: [ user]
    gateway:
@@ -1742,7 +1742,7 @@ domain:
 system:
    resources:
       -  key: rm-mockup
-         server: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/rm-proxy-casual-mockup"
+         server: "${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/rm-proxy-casual-mockup"
          xa_struct_name: casual_mockup_xa_switch_static
          libraries:
             -  casual-mockup-rm
@@ -1754,7 +1754,7 @@ domain:
             key: rm-mockup
             instances: 1
    servers:
-      -  path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-resource-server
+      -  path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-resource-server
          arguments: [ --nested-calls, x]
          memberships: [ user]
    gateway:
@@ -1830,7 +1830,7 @@ domain:
 domain:
    name: A
    servers:
-      -  path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server
+      -  path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server
          arguments: [ --forward, b]
          memberships: [ user]
    gateway:

--- a/middleware/gateway/unittest/source/test_reverse.cpp
+++ b/middleware/gateway/unittest/source/test_reverse.cpp
@@ -41,11 +41,11 @@ domain:
         dependencies: [ base]
    
    servers:
-      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/service/bin/casual-service-manager
         memberships: [ base]
-      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/casual-transaction-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/casual-transaction-manager
         memberships: [ base]
-      - path: bin/casual-gateway-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/gateway/bin/casual-gateway-manager
         memberships: [ gateway]
 )";
 

--- a/middleware/http/source/inbound/nginx/plugin/config
+++ b/middleware/http/source/inbound/nginx/plugin/config
@@ -2,7 +2,7 @@ ngx_module_name=ngx_http_casual_module
 ngx_module_type=HTTP
 ngx_module_srcs="$ngx_addon_dir/$ngx_module_name.c"
 ngx_module_incs="$ngx_addon_dir $CASUAL_MAKE_SOURCE_ROOT/middleware/http/include"
-ngx_module_libs="-L$CASUAL_MAKE_SOURCE_ROOT/middleware/http/bin -lcasual-http-inbound-common" 
+ngx_module_libs="-L$CASUAL_MAKE_BUILD_ROOT/middleware/http/bin -lcasual-http-inbound-common" 
 
 platform=`uname`
 
@@ -10,9 +10,9 @@ echo "Building nginx on platform = $platform"
 
 if [[ "$platform" != "Darwin" ]]; then
     ngx_module_libs="$ngx_module_libs \
-        -Wl,-rpath-link=$CASUAL_MAKE_SOURCE_ROOT/middleware/buffer/bin \
-        -Wl,-rpath-link=$CASUAL_MAKE_SOURCE_ROOT/middleware/xatmi/bin \
-        -Wl,-rpath-link=$CASUAL_MAKE_SOURCE_ROOT/middleware/common/bin"
+        -Wl,-rpath-link=$CASUAL_MAKE_BUILD_ROOT/middleware/buffer/bin \
+        -Wl,-rpath-link=$CASUAL_MAKE_BUILD_ROOT/middleware/xatmi/bin \
+        -Wl,-rpath-link=$CASUAL_MAKE_BUILD_ROOT/middleware/common/bin"
 fi
 
 . auto/module

--- a/middleware/http/source/inbound/nginx/plugin/makefile.cmk
+++ b/middleware/http/source/inbound/nginx/plugin/makefile.cmk
@@ -6,7 +6,7 @@ import subprocess
 import os
 
 def perform_build(dummy):
-   print( "building and installing nginx - source root: ", os.getenv("CASUAL_MAKE_SOURCE_ROOT"))
+   print( f"building and installing nginx - source root: {os.getenv('CASUAL_MAKE_SOURCE_ROOT')}, build root: {os.getenv('CASUAL_MAKE_BUILD_ROOT')}")
    filename = os.path.join( os.getenv("CASUAL_MAKE_SOURCE_ROOT"), 'thirdparty/setup/install_nginx.py')
    try:
       out = subprocess.check_output(["python3", filename])

--- a/middleware/http/unittest/source/inbound/test_call.cpp
+++ b/middleware/http/unittest/source/inbound/test_call.cpp
@@ -35,11 +35,11 @@ domain:
         dependencies: [ base]
    
    servers:
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/service/bin/casual-service-manager"
         memberships: [ base]
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/casual-transaction-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/casual-transaction-manager"
         memberships: [ base]
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
         memberships: [ user]
 )";
                

--- a/middleware/http/unittest/source/test_outbound.cpp
+++ b/middleware/http/unittest/source/test_outbound.cpp
@@ -71,11 +71,11 @@ domain:
          dependencies: [ base]
 
    servers:
-      -  path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager
+      -  path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/service/bin/casual-service-manager
          memberships: [ base]
-      -  path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/casual-transaction-manager
+      -  path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/casual-transaction-manager
          memberships: [ base]
-      -  path: bin/casual-http-outbound
+      -  path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/http/bin/casual-http-outbound
          arguments: [ --configuration, "${CASUAL_UNITTEST_HTTP_CONFIGURATION}"]
          memberships: [ http]
 

--- a/middleware/queue/unittest/source/api/test_c.cpp
+++ b/middleware/queue/unittest/source/api/test_c.cpp
@@ -35,11 +35,11 @@ domain:
         dependencies: [ base]
    
    servers:
-      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/service/bin/casual-service-manager
         memberships: [ base]
-      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/casual-transaction-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/casual-transaction-manager
         memberships: [ base]
-      - path: bin/casual-queue-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/queue/bin/casual-queue-manager
         memberships: [ queue]
 
    queue:

--- a/middleware/queue/unittest/source/test_example.cpp
+++ b/middleware/queue/unittest/source/test_example.cpp
@@ -27,7 +27,7 @@ namespace casual
 system:
    resources:
       -  key: rm-mockup
-         server: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/rm-proxy-casual-mockup"
+         server: "${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/rm-proxy-casual-mockup"
          xa_struct_name: casual_mockup_xa_switch_static
          libraries:
             -  casual-mockup-rm
@@ -52,13 +52,13 @@ domain:
             - name: example.q3
 
    servers:
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/service/bin/casual-service-manager"
         memberships: [ base]
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/casual-transaction-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/casual-transaction-manager"
         memberships: [ base]
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/gateway/bin/casual-gateway-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/gateway/bin/casual-gateway-manager"
         memberships: [ gateway]
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/queue/bin/casual-queue-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/queue/bin/casual-queue-manager"
         memberships: [ queue]
 )";
             } // configuration
@@ -87,7 +87,7 @@ domain:
          constexpr auto example_server = R"(
 domain:
    servers:
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/queue/bin/casual-queue-example-server"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/queue/bin/casual-queue-example-server"
         memberships: [ user]
         arguments: [ --queues, non-existing]
 )";
@@ -108,7 +108,7 @@ domain:
          constexpr auto example_server = R"(
 domain:
    servers:
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/queue/bin/casual-queue-example-server"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/queue/bin/casual-queue-example-server"
         memberships: [ user]
         arguments: [ --queues, example.q1]
 )";
@@ -142,7 +142,7 @@ domain:
          constexpr auto example_server = R"(
 domain:
    servers:
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/queue/bin/casual-queue-example-server"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/queue/bin/casual-queue-example-server"
         memberships: [ user]
         arguments: [ --queues, example.q1]
 )";
@@ -175,7 +175,7 @@ domain:
          constexpr auto example_server = R"(
 domain:
    servers:
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/queue/bin/casual-queue-example-server"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/queue/bin/casual-queue-example-server"
         memberships: [ user]
         arguments: [ --queues, non-existing]
 )";
@@ -194,7 +194,7 @@ domain:
          constexpr auto example_server = R"(
 domain:
    servers:
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/queue/bin/casual-queue-example-server"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/queue/bin/casual-queue-example-server"
         memberships: [ user]
         arguments: [ --queues, example.q1]
 )";
@@ -214,7 +214,7 @@ domain:
          constexpr auto example_server = R"(
 domain:
    servers:
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/queue/bin/casual-queue-example-server"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/queue/bin/casual-queue-example-server"
         memberships: [ user]
         arguments: [ --queues, example.q1]
 )";
@@ -257,7 +257,7 @@ domain:
          constexpr auto example_server = R"(
 domain:
    servers:
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/queue/bin/casual-queue-example-server"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/queue/bin/casual-queue-example-server"
         memberships: [ user]
         arguments: [ --queues, example.q1, example.q2, example.q3]
 )";

--- a/middleware/queue/unittest/source/test_forward.cpp
+++ b/middleware/queue/unittest/source/test_forward.cpp
@@ -53,11 +53,11 @@ domain:
         dependencies: [ base]
 
    servers:
-      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/service/bin/casual-service-manager
         memberships: [ base]
-      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/casual-transaction-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/casual-transaction-manager
         memberships: [ base]
-      - path: bin/casual-queue-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/queue/bin/casual-queue-manager
         memberships: [ queue]
 )";
                

--- a/middleware/queue/unittest/source/test_queue.cpp
+++ b/middleware/queue/unittest/source/test_queue.cpp
@@ -63,11 +63,11 @@ domain:
         dependencies: [ base]
    
    servers:
-      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/service/bin/casual-service-manager
         memberships: [ base]
-      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/casual-transaction-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/casual-transaction-manager
         memberships: [ base]
-      - path: bin/casual-queue-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/queue/bin/casual-queue-manager
         memberships: [ queue]
 )";
 
@@ -876,7 +876,7 @@ domain:
         dependencies: [ queue]
    
    servers:
-      - path: bin/casual-queue-forward-queue
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/queue/bin/casual-queue-forward-queue
         arguments: [ --forward, a3, b3]
         memberships: [ forward]
 )";   

--- a/middleware/service/unittest/source/manager/test_api.cpp
+++ b/middleware/service/unittest/source/manager/test_api.cpp
@@ -49,7 +49,7 @@ domain:
    name: service-domain
 
    servers:
-      - path: bin/casual-service-manager
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/service/bin/casual-service-manager"
 )";
 
                auto manager = casual::domain::unittest::manager( configuration);

--- a/middleware/service/unittest/source/manager/test_manager.cpp
+++ b/middleware/service/unittest/source/manager/test_manager.cpp
@@ -58,7 +58,7 @@ domain:
          dependencies: [ base]
 
    servers:
-      -  path: bin/casual-service-manager
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/service/bin/casual-service-manager"
          memberships: [ base]
 
 )";

--- a/middleware/service/unittest/source/test_forward.cpp
+++ b/middleware/service/unittest/source/test_forward.cpp
@@ -43,7 +43,7 @@ domain:
    name: service-forward-domain
 
    servers:
-      - path: ./bin/casual-service-manager    
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/service/bin/casual-service-manager
 )";
             }
 

--- a/middleware/transaction/makefile.cmk
+++ b/middleware/transaction/makefile.cmk
@@ -95,7 +95,7 @@ install_headers.append( ( 'include/casual/transaction/resource/proxy/server.h', 
 
 
 # Mockup resource proxy
-target = make.LinkExecutable( 'bin/rm-proxy-casual-mockup',
+rm_mockup_target = make.LinkExecutable( 'bin/rm-proxy-casual-mockup',
     [ make.Compile( 'source/resource/template_build_resource_proxy.cpp')],
     [ 
         'casual-mockup-rm', 
@@ -103,7 +103,7 @@ target = make.LinkExecutable( 'bin/rm-proxy-casual-mockup',
     ])
 
 
-install_bin.append( target)
+install_bin.append( rm_mockup_target)
 
 unittest_library = make.LinkLibrary( 'bin/casual-transaction-unittest',
     [ 
@@ -141,7 +141,7 @@ test_transaction = make.LinkUnittest( 'bin/test-casual-transaction',
     ])
 
 # make sure we link manager before we run tests 
-make.Dependencies( test_transaction, [ manager])
+make.Dependencies( test_transaction, [ manager, rm_mockup_target])
 
 
 

--- a/middleware/transaction/unittest/source/test_manager.cpp
+++ b/middleware/transaction/unittest/source/test_manager.cpp
@@ -61,7 +61,7 @@ namespace casual
 system:
    resources:
       -  key: rm-mockup
-         server: bin/rm-proxy-casual-mockup
+         server: ${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/rm-proxy-casual-mockup
          xa_struct_name: casual_mockup_xa_switch_static
          libraries:
             -  casual-mockup-rm
@@ -75,9 +75,9 @@ domain:
         dependencies: [ first]
 
    servers:
-      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/service/bin/casual-service-manager
         memberships: [ first]
-      - path: bin/casual-transaction-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/casual-transaction-manager
         memberships: [ second]
          
 )";

--- a/pipeline/script/backend/common/build
+++ b/pipeline/script/backend/common/build
@@ -3,8 +3,8 @@
 set -e
 
 cd $REPOSITORY_ROOT && \
-    casual-make --stat --quiet --no-colors compile && \
-    casual-make --stat --no-colors link && \
-    casual-make --no-colors test --gtest_color=no --gtest_output='xml:report.xml' && \
-    casual-make --no-colors install && \
-    casual-make nginx
+    casual-make --build-root /tmp/build --stat --quiet --no-colors compile && \
+    casual-make --build-root /tmp/build --stat --no-colors link && \
+    casual-make --build-root /tmp/build --no-colors test --gtest_color=no --gtest_output='xml:report.xml' && \
+    casual-make --build-root /tmp/build --no-colors install && \
+    casual-make --build-root /tmp/build nginx

--- a/test/unittest/source/gateway/test_discovery.cpp
+++ b/test/unittest/source/gateway/test_discovery.cpp
@@ -80,13 +80,13 @@ domain:
         dependencies: [ queue]
    
    servers:
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/service/bin/casual-service-manager"
         memberships: [ base]
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/casual-transaction-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/casual-transaction-manager"
         memberships: [ base]
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/queue/bin/casual-queue-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/queue/bin/casual-queue-manager"
         memberships: [ queue]
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/gateway/bin/casual-gateway-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/gateway/bin/casual-gateway-manager"
         memberships: [ gateway]
 )";
 
@@ -104,7 +104,7 @@ domain:
    name: C
 
    servers:
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
         memberships: [ user]
    gateway:
       inbound:
@@ -162,7 +162,7 @@ domain:
    name: C
 
    servers:
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
         memberships: [ user]
    gateway:
       inbound:
@@ -175,7 +175,7 @@ domain:
 domain: 
    name: B
    servers:
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
         memberships: [ user]
    gateway:
       outbound:
@@ -200,7 +200,7 @@ domain:
 domain: 
    name: A
    servers:
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
         memberships: [ user]
    gateway:
       outbound:
@@ -261,7 +261,7 @@ domain:
    name: C
 
    servers:
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
         memberships: [ user]
    gateway:
       inbound:
@@ -322,7 +322,7 @@ domain:
 domain: 
    name: C
    servers:
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
          memberships: [ user]
 
    services:
@@ -387,7 +387,7 @@ domain:
    name: C
 
    servers:
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
         memberships: [ user]
    gateway:
       inbound:
@@ -401,7 +401,7 @@ domain:
    name: B
 
    servers:
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
         memberships: [ user]
    gateway:
       inbound:
@@ -484,7 +484,7 @@ domain:
 domain: 
    name: C      
    servers:
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
         memberships: [ user]
    services:
       -  name: casual/example/domain/echo/C
@@ -500,7 +500,7 @@ domain:
 domain: 
    name: B
    servers:
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
         memberships: [ user]
    gateway:
       inbound:
@@ -564,7 +564,7 @@ domain:
 domain: 
    name: C
    servers:
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
         memberships: [ user]
    gateway:
       inbound:
@@ -633,7 +633,7 @@ domain:
 domain: 
    name: B
    servers:
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
         memberships: [ user]
    gateway:
       inbound:

--- a/test/unittest/source/gateway/test_reverse.cpp
+++ b/test/unittest/source/gateway/test_reverse.cpp
@@ -50,13 +50,13 @@ domain:
         dependencies: [ user]
    
    servers:
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/service/bin/casual-service-manager"
         memberships: [ base]
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/casual-transaction-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/casual-transaction-manager"
         memberships: [ base]
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/gateway/bin/casual-gateway-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/gateway/bin/casual-gateway-manager"
         memberships: [ gateway]
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
         memberships: [ user]
    gateway:
       reverse:
@@ -76,11 +76,11 @@ domain:
         dependencies: [ base]
    
    servers:
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/service/bin/casual-service-manager"
         memberships: [ base]
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/casual-transaction-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/casual-transaction-manager"
         memberships: [ base]
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/gateway/bin/casual-gateway-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/gateway/bin/casual-gateway-manager"
         memberships: [ gateway]
    gateway:
       reverse:

--- a/test/unittest/source/test_assassinate.cpp
+++ b/test/unittest/source/test_assassinate.cpp
@@ -43,11 +43,11 @@ domain:
             duration: 2ms
             contract: kill
    servers:
-      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/service/bin/casual-service-manager
         memberships: [ base]
-      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/casual-transaction-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/casual-transaction-manager
         memberships: [ base]
-      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server
         memberships: [ user]
         arguments: [ --sleep, 1s]
 )";
@@ -88,11 +88,11 @@ domain:
         dependencies: [ base]
 
    servers:
-      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/service/bin/casual-service-manager
         memberships: [ base]
-      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/casual-transaction-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/casual-transaction-manager
         memberships: [ base]
-      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server
         memberships: [ user]
         arguments: [ --sleep, 1s]
 )";

--- a/test/unittest/source/test_configuration.cpp
+++ b/test/unittest/source/test_configuration.cpp
@@ -28,13 +28,13 @@ namespace casual
                constexpr auto servers = R"(
 domain:
    servers:
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/service/bin/casual-service-manager"
         memberships: [ .casual.master]
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/casual-transaction-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/casual-transaction-manager"
         memberships: [ .casual.transaction]
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/queue/bin/casual-queue-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/queue/bin/casual-queue-manager"
         memberships: [ .casual.queue]
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/gateway/bin/casual-gateway-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/gateway/bin/casual-gateway-manager"
         memberships: [ .casual.gateway]
 )";
 
@@ -43,7 +43,7 @@ domain:
 system:
    resources:
       -  key: rm-mockup
-         server: bin/rm-proxy-casual-mockup
+         server: ${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/rm-proxy-casual-mockup
          xa_struct_name: casual_mockup_xa_switch_static
          libraries:
             - casual-mockup-rm
@@ -123,7 +123,7 @@ domain:
          dependencies: [ A]
 
    servers:
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
          alias: example-server
          memberships: [ B]
          note: x

--- a/test/unittest/source/test_domain.cpp
+++ b/test/unittest/source/test_domain.cpp
@@ -41,9 +41,9 @@ domain:
          dependencies: [ user]
    
    servers:
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/service/bin/casual-service-manager"
         memberships: [ base]
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/casual-transaction-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/casual-transaction-manager"
         memberships: [ base]
 )";
 
@@ -70,7 +70,7 @@ domain:
 domain:
    servers:
       -  alias: example
-         path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+         path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
          memberships: [ user]
          instances: 4
 )");
@@ -94,7 +94,7 @@ domain:
          auto domain = casual::domain::unittest::manager( local::configuration::base, R"(
 domain:
    servers:
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/queue/bin/casual-queue-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/queue/bin/casual-queue-manager"
         memberships: [ base]
         restart: true
 )");

--- a/test/unittest/source/test_gateway.cpp
+++ b/test/unittest/source/test_gateway.cpp
@@ -56,7 +56,7 @@ namespace casual
 system:
    resources:
       -  key: rm-mockup
-         server: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/rm-proxy-casual-mockup"
+         server: "${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/rm-proxy-casual-mockup"
          xa_struct_name: casual_mockup_xa_switch_static
          libraries:
             -  casual-mockup-rm
@@ -79,11 +79,11 @@ domain:
          dependencies: [ user]
    
    servers:
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/service/bin/casual-service-manager"
         memberships: [ base]
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/casual-transaction-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/casual-transaction-manager"
         memberships: [ base]
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/gateway/bin/casual-gateway-manager"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/gateway/bin/casual-gateway-manager"
         memberships: [ gateway]
 )";
                
@@ -191,7 +191,7 @@ domain:
    name: NAME
 
    servers:
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
         memberships: [ user]
         arguments: [ --sleep, 10ms]
    gateway:
@@ -220,7 +220,7 @@ domain:
    name: NAME
 
    servers:
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
         memberships: [ user]
         arguments: [ --sleep, 10ms]
    gateway:
@@ -298,7 +298,7 @@ domain:
    name: A
 
    servers:
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
         memberships: [ user]
    gateway:
       inbound:
@@ -312,7 +312,7 @@ domain:
    name: B
 
    servers:
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/queue/bin/casual-queue-manager"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/queue/bin/casual-queue-manager"
          memberships: [ queue]
       
    queue:
@@ -379,7 +379,7 @@ domain:
 domain: 
    name: B
    servers:
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
         memberships: [ user]
    gateway:
       inbound:
@@ -444,7 +444,7 @@ domain:
 domain: 
    name: B
    servers:
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
         memberships: [ user]
    services:
       -  name: casual/example/domain/echo/C
@@ -1136,7 +1136,7 @@ domain:
    name: B
 
    servers:
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
          memberships: [ user]
          arguments: [ --sleep, 100ms]
          instances: 5
@@ -1206,7 +1206,7 @@ domain:
    name: B
 
    servers:
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
          memberships: [ user]
          arguments: [ --sleep, 100ms]
          instances: 5
@@ -1276,7 +1276,7 @@ domain:
    name: B
 
    servers:
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
          memberships: [ user]
          arguments: [ --sleep, 100ms]
          instances: 5
@@ -1346,7 +1346,7 @@ domain:
 domain: 
    name: B
    servers:
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
          memberships: [ user]
          arguments: [ --sleep, 10ms]
          instances: 1
@@ -1724,7 +1724,7 @@ domain:
    name: B
 
    servers:
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
          memberships: [ user]
 
    gateway:
@@ -1795,7 +1795,7 @@ domain:
    name: B
 
    servers:
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
          memberships: [ user]
 
    services:
@@ -1848,7 +1848,7 @@ domain:
    name: B
 
    servers:
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
          memberships: [ user]
 
    gateway:
@@ -1919,7 +1919,7 @@ domain:
    name: B
 
    servers:
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
          memberships: [ user]
 
    gateway:
@@ -1975,7 +1975,7 @@ domain:
 domain:
    name: A
    servers:
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-resource-server"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-resource-server"
         memberships: [ user]
    gateway:
       inbound:
@@ -1989,7 +1989,7 @@ domain:
 domain: 
    name: B
    servers:
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-resource-server"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-resource-server"
          memberships: [ user]
    gateway:
       inbound:
@@ -2117,7 +2117,7 @@ domain:
 domain:
    name: A
    servers:
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-resource-server"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-resource-server"
          memberships: [ user]
          arguments: [ --nested-calls, casual/example/resource/domain/echo/B, casual/example/resource/domain/echo/C, casual/example/resource/domain/echo/X]
          instances: 4
@@ -2138,7 +2138,7 @@ domain:
    name: B
 
    servers:
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-resource-server"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-resource-server"
          memberships: [ user]
          arguments: [ --nested-calls, casual/example/resource/domain/echo/A, casual/example/resource/domain/echo/C, casual/example/resource/domain/echo/X]
          instances: 4
@@ -2159,7 +2159,7 @@ domain:
    name: C
 
    servers:
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-resource-server"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-resource-server"
          memberships: [ user]
          arguments: [ --nested-calls, casual/example/resource/nested/calls/A, casual/example/resource/nested/calls/B, casual/example/resource/domain/echo/X]
          instances: 4
@@ -2201,7 +2201,7 @@ domain:
 domain: 
    name: X
    servers:
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-resource-server"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-resource-server"
          memberships: [ user]
          instances: 3
    gateway:
@@ -2352,7 +2352,7 @@ domain:
 domain:
    name: A
    servers:
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-resource-server"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-resource-server"
          memberships: [ user]
          arguments: [ --nested-calls, casual/example/resource/domain/echo/B, casual/example/resource/domain/echo/C, casual/example/resource/domain/echo/X]
          instances: 4
@@ -2374,7 +2374,7 @@ domain:
    name: B
 
    servers:
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-resource-server"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-resource-server"
          memberships: [ user]
          arguments: [ --nested-calls, casual/example/resource/domain/echo/A, casual/example/resource/domain/echo/C, casual/example/resource/domain/echo/X]
          instances: 4
@@ -2396,7 +2396,7 @@ domain:
    name: C
 
    servers:
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-resource-server"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-resource-server"
          memberships: [ user]
          arguments: [ --nested-calls, casual/example/resource/nested/calls/A, casual/example/resource/nested/calls/B, casual/example/resource/domain/echo/X]
          instances: 4
@@ -2438,7 +2438,7 @@ domain:
 domain: 
    name: X
    servers:
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-resource-server"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-resource-server"
          memberships: [ user]
          instances: 3
    gateway:
@@ -2584,7 +2584,7 @@ domain:
             openinfo: --prepare -3
             instances: 1
    servers:
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-resource-server"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-resource-server"
          memberships: [ user]
          arguments: [ --nested-calls, casual/example/resource/domain/echo/B, casual/example/resource/domain/echo/C, casual/example/resource/domain/echo/X]
          instances: 4
@@ -2606,7 +2606,7 @@ domain:
    name: B
 
    servers:
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-resource-server"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-resource-server"
          memberships: [ user]
          arguments: [ --nested-calls, casual/example/resource/domain/echo/A, casual/example/resource/domain/echo/C, casual/example/resource/domain/echo/X]
          instances: 4
@@ -2628,7 +2628,7 @@ domain:
    name: C
 
    servers:
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-resource-server"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-resource-server"
          memberships: [ user]
          arguments: [ --nested-calls, casual/example/resource/nested/calls/A, casual/example/resource/nested/calls/B, casual/example/resource/domain/echo/X]
          instances: 4
@@ -2670,7 +2670,7 @@ domain:
 domain: 
    name: X
    servers:
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-resource-server"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-resource-server"
          memberships: [ user]
          instances: 3
    gateway:
@@ -2825,7 +2825,7 @@ domain:
             openinfo: --start -7 --end -7
             instances: 1
    servers:
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-resource-server"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-resource-server"
          memberships: [ user]
          arguments: [ --nested-calls, casual/example/resource/domain/echo/B, casual/example/resource/domain/echo/C, casual/example/resource/domain/echo/X]
          instances: 4
@@ -2847,7 +2847,7 @@ domain:
    name: B
 
    servers:
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-resource-server"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-resource-server"
          memberships: [ user]
          arguments: [ --nested-calls, casual/example/resource/domain/echo/A, casual/example/resource/domain/echo/C, casual/example/resource/domain/echo/X]
          instances: 4
@@ -2869,7 +2869,7 @@ domain:
    name: C
 
    servers:
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-resource-server"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-resource-server"
          memberships: [ user]
          arguments: [ --nested-calls, casual/example/resource/nested/calls/A, casual/example/resource/nested/calls/B, casual/example/resource/domain/echo/X]
          instances: 4
@@ -2911,7 +2911,7 @@ domain:
 domain: 
    name: X
    servers:
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-resource-server"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-resource-server"
          memberships: [ user]
          instances: 3
    gateway:
@@ -3052,7 +3052,7 @@ domain:
 domain:
    name: A
    servers:
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-resource-server"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-resource-server"
          memberships: [ user]
          arguments: [ --nested-calls, casual/example/resource/domain/echo/B, casual/example/resource/domain/echo/C, casual/example/resource/domain/echo/X]
          instances: 4
@@ -3073,7 +3073,7 @@ domain:
 domain: 
    name: B
    servers:
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-resource-server"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-resource-server"
          memberships: [ user]
          arguments: [ --nested-calls, casual/example/resource/domain/echo/A, casual/example/resource/domain/echo/C, casual/example/resource/domain/echo/X]
          instances: 4
@@ -3094,7 +3094,7 @@ domain:
 domain: 
    name: C
    servers:
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-resource-server"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-resource-server"
          memberships: [ user]
          arguments: [ --nested-calls, casual/example/resource/nested/calls/A, casual/example/resource/nested/calls/B, casual/example/resource/domain/echo/X]
          instances: 4
@@ -3135,7 +3135,7 @@ domain:
 domain: 
    name: X
    servers:
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-resource-server"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-resource-server"
          memberships: [ user]
          instances: 3
    gateway:
@@ -3274,7 +3274,7 @@ domain:
    name: B
    servers:
       -  alias: casual-example-server
-         path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+         path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
          memberships: [ user]
          arguments: [ --sleep, 1s]
    gateway:
@@ -3431,7 +3431,7 @@ domain:
    name: B
 
    servers:
-      - path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+      - path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
         instances: 0
 
    gateway:
@@ -3534,7 +3534,7 @@ domain:
 domain:
    name: B
    servers:
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/queue/bin/casual-queue-manager"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/queue/bin/casual-queue-manager"
          memberships: [ queue]
    queue:
       groups:
@@ -3561,7 +3561,7 @@ domain:
             openinfo: --prepare -3
             instances: 1
    servers:
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-resource-server"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-resource-server"
          memberships: [ user]
          instances: 1
    gateway:
@@ -3576,7 +3576,7 @@ domain:
 domain:
    name: A
    servers:
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/queue/bin/casual-queue-manager"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/queue/bin/casual-queue-manager"
          memberships: [ queue]
    gateway:
       outbound:
@@ -3629,7 +3629,7 @@ domain:
             duration: 2ms
             contract: kill
    servers:
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
          memberships: [ user]
          arguments: [ --sleep, 1s]
    gateway:
@@ -3680,7 +3680,7 @@ domain:
    name: B
    servers:
       -  alias: casual-example-server
-         path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+         path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
          memberships: [ user]
    gateway:
       inbound:
@@ -3694,7 +3694,7 @@ domain:
    name: C
    servers:
       -  alias: casual-example-server
-         path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+         path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
          memberships: [ user]
    gateway:
       inbound:
@@ -3786,7 +3786,7 @@ domain:
 domain: 
    name: B
    servers:         
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
          alias: example
          memberships: [ user]
          instances: 0

--- a/test/unittest/source/test_http.cpp
+++ b/test/unittest/source/test_http.cpp
@@ -45,8 +45,8 @@ domain:
          arguments: [ -p, "${CASUAL_DOMAIN_HOME}", -c, "${CASUAL_UNITTEST_HTTP_INBOUND_CONFIG}", -e, "${CASUAL_DOMAIN_HOME}/error.log"]
 
    servers:
-      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager
-      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/service/bin/casual-service-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server
 )";
    
                   constexpr std::string_view b = R"(
@@ -56,8 +56,8 @@ domain:
       log: ":memory:"
 
    servers:
-      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager
-      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/http/bin/casual-http-outbound
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/service/bin/casual-service-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/http/bin/casual-http-outbound
         arguments: [ --configuration, "${CASUAL_UNITTEST_HTTP_OUTBOUND_CONFIG}"]
 )";
 

--- a/test/unittest/source/test_queue.cpp
+++ b/test/unittest/source/test_queue.cpp
@@ -43,13 +43,13 @@ domain:
          dependencies: [ user]
    
    servers:
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/service/bin/casual-service-manager"
          memberships: [ base]
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/casual-transaction-manager"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/casual-transaction-manager"
          memberships: [ base]
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/queue/bin/casual-queue-manager"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/queue/bin/casual-queue-manager"
          memberships: [ queue]
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/gateway/bin/casual-gateway-manager"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/gateway/bin/casual-gateway-manager"
          memberships: [ end]
    
 )";

--- a/test/unittest/source/test_service.cpp
+++ b/test/unittest/source/test_service.cpp
@@ -54,11 +54,11 @@ domain:
          dependencies: [ user]
    
    servers:
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/service/bin/casual-service-manager"
          memberships: [ base]
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/casual-transaction-manager"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/casual-transaction-manager"
          memberships: [ base]
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/gateway/bin/casual-gateway-manager"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/gateway/bin/casual-gateway-manager"
          memberships: [ gateway]
 )";
             } // configuration
@@ -94,13 +94,13 @@ domain:
    name: A
    servers:         
       -  alias: A
-         path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+         path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
          memberships: [ user]
          restrictions:
             -  casual/example/echo
 
       -  alias: B
-         path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+         path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
          memberships: [ user]
          restrictions:
             -  casual/example/sink
@@ -137,7 +137,7 @@ domain:
    name: A
    servers:         
       -  alias: A
-         path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+         path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
          memberships: [ user]
          restrictions:
             -  ".*/echo$"
@@ -202,7 +202,7 @@ domain:
 domain: 
    name: B
    servers:         
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
          memberships: [ user]
    services:
       -  name: casual/example/echo
@@ -218,7 +218,7 @@ domain:
 domain: 
    name: A
    servers:         
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server"
          memberships: [ user]
    services:
       -  name: casual/example/echo
@@ -277,7 +277,7 @@ domain:
          auto domain = casual::domain::unittest::manager( local::configuration::base, R"(
 domain:
    servers:
-      -  path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server
+      -  path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server
          memberships: [ user]
 
    services:
@@ -316,7 +316,7 @@ domain:
          auto domain = casual::domain::unittest::manager( local::configuration::base, R"(
 domain:
    servers:
-      -  path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server
+      -  path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server
          memberships: [ user]
 
    services:
@@ -358,7 +358,7 @@ domain:
          auto domain = casual::domain::unittest::manager( local::configuration::base, R"(
 domain:
    servers:
-      -  path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server
+      -  path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server
          memberships: [ user]
          restrictions:
             - casual/example/atomic/echo
@@ -396,7 +396,7 @@ domain:
          auto domain = casual::domain::unittest::manager( local::configuration::base, R"(
 domain:
    servers:
-      -  path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server
+      -  path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server
          memberships: [ user]
          instances: 1
          restrictions:
@@ -478,7 +478,7 @@ domain:
          constexpr auto configuration = R"(
 domain:
    servers:
-      -  path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server
+      -  path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server
          memberships: [ user]
          instances: 1
          arguments:

--- a/test/unittest/source/test_transaction.cpp
+++ b/test/unittest/source/test_transaction.cpp
@@ -39,7 +39,7 @@ namespace casual
 system:
    resources:
       -  key: rm-mockup
-         server: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/rm-proxy-casual-mockup
+         server: ${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/rm-proxy-casual-mockup
          xa_struct_name: casual_mockup_xa_switch_static
          libraries:
             -  casual-mockup-rm
@@ -57,18 +57,18 @@ domain:
         dependencies: [ queue]
 
    servers:
-      -  path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager
+      -  path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/service/bin/casual-service-manager
          memberships: [ base]
-      -  path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/casual-transaction-manager
+      -  path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/casual-transaction-manager
          memberships: [ transaction]
-      -  path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/queue/bin/casual-queue-manager
+      -  path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/queue/bin/casual-queue-manager
          memberships: [ queue]
-      -  path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-error-server
+      -  path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-error-server
          memberships: [ example]
-      -  path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server
+      -  path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server
          memberships: [ example]
       -  alias: resource-example
-         path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-resource-server
+         path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-resource-server
          memberships: [ example]
 )";
 
@@ -398,7 +398,7 @@ domain:
 
    servers:
       -  alias: dynamic-resource-example
-         path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-dynamic-resource-server
+         path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-dynamic-resource-server
          memberships: [ resource]
 
 )";
@@ -443,7 +443,7 @@ domain:
 
    servers:
       -  alias: dynamic-resource-example
-         path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-dynamic-resource-server
+         path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-dynamic-resource-server
          memberships: [ resource]
 
 )";

--- a/test/unittest/source/xatmi/test_call.cpp
+++ b/test/unittest/source/xatmi/test_call.cpp
@@ -46,7 +46,7 @@ namespace casual
 system:
    resources:
       -  key: rm-mockup
-         server: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/rm-proxy-casual-mockup
+         server: ${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/rm-proxy-casual-mockup
          xa_struct_name: casual_mockup_xa_switch_static
          libraries:
             -  casual-mockup-rm
@@ -83,17 +83,17 @@ domain:
         dependencies: [ queue]
 
    servers:
-      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/service/bin/casual-service-manager
         memberships: [ base]
-      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/casual-transaction-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/casual-transaction-manager
         memberships: [ transaction]
-      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/queue/bin/casual-queue-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/queue/bin/casual-queue-manager
         memberships: [ queue]
-      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-error-server
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-error-server
         memberships: [ example]
-      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server
         memberships: [ example]
-      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-resource-server
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-resource-server
         memberships: [ example]
 )");
             }

--- a/test/unittest/source/xatmi/test_conversation.cpp
+++ b/test/unittest/source/xatmi/test_conversation.cpp
@@ -55,11 +55,11 @@ domain:
          dependencies: [ user]
    
    servers:
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/service/bin/casual-service-manager"
          memberships: [ base]
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/casual-transaction-manager"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/casual-transaction-manager"
          memberships: [ base]
-      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/gateway/bin/casual-gateway-manager"
+      -  path: "${CASUAL_MAKE_BUILD_ROOT}/middleware/gateway/bin/casual-gateway-manager"
          memberships: [ gateway]
 )";
 
@@ -67,9 +67,9 @@ domain:
 domain:
    name: conversation
    servers:
-      -  path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-error-server
+      -  path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-error-server
          memberships: [ user]
-      -  path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server
+      -  path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server
          memberships: [ user]
 )";
 

--- a/test/unittest/source/xatmi/test_start.cpp
+++ b/test/unittest/source/xatmi/test_start.cpp
@@ -63,15 +63,15 @@ domain:
         dependencies: [ queue]
 
    servers:
-      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/service/bin/casual-service-manager
         memberships: [ base]
-      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/casual-transaction-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/transaction/bin/casual-transaction-manager
         memberships: [ transaction]
-      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/queue/bin/casual-queue-manager
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/queue/bin/casual-queue-manager
         memberships: [ queue]
-      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-error-server
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-error-server
         memberships: [ example]
-      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server
+      - path: ${CASUAL_MAKE_BUILD_ROOT}/middleware/example/server/bin/casual-example-server
         memberships: [ example]
 )");
             }

--- a/thirdparty/setup/install_nginx.py
+++ b/thirdparty/setup/install_nginx.py
@@ -12,10 +12,11 @@ from shutil import copyfile
 NGINX_VERSION = "1.22.1"
 BASENAME = "nginx-" + NGINX_VERSION
 SOURCE_ROOT = os.getenv("CASUAL_MAKE_SOURCE_ROOT")
+BUILD_ROOT = os.getenv("CASUAL_MAKE_BUILD_ROOT")
 CASUAL_THIRDPARTY = os.getenv("CASUAL_THIRDPARTY")
 
-if not SOURCE_ROOT or not CASUAL_THIRDPARTY:
-	raise SystemError("CASUAL_MAKE_SOURCE_ROOT and CASUAL_THIRDPARTY need to be set")
+if not SOURCE_ROOT or not CASUAL_THIRDPARTY or not BUILD_ROOT:
+	raise SystemError("CASUAL_MAKE_SOURCE_ROOT, CASUAL_MAKE_BUILD_ROOT and CASUAL_THIRDPARTY need to be set")
 
 os.chdir(CASUAL_THIRDPARTY + '/nginx/' + BASENAME)
 
@@ -27,6 +28,7 @@ print("Running configure")
 print( subprocess.check_output(['./configure',
    '--with-debug',
    '--prefix=' + prefix,
+   '--builddir=' + BUILD_ROOT + '/../casual-thirdparty/nginx',
    '--with-cc-opt=-Wno-deprecated',
    '--add-module=' + SOURCE_ROOT + '/middleware/http/source/inbound/nginx/plugin',
    '--without-http_rewrite_module']).decode())


### PR DESCRIPTION
This PR has a dependency to https://github.com/casualcore/casual-make/pull/10.
In order to be able to build the .github/workflows/casual-build-alpha.yaml temporarly reference a different branch.
This needs to be corrected before merge.