### PR TITLE
common: server-service finalize needs to wait for pending calls

### DIFF
--- a/documentation/changelog.md
+++ b/documentation/changelog.md
@@ -1,6 +1,12 @@
 # Changelog
 This is the changelog for `casual` and all changes are listed in this document.
 
+## [1.7.9] - 2025-07-13
+
+### Fixes
+- common: server-service finalize needs to wait for pending calls ([#575](https://github.com/casualcore/casual/issues/575))
+
+
 ## [1.7.8] - 2025-06-18
 
 ### Fixes

--- a/middleware/common/include/common/service/call/context.h
+++ b/middleware/common/include/common/service/call/context.h
@@ -85,6 +85,11 @@ namespace casual
          void deadline( platform::time::point::type now, std::optional< platform::time::unit> timeout);
          std::optional< platform::time::point::type> deadline() const;
 
+         //! Tries to finalize the context, wait for "all" pending replies that is found in `transaction_associated`.
+         void finalize( std::span< const strong::correlation::id> transaction_associated);
+
+         bool empty() const;
+
       private:
          Context();
          bool receive( message::service::call::Reply& reply, descriptor_type descriptor, reply::Flag);

--- a/middleware/common/include/common/service/call/state.h
+++ b/middleware/common/include/common/service/call/state.h
@@ -63,6 +63,10 @@ namespace casual
             //!  Thus, it's ok to do a service-forward
             bool empty() const;
 
+            //! @returns all in-flight correlations, and clear state.
+            std::vector< strong::correlation::id> finalize();
+
+
          private:
 
             pending::Descriptor& reserve();

--- a/middleware/common/include/common/transaction/context.h
+++ b/middleware/common/include/common/transaction/context.h
@@ -110,6 +110,8 @@ namespace casual
 
          //! @return true if @p correlation is associated with an active transaction
          bool associated( const strong::correlation::id& correlation);
+         //! @return all associated correlations
+         std::vector< strong::correlation::id> associated() const;
 
          void configure( std::vector< resource::Link> resources);
 

--- a/middleware/common/source/server/handle/policy.cpp
+++ b/middleware/common/source/server/handle/policy.cpp
@@ -8,6 +8,7 @@
 #include "common/server/handle/policy.h"
 
 #include "common/transaction/context.h"
+#include "common/service/call/context.h"
 #include "common/buffer/pool.h"
 #include "common/service/lookup.h"
 #include "common/communication/instance.h"
@@ -187,6 +188,9 @@ namespace casual
 
          message::service::transaction::State Default::transaction( bool commit)
          {
+            // try to wait for all in-flights that are associated with transactions
+            common::service::call::context().finalize( transaction::context().associated());
+
             return transaction::context().finalize( commit);
          }
 

--- a/middleware/common/source/service/call/context.cpp
+++ b/middleware/common/source/service/call/context.cpp
@@ -366,6 +366,7 @@ namespace casual
       void Context::clear()
       {
          m_state.deadline = {}; 
+         m_state.pending.finalize();
          // TODO: Do some cleaning on buffers, pending replies and such...
       }
 
@@ -387,6 +388,36 @@ namespace casual
       std::optional< platform::time::point::type> Context::deadline() const
       {
          return m_state.deadline;
+      }
+
+      void Context::finalize( std::span< const strong::correlation::id> transaction_associated)
+      {
+         Trace trace( "service::call::Context::finalize");
+         
+         auto correlations = m_state.pending.finalize();
+
+         auto [ associated, discardable] = algorithm::intersection( correlations, transaction_associated);
+
+         log::line( log::debug, "associated: ", associated, " discardable: ", discardable);
+
+         for( auto& discard: discardable)
+            communication::ipc::inbound::device().discard( discard);
+
+         while( ! associated.empty())
+         {
+            auto reply = communication::ipc::receive< message::service::call::Reply>();
+            log::line( log::debug, "reply: ", reply);
+
+            // disassociate the the call from transaction
+            common::transaction::context().update( reply);
+
+            associated = algorithm::remove( associated, reply.correlation);
+         }
+      }
+
+      bool Context::empty() const
+      {
+         return m_state.pending.empty();
       }
 
 

--- a/middleware/common/source/service/call/state.cpp
+++ b/middleware/common/source/service/call/state.cpp
@@ -118,6 +118,24 @@ namespace casual
             return algorithm::all_of( m_descriptors, predicate::negate( std::mem_fn( &pending::Descriptor::active)));
          }
 
+         std::vector< strong::correlation::id> Pending::finalize()
+         {
+            Trace trace{ "common::service::call::state::Pending::finalize"};
+
+            std::vector< strong::correlation::id> result;
+
+            for( auto& descriptor : m_descriptors)
+            {
+               if( descriptor.active)
+               {
+                  result.push_back( descriptor.correlation);
+                  descriptor.active = false;
+               }
+            }
+
+            return result;
+         }
+
       } // state
 
 

