### PR TITLE
common: transaction::global::ID istream asserts on hex <= 64B

### DIFF
--- a/documentation/changelog.md
+++ b/documentation/changelog.md
@@ -5,6 +5,7 @@ This is the changelog for `casual` and all changes are listed in this document.
 
 ### Fixes
 - tools: build-server does not generate function name via argument ([#568](https://github.com/casualcore/casual/issues/568))
+- common: transaction::global::ID istream asserts on hex <= 64B ([#570](https://github.com/casualcore/casual/issues/570))
 
 ## [1.7.7] - 2025-05-27
 

--- a/middleware/common/source/transaction/global.cpp
+++ b/middleware/common/source/transaction/global.cpp
@@ -51,7 +51,8 @@ namespace casual::common
          if( string.size() % 2 == 1)
             code::raise::error( code::casual::invalid_argument, "invalid format on gtrid: ", string, ", needs to be even length");
 
-         assertion( string.size() <= 64, "trid: ", string, " has larger gtrid size than 64");
+         if( string.size() > 128)
+            code::raise::error( code::casual::invalid_argument, "invalid format on gtrid: ", string, ", exceeds maximum size of 64 bytes (128 hex characters)");
 
          common::transcode::hex::decode( string, gtrid.m_gtrid);
          gtrid.m_size = string.size() / 2;

--- a/middleware/common/unittest/source/transaction/test_id.cpp
+++ b/middleware/common/unittest/source/transaction/test_id.cpp
@@ -113,6 +113,46 @@ namespace casual
          EXPECT_TRUE( algorithm::equal( bqual.range(), transaction::id::range::branch( id.xid)));
       }
 
+      TEST( common_transaction_global_id, istream_operator)
+      {
+         common::unittest::Trace trace;
+
+         // longer hex gtrid than 64 bytes
+         const std::string hex_id{ "00000000000000000000ffff0a82176e877949d1684dda18002d377c756b6f2d72616b75722d363864376336356437632d6d35"};
+         
+         std::istringstream stream{ hex_id};
+
+         transaction::global::ID gtrid;
+         stream >> gtrid;
+
+         EXPECT_TRUE( gtrid.range().size() == hex_id.size() / 2);
+         EXPECT_TRUE( transcode::hex::encode( gtrid.range()) == hex_id);
+      }
+
+      TEST( common_transaction_global_id, istream_operator_invalid_hex)
+      {
+         common::unittest::Trace trace;
+
+         auto deserialize = []( const std::string& hex_id)
+         {
+            std::istringstream stream{ hex_id};
+
+            transaction::global::ID gtrid;
+            stream >> gtrid;
+
+            return gtrid;
+         };
+
+         // uneven length
+         EXPECT_CODE( deserialize( "12345"), code::casual::invalid_argument) << "expected invalid hex gtrid to throw";
+         // invalid characters
+         EXPECT_CODE( deserialize( "1234gn"), code::casual::invalid_argument);
+         // too long
+         EXPECT_CODE( deserialize( std::string( 129, 'a')), code::casual::invalid_argument) << "expected invalid hex gtrid to throw";
+
+      }
+ 
+
    } // common
 
 } // casual


### PR DESCRIPTION
Before: transaction::global::ID istream operator did an assert if the hex string was larger than 64B.

Now: transaction::global::ID istream operator raises invalid-argument if the hex string is larger than 128B

Resolves #570