--- a/middleware/common/source/transaction/context.cpp
+++ b/middleware/common/source/transaction/context.cpp
@@ -113,6 +113,16 @@ namespace casual
             });
          }
 
+         std::vector< strong::correlation::id> Context::associated() const
+         {
+            std::vector< strong::correlation::id> result;
+
+            for( const auto& transaction : m_transactions)
+               algorithm::container::append( transaction.correlations(), result);
+
+            return result;
+         }
+
          namespace local
          {
             namespace

--- a/test/makefile.cmk
+++ b/test/makefile.cmk
@@ -70,6 +70,7 @@ unittest_object = [
     make.Compile( 'unittest/source/gateway/test_reverse.cpp'),
     make.Compile( 'unittest/source/gateway/test_discovery.cpp'),
     make.Compile( 'unittest/source/test_service.cpp'),
+    make.Compile( 'unittest/source/test_server.cpp'),
     make.Compile( 'unittest/source/test_queue.cpp'),
     make.Compile( 'unittest/source/test_assassinate.cpp'),
     make.Compile( 'unittest/source/xatmi/test_conversation.cpp'),

--- a/test/unittest/source/test_server.cpp
+++ b/test/unittest/source/test_server.cpp
@@ -1,0 +1,111 @@
+//!
+//! Copyright (c) 2025, The casual project
+//!
+//! This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+//!
+
+
+#define CASUAL_NO_XATMI_UNDEFINE
+
+#include "common/unittest.h"
+
+#include "common/server/handle/policy.h"
+#include "common/service/call/context.h"
+
+#include "test/unittest/xatmi/buffer.h"
+
+#include "domain/unittest/manager.h"
+
+#include "casual/xatmi.h"
+#include "casual/tx.h"
+
+
+
+namespace casual
+{
+   namespace test::server
+   {
+      namespace local
+      {
+         namespace
+         {
+            namespace configuration
+            {
+               constexpr auto base = R"(
+domain: 
+   groups: 
+      -  name: base
+         dependencies: [ base]
+      -  name: user
+         dependencies: [ base]
+      -  name: end
+         dependencies: [ user]
+   
+   servers:
+      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/service/bin/casual-service-manager"
+         memberships: [ base]
+      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/transaction/bin/casual-transaction-manager"
+         memberships: [ base]
+   
+)";
+   
+            } // configuration
+
+            template< typename... Cs>
+            auto domain( Cs&&... configurations)
+            {
+               return casual::domain::unittest::manager( local::configuration::base, std::forward< Cs>( configurations)...);
+            }
+            
+         } // <unnamed>
+      } // local
+
+
+      TEST( test_server, pending_transaction_calls__policy_finalize__expect_fetch_all_in_flight)
+      {
+         common::unittest::Trace trace;
+
+         auto a = local::domain( R"(
+domain: 
+   name: A
+   transaction:
+      log: ":memory:"
+   servers:         
+      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+         memberships: [ user]
+         instances: 4
+)");  
+         
+         auto buffer = test::unittest::xatmi::buffer::x_octet{ 128L};
+         
+         // start a transaction 'manually'
+         ASSERT_TRUE( ::tx_begin() == TX_OK ) << "tx_begin: " << tperrnostring( tperrno);
+         
+         common::algorithm::for_n< 2>( [ &]()
+         {
+            // in transaction
+            EXPECT_TRUE( ::tpacall( "casual/example/echo", buffer.data, buffer.size, 0) != -1) << "tpacall: " << tperrnostring( tperrno);
+            // outside transaction
+            EXPECT_TRUE( ::tpacall( "casual/example/echo", buffer.data, buffer.size, TPNOTRAN) != -1) << "tpacall: " << tperrnostring( tperrno);
+         });
+
+         // should be 2 associated calls to the transaction
+         EXPECT_TRUE( common::transaction::context().associated().size() == 2);
+            
+         
+         common::server::handle::policy::call::Default policy;
+
+         // emulate a rollback finalize
+         policy.transaction( false);
+
+         // we should have cleared the in-flight calls
+         EXPECT_TRUE( common::service::call::context().empty());
+
+         // we should have cleared the transaction context
+         EXPECT_TRUE( common::transaction::context().empty());
+
+      }
+
+      
+   } // test::server
+} // casual


### PR DESCRIPTION
Before: The default Policy (that is used for user servers) didn't wait/fetch pending in-flight replies before sending rollback to TM. This could lead to timing issues if TM reaches resources before any of the pending calls.

Now: We wait for all in-flight calls that are associated with a transaction.

Resolves #575