### PR TITLE
common: time_point is not logged with iso8601 utc offset in some places

### DIFF
--- a/middleware/cli/include/casual/cli/message.h
+++ b/middleware/cli/include/casual/cli/message.h
@@ -87,7 +87,7 @@ namespace casual
             {
                std::string properties;
                std::string reply;
-               platform::time::point::type available;
+               common::chronology::time_point available;
                
                CASUAL_CONST_CORRECT_SERIALIZE(
                   CASUAL_SERIALIZE( properties);

--- a/middleware/common/include/casual/platform.h
+++ b/middleware/common/include/casual/platform.h
@@ -411,20 +411,9 @@ namespace casual
             using type = std::chrono::system_clock;
          } // clock
 
-         namespace point
-         {
-            using type = clock::type::time_point;
-
-            namespace limit
-            {
-               constexpr auto zero() noexcept { return point::type{};}
-            } // limit
-         } // point
-
-         using unit = point::type::duration;
-         
          namespace serialization
          {
+            // the unit used when serializing time
             using unit = std::chrono::nanoseconds;
          } // serialization
 

--- a/middleware/common/include/common/chronology.h
+++ b/middleware/common/include/common/chronology.h
@@ -10,6 +10,7 @@
 
 #include "casual/platform.h"
 #include "common/stream/customization.h"
+#include "common/serialize/value.h"
 
 #include <string>
 #include <chrono>
@@ -18,14 +19,20 @@ namespace casual
 {
    namespace common::chronology
    {
+      using time_point = platform::time::clock::type::time_point;
+      using duration = time_point::duration;
+
       namespace utc
       {
          //! Format a timepoint to iso 8601 extended date time with UTC offset
          //! @{
-         void offset( std::ostream& out, platform::time::point::type time);
-         std::string offset( platform::time::point::type time);
+         void offset( std::ostream& out, time_point time);
+         std::string offset( time_point time);
          //! @}
       } // utc
+
+      //! @returns a time_point that represents 'empty/nill' timepoint
+      constexpr time_point empty() noexcept { return time_point{};}
 
       namespace unit
       {
@@ -64,7 +71,7 @@ namespace casual
 
       namespace from
       {
-         platform::time::unit string( const std::string& value);
+         duration string( const std::string& value);
       } // from
 
       namespace to
@@ -80,6 +87,8 @@ namespace casual
 
    } // common::chronology
 
+
+   // specialization for stream/log customization
    namespace common::stream::customization::supersede
    {
       template< typename R, typename P>
@@ -93,15 +102,68 @@ namespace casual
       };
 
       template<>
-      struct point< platform::time::point::type>
+      struct point< chronology::time_point>
       {
-         static void stream( std::ostream& out, const platform::time::point::type& time)
+         static void stream( std::ostream& out, const chronology::time_point& time)
          {
             chronology::utc::offset( out, time);
          }
       };
 
    } // common::stream::customization::supersede
+
+
+   // specialization for serialization customization
+   namespace common::serialize::customize
+   {
+      template< typename R, typename P, typename A>
+      struct Value< std::chrono::duration< R, P>, A>
+      {
+         using value_type = std::chrono::duration< R, P>;
+
+         template< typename V> 
+         static void write( A& archive, V&& value, const char* name)
+         {
+            value::write( archive, std::chrono::duration_cast< platform::time::serialization::unit>( value).count(), name);
+         }
+
+         static bool read( A& archive, value_type& value, const char* name)
+         {
+            platform::time::serialization::unit::rep representation;
+
+            if( value::read( archive, representation, name))
+            {
+               value = std::chrono::duration_cast< value_type>( platform::time::serialization::unit{ representation});
+               return true;
+            }
+            return false;
+         }
+      };
+
+      template< typename A>
+      struct Value< chronology::time_point, A>
+      {
+         static void write( A& archive, chronology::time_point value, const char* name)
+         {
+            value::write(
+               archive, 
+               std::chrono::time_point_cast< platform::time::serialization::unit>( value).time_since_epoch(), 
+               name);
+         }
+
+         static bool read( A& archive, chronology::time_point& value, const char* name)
+         {
+            platform::time::serialization::unit duration;
+            if( value::read( archive, duration, name))
+            {
+               value = chronology::time_point{ std::chrono::duration_cast< chronology::duration>( duration)};
+               return true;
+            }
+            return false;
+         }
+      };
+      
+   } // common::serialize::customize
 
 } // casual
 

--- a/middleware/common/include/common/message/conversation.h
+++ b/middleware/common/include/common/message/conversation.h
@@ -66,7 +66,7 @@ namespace casual
                      std::string parent;
                      common::transaction::ID trid;
                      header::Fields header;
-                     platform::time::unit pending{};
+                     chronology::duration pending{};
                      duplex::Type duplex{};
                      common::buffer::Payload buffer;
 
@@ -100,7 +100,7 @@ namespace casual
 
                //! pending time, only to be return in the "ACK", to collect
                //! metrics
-               platform::time::unit pending{};
+               chronology::duration pending{};
 
                duplex::Type duplex{};
 

--- a/middleware/common/include/common/message/event.h
+++ b/middleware/common/include/common/message/event.h
@@ -248,10 +248,10 @@ namespace casual
                execution::type execution;
                common::transaction::ID trid;
 
-               platform::time::point::type start{};
-               platform::time::point::type end{};
+               chronology::time_point start{};
+               chronology::time_point end{};
 
-               platform::time::unit pending{};
+               chronology::duration pending{};
 
                common::service::Code code;
 

--- a/middleware/common/include/common/message/service.h
+++ b/middleware/common/include/common/message/service.h
@@ -49,7 +49,7 @@ namespace casual
 
             struct Deadline
             {
-               std::optional< platform::time::unit> remaining;
+               std::optional< chronology::duration> remaining;
 
                CASUAL_CONST_CORRECT_SERIALIZE(
                   CASUAL_SERIALIZE( remaining);
@@ -61,7 +61,7 @@ namespace casual
          //! service timeout
          struct Timeout
          {
-            platform::time::unit duration{};
+            chronology::duration duration{};
 
             CASUAL_CONST_CORRECT_SERIALIZE(
                CASUAL_SERIALIZE( duration);
@@ -340,7 +340,7 @@ namespace casual
                std::string requested;
                request::Context context;
                common::transaction::ID trid;
-               std::optional< platform::time::point::type> deadline{};
+               std::optional< chronology::time_point> deadline{};
 
                inline bool no_reply() const noexcept
                {
@@ -387,7 +387,7 @@ namespace casual
                call::Service service;
                call::Deadline deadline;
                //! represent how long this request was pending (busy);
-               platform::time::unit pending{};
+               chronology::duration pending{};
                reply::State state = reply::State::idle;
                
                inline bool absent() const { return state == reply::State::absent;}
@@ -497,7 +497,7 @@ namespace casual
 
                   //! pending time, only to be return in the "ACK", to collect
                   //! metrics
-                  platform::time::unit pending{};
+                  chronology::duration pending{};
 
                   CASUAL_CONST_CORRECT_SERIALIZE(
                      base_type::serialize( archive);
@@ -561,7 +561,7 @@ namespace casual
 
                //! pending time, only to be return in the "ACK", to collect
                //! metrics
-               platform::time::unit pending{};
+               chronology::duration pending{};
 
                CASUAL_CONST_CORRECT_SERIALIZE(
                   base_type::serialize( archive);

--- a/middleware/common/include/common/message/type.h
+++ b/middleware/common/include/common/message/type.h
@@ -427,8 +427,8 @@ namespace casual
 
       struct Statistics
       {
-         platform::time::point::type start;
-         platform::time::point::type end;
+         chronology::time_point start;
+         chronology::time_point end;
 
          CASUAL_CONST_CORRECT_SERIALIZE(
             CASUAL_SERIALIZE( start);

--- a/middleware/common/include/common/metric.h
+++ b/middleware/common/include/common/metric.h
@@ -8,6 +8,7 @@
 
 #include "casual/platform.h"
 #include "common/serialize/macro.h"
+#include "common/chronology.h"
 
 
 #include <iosfwd>
@@ -20,10 +21,10 @@ namespace casual
       {
          struct Limit
          {
-            platform::time::unit min = platform::time::unit::zero();
-            platform::time::unit max = platform::time::unit::zero();
+            chronology::duration min = chronology::duration::zero();
+            chronology::duration max = chronology::duration::zero();
 
-            Limit& operator += ( platform::time::unit duration);
+            Limit& operator += ( chronology::duration duration);
             Limit& operator += ( const Limit& rhs);
 
             friend Limit operator + ( const Limit& lhs, const Limit& rhs);
@@ -36,18 +37,18 @@ namespace casual
          };
 
          platform::size::type count = 0;
-         platform::time::unit total = platform::time::unit::zero();
+         chronology::duration total = chronology::duration::zero();
          Limit limit;
 
 
-         Metric& operator += ( platform::time::unit duration);
+         Metric& operator += ( chronology::duration duration);
          Metric& operator += ( const Metric& rhs);
          friend Metric operator + ( const Metric& lhs, const Metric& rhs);
 
          template< typename R, typename P>
          Metric& operator += ( std::chrono::duration< R, P> duration)
          {
-            return *this += std::chrono::duration_cast< platform::time::unit>( duration);
+            return *this += std::chrono::duration_cast< chronology::duration>( duration);
          }
 
          friend bool operator == ( const Metric& lhs, const Metric& rhs);

--- a/middleware/common/include/common/process.h
+++ b/middleware/common/include/common/process.h
@@ -13,6 +13,7 @@
 
 #include "common/algorithm.h"
 #include "common/environment/variable.h"
+#include "common/chronology.h"
 
 #include "common/serialize/macro.h"
 
@@ -81,7 +82,7 @@ namespace casual
       //! @throws exception::signal::* when a signal is received
       //!
       //! @param time numbers of microseconds to sleep
-      void sleep( platform::time::unit time);
+      void sleep( chronology::duration time);
 
       //! Sleep for an arbitrary duration
       //!
@@ -98,7 +99,7 @@ namespace casual
       template< typename R, typename P>
       void sleep( std::chrono::duration< R, P> time)
       {
-         sleep( std::chrono::duration_cast< platform::time::unit>( time));
+         sleep( std::chrono::duration_cast< chronology::duration>( time));
       }
 
 
@@ -218,14 +219,14 @@ namespace casual
          std::vector< Exit> ended();
 
          std::vector< Exit> wait( const std::vector< strong::process::id>& pids);
-         std::vector< Exit> wait( const std::vector< strong::process::id>& pids, platform::time::unit timeout);
+         std::vector< Exit> wait( const std::vector< strong::process::id>& pids, chronology::duration timeout);
 
          //! Terminates and waits for the termination.
          //!
          //! @return the terminated l
          std::vector< Exit> terminate( const std::vector< Handle>& handles);
          std::vector< Exit> terminate( const std::vector< strong::process::id>& pids);
-         std::vector< Exit> terminate( const std::vector< strong::process::id>& pids, platform::time::unit timeout);
+         std::vector< Exit> terminate( const std::vector< strong::process::id>& pids, chronology::duration timeout);
 
       } // lifetime
 

--- a/middleware/common/include/common/serialize/value.h
+++ b/middleware/common/include/common/serialize/value.h
@@ -650,56 +650,6 @@ namespace casual
          }
       };
 
-      //! Specialization for time
-      //! @{
-
-      template< typename R, typename P, typename A>
-      struct Value< std::chrono::duration< R, P>, A>
-      {
-         using value_type = std::chrono::duration< R, P>;
-
-         template< typename V> 
-         static void write( A& archive, V&& value, const char* name)
-         {
-            value::write( archive, std::chrono::duration_cast< platform::time::serialization::unit>( value).count(), name);
-         }
-
-         static bool read( A& archive, value_type& value, const char* name)
-         {
-            platform::time::serialization::unit::rep representation;
-
-            if( value::read( archive, representation, name))
-            {
-               value = std::chrono::duration_cast< value_type>( platform::time::serialization::unit{ representation});
-               return true;
-            }
-            return false;
-         }
-      };
-
-      template< typename A>
-      struct Value< platform::time::point::type, A>
-      {
-         static void write( A& archive, platform::time::point::type value, const char* name)
-         {
-            value::write(
-               archive, 
-               std::chrono::time_point_cast< platform::time::serialization::unit>( value).time_since_epoch(), 
-               name);
-         }
-
-         static bool read( A& archive, platform::time::point::type& value, const char* name)
-         {
-            platform::time::serialization::unit duration;
-            if( value::read( archive, duration, name))
-            {
-               value = platform::time::point::type{ std::chrono::duration_cast< platform::time::unit>( duration)};
-               return true;
-            }
-            return false;
-         }
-      };
-      //! @}
 
       //! Specialization for std::error_code
       template< typename A>

--- a/middleware/common/include/common/signal/timer.h
+++ b/middleware/common/include/common/signal/timer.h
@@ -8,6 +8,7 @@
 
 #include "casual/platform.h"
 #include "common/move.h"
+#include "common/chronology.h"
 #include "common/serialize/macro.h"
 
 #include <optional>
@@ -18,13 +19,13 @@ namespace casual
    {
       namespace unit
       {
-         //using type = value::basic_optional< platform::time::unit, detail::policy>; 
-         using type = std::optional< platform::time::unit>;
+         //using type = value::basic_optional< chronology::duration, detail::policy>; 
+         using type = std::optional< chronology::duration>;
       } // unit
 
       namespace point
       {
-         using type = std::optional< platform::time::point::type>;
+         using type = std::optional< chronology::time_point>;
       } // point
 
       //! Sets a timeout.
@@ -39,14 +40,14 @@ namespace casual
       template< typename R, typename P>
       unit::type set( std::chrono::duration< R, P> offset)
       {
-         return set( unit::type{ std::chrono::duration_cast< platform::time::unit>( offset)});
+         return set( unit::type{ std::chrono::duration_cast< chronology::duration>( offset)});
       }
 
       //! sets a timout that will expire ot `deadline`
       template< typename R, typename P>
       unit::type set( std::chrono::time_point< R, P> deadline)
       {
-         return set( deadline - platform::time::point::type::clock::now());
+         return set( deadline - chronology::time_point::clock::now());
       }
 
       //! @return current timeout, or 'emtpy' if there isn't one
@@ -62,11 +63,11 @@ namespace casual
       struct Scoped
       {
          Scoped( unit::type timeout);
-         Scoped( unit::type timeout, platform::time::point::type now);
+         Scoped( unit::type timeout, chronology::time_point now);
 
          template< typename R, typename P>
          Scoped( std::chrono::duration< R, P> timeout)
-            : Scoped( unit::type{ std::chrono::duration_cast< platform::time::unit>( timeout)})
+            : Scoped( unit::type{ std::chrono::duration_cast< chronology::duration>( timeout)})
          {}
 
          ~Scoped();
@@ -88,8 +89,8 @@ namespace casual
       //! dtor will 'unset' timeout regardless
       struct Deadline
       {
-         Deadline( point::type deadline, platform::time::point::type now);
-         Deadline( platform::time::unit duration);
+         Deadline( point::type deadline, chronology::time_point now);
+         Deadline( chronology::duration duration);
          ~Deadline();
 
          Deadline( Deadline&&) noexcept;

--- a/middleware/common/include/common/transaction/transaction.h
+++ b/middleware/common/include/common/transaction/transaction.h
@@ -37,7 +37,7 @@ namespace casual
          explicit Transaction( ID trid);
 
          ID trid;
-         std::optional< platform::time::point::type> deadline;
+         std::optional< chronology::time_point> deadline;
          State state = State::active;
 
          //! @return true if `trid` is _active_ 

--- a/middleware/common/source/chronology.cpp
+++ b/middleware/common/source/chronology.cpp
@@ -29,12 +29,12 @@ namespace casual
 
       namespace utc
       {
-         std::string offset( platform::time::point::type timepoint)
+         std::string offset( time_point timepoint)
          {
             return std::format("{:%FT%T%Ez}", std::chrono::zoned_time{ std::chrono::current_zone(), std::chrono::floor< std::chrono::microseconds>( timepoint)});
          }
 
-         void offset( std::ostream& out, platform::time::point::type timepoint)
+         void offset( std::ostream& out, time_point timepoint)
          {
             out << offset( timepoint);
          }
@@ -97,9 +97,9 @@ namespace casual
                
             } // detail
 
-            void format( std::ostream& out, platform::time::point::type timepoint)
+            void format( std::ostream& out, time_point timepoint)
             {
-               if( timepoint == platform::time::point::limit::zero())
+               if( timepoint ==  chronology::empty())
                   return;
 
                auto timer = platform::time::clock::type::to_time_t( timepoint);
@@ -117,14 +117,14 @@ namespace casual
 
       namespace utc
       {
-         std::string offset( platform::time::point::type timepoint)
+         std::string offset( time_point timepoint)
          {
             std::ostringstream out;
             offset( out, timepoint);
             return std::move( out).str();
         }
 
-        void offset( std::ostream& out, platform::time::point::type timepoint)
+        void offset( std::ostream& out, time_point timepoint)
         {
            local::format( out, timepoint);
          }
@@ -139,7 +139,7 @@ namespace casual
             namespace
             {
                template< typename R>
-               platform::time::unit string( R&& value)
+               chronology::duration string( R&& value)
                {
                   auto is_ws = []( auto c){ return c != ' ';};
 
@@ -154,7 +154,7 @@ namespace casual
                   // extract the count part
                   auto count = [number = std::get< 0>( split)]( )
                   {
-                     using count_type = decltype( platform::time::unit{}.count());
+                     using count_type = decltype( chronology::duration{}.count());
                      if( number)
                         return common::string::from< count_type>( string::view::make( number));
                      return count_type{ 0};
@@ -173,10 +173,10 @@ namespace casual
                   if( unit == "ns") 
                   {
                      auto point = std::chrono::nanoseconds( count);
-                     if constexpr( std::is_same_v< platform::time::unit, std::chrono::nanoseconds>)
-                        return std::chrono::duration_cast< platform::time::unit>( point);
+                     if constexpr( std::is_same_v< chronology::duration, std::chrono::nanoseconds>)
+                        return std::chrono::duration_cast< chronology::duration>( point);
                      else
-                        return std::chrono::round< platform::time::unit>( point);
+                        return std::chrono::round< chronology::duration>( point);
                   }
 
                   code::raise::error( code::casual::invalid_argument, "invalid time representation: ", string::view::make( value));
@@ -185,9 +185,8 @@ namespace casual
             } // <unnamed>
          } // local
 
-         platform::time::unit string( const std::string& value)
+         duration string( const std::string& value)
          {
-            using time_unit = platform::time::unit;
 
             // we split on '+', and provide _next range_ for the range-adapter 
             auto next_range = []( auto range)
@@ -196,14 +195,14 @@ namespace casual
                return algorithm::split( range, '+');
             };
             
-            auto accumulate_time = []( time_unit current, auto range)
+            auto accumulate_time = []( duration current, auto range)
             {
                return current + local::string( range);
             };
 
             return algorithm::accumulate( 
                range::adapter::make( next_range, range::make( value)), 
-               time_unit{}, 
+               duration{}, 
                accumulate_time);
          }
       } // from
@@ -233,7 +232,7 @@ namespace casual
 
          std::string string( std::chrono::nanoseconds duration)
          {
-            if( duration == platform::time::unit::zero())
+            if( duration == chronology::duration::zero())
                return {};
 
             std::ostringstream out;

--- a/middleware/common/source/metric.cpp
+++ b/middleware/common/source/metric.cpp
@@ -17,9 +17,9 @@ namespace casual
       {
          namespace
          {
-            auto min( platform::time::unit lhs, platform::time::unit rhs)
+            auto min( chronology::duration lhs, chronology::duration rhs)
             {
-               if( lhs == platform::time::unit::zero())
+               if( lhs == chronology::duration::zero())
                   return rhs;
                
                return std::min( lhs, rhs);
@@ -27,7 +27,7 @@ namespace casual
          } // <unnamed>
       } // local
 
-      Metric::Limit& Metric::Limit::operator += ( platform::time::unit duration)
+      Metric::Limit& Metric::Limit::operator += ( chronology::duration duration)
       {
          min = local::min( min, duration);
          max = std::max( max, duration);
@@ -49,7 +49,7 @@ namespace casual
          };
       }
 
-      Metric& Metric::operator += ( platform::time::unit duration)
+      Metric& Metric::operator += ( chronology::duration duration)
       {
          ++count;
          total += duration;

--- a/middleware/common/source/process.cpp
+++ b/middleware/common/source/process.cpp
@@ -115,7 +115,7 @@ namespace casual
          }
 
 
-         void sleep( platform::time::unit time)
+         void sleep( chronology::duration time)
          {
             log::debug( "process::sleep time: ", time);
 
@@ -622,7 +622,7 @@ namespace casual
                return result;
             }
 
-            std::vector< Exit> wait( const std::vector< strong::process::id>& pids, platform::time::unit timeout)
+            std::vector< Exit> wait( const std::vector< strong::process::id>& pids, chronology::duration timeout)
             {
                Trace trace{ "common::process::lifetime::wait"};
 
@@ -656,7 +656,7 @@ namespace casual
                return wait( process::terminate( pids));
             }
 
-            std::vector< Exit> terminate( const std::vector< strong::process::id>& pids, platform::time::unit timeout)
+            std::vector< Exit> terminate( const std::vector< strong::process::id>& pids, chronology::duration timeout)
             {
                return wait( process::terminate( pids), timeout);
             }

--- a/middleware/common/source/signal/timer.cpp
+++ b/middleware/common/source/signal/timer.cpp
@@ -104,7 +104,7 @@ namespace casual
 
 
 
-      Scoped::Scoped( unit::type timeout, platform::time::point::type now)
+      Scoped::Scoped( unit::type timeout, chronology::time_point now)
       {
          auto old = timer::set( timeout);
 
@@ -136,7 +136,7 @@ namespace casual
       Scoped& Scoped::operator = ( Scoped&& other) noexcept = default;
 
 
-      Deadline::Deadline( point::type deadline, platform::time::point::type now)
+      Deadline::Deadline( point::type deadline, chronology::time_point now)
       {
          if( deadline)
             timer::set( deadline.value() - now);
@@ -144,7 +144,7 @@ namespace casual
             timer::unset();
       }
 
-      Deadline::Deadline( platform::time::unit duration)
+      Deadline::Deadline( chronology::duration duration)
       {
          timer::set( duration);
       }

--- a/middleware/common/unittest/include/test_vo.h
+++ b/middleware/common/unittest/include/test_vo.h
@@ -11,6 +11,7 @@
 
 #include "common/serialize/macro.h"
 #include "common/serialize/archive.h"
+#include "common/chronology.h"
 
 #include "common/pimpl.h"
 #include "common/uuid.h"
@@ -35,7 +36,7 @@ namespace casual
          std::string m_string = "foo";
          short m_short = 256;
          long long m_longlong = std::numeric_limits< long long>::max();
-         platform::time::point::type m_time = platform::time::point::type::max();
+         common::chronology::time_point m_time = common::chronology::time_point::max();
          std::filesystem::path m_path{u8"/tmp/file.txt"};
 
          std::optional< long> m_optional = 42;

--- a/middleware/common/unittest/source/serialize/native/test_binary.cpp
+++ b/middleware/common/unittest/source/serialize/native/test_binary.cpp
@@ -237,12 +237,12 @@ namespace casual
                using input_type = typename TestFixture::input_type;
                using output_type = typename TestFixture::output_type;
 
-               const auto expected = platform::time::unit::zero();
+               const auto expected = chronology::duration::zero();
 
                auto output = output_type{}();
                output << expected;
 
-               platform::time::unit target;
+               chronology::duration target;
                {
                   auto buffer = output.consume();
                   auto input = input_type{}( buffer);
@@ -253,7 +253,7 @@ namespace casual
                   << CASUAL_NAMED_VALUE( target.count()) 
                   << "\n" << CASUAL_NAMED_VALUE( expected.count());
 
-               EXPECT_TRUE( target == platform::time::unit::zero());
+               EXPECT_TRUE( target == chronology::duration::zero());
             }
 
             TYPED_TEST( casual_serialize_native_binary, time_point_min)
@@ -263,12 +263,12 @@ namespace casual
                using input_type = typename TestFixture::input_type;
                using output_type = typename TestFixture::output_type;
 
-               const platform::time::point::type expected;
+               const chronology::time_point expected;
 
                auto output = output_type{}();
                output << expected;
 
-               platform::time::point::type target;
+               chronology::time_point target;
                {
                   auto buffer = output.consume();
                   auto input = input_type{}( buffer);

--- a/middleware/common/unittest/source/serialize/test_log.cpp
+++ b/middleware/common/unittest/source/serialize/test_log.cpp
@@ -68,3 +68,4 @@ namespace casual
    }
 
 } // casual
+

--- a/middleware/common/unittest/source/test_chronology.cpp
+++ b/middleware/common/unittest/source/test_chronology.cpp
@@ -77,7 +77,7 @@ namespace casual
          {
             unittest::Trace trace;
 
-            if constexpr( std::is_same_v< std::chrono::nanoseconds, platform::time::unit>)
+            if constexpr( std::is_same_v< std::chrono::nanoseconds, chronology::duration>)
             {
                EXPECT_TRUE( from::string( "42ns") == std::chrono::nanoseconds( 42)) << trace.compose( "42ns - ", from::string( "42ns"), " - ", from::string( "42ns").count());
                EXPECT_TRUE( from::string( "0ns") == std::chrono::seconds::zero());

--- a/middleware/common/unittest/source/test_metric.cpp
+++ b/middleware/common/unittest/source/test_metric.cpp
@@ -18,9 +18,9 @@ namespace casual
          Metric metric;
 
          EXPECT_TRUE( metric.count == 0);
-         EXPECT_TRUE( metric.total == platform::time::unit::zero());
-         EXPECT_TRUE( metric.limit.min == platform::time::unit::zero());
-         EXPECT_TRUE( metric.limit.max == platform::time::unit::zero());
+         EXPECT_TRUE( metric.total == chronology::duration::zero());
+         EXPECT_TRUE( metric.limit.min == chronology::duration::zero());
+         EXPECT_TRUE( metric.limit.max == chronology::duration::zero());
       }
 
       TEST( common_metric, compound_assign_1_duration)

--- a/middleware/configuration/include/configuration/model.h
+++ b/middleware/configuration/include/configuration/model.h
@@ -9,6 +9,7 @@
 #include "common/environment/variable.h"
 #include "common/serialize/macro.h"
 #include "common/service/type.h"
+#include "common/chronology.h"
 
 #include <vector>
 #include <string>
@@ -238,7 +239,7 @@ namespace casual::configuration
          {
             using Contract = common::service::execution::timeout::contract::Type;
             
-            std::optional< platform::time::unit> duration;
+            std::optional< common::chronology::duration> duration;
             std::optional< Contract> contract;
 
             friend Timeout set_union( Timeout lhs, Timeout rhs);
@@ -600,9 +601,9 @@ namespace casual::configuration
             struct Retry
             {
                platform::size::type count{};
-               platform::time::unit delay = platform::time::unit::zero();
+               common::chronology::duration delay = common::chronology::duration::zero();
 
-               inline auto empty() const { return count == 0 && delay == platform::time::unit::zero();}
+               inline auto empty() const { return count == 0 && delay == common::chronology::duration::zero();}
 
                friend auto operator <=> ( const Retry&, const Retry&) = default;
 
@@ -697,7 +698,7 @@ namespace casual::configuration
                struct Target
                {
                   std::string queue;
-                  platform::time::unit delay{};
+                  common::chronology::duration delay{};
 
                   friend auto operator <=> ( const Target&, const Target&) = default;
 

--- a/middleware/domain/include/casual/domain/manager/api/model.h
+++ b/middleware/domain/include/casual/domain/manager/api/model.h
@@ -96,7 +96,7 @@ namespace casual
                {
                   H handle;
                   instance::State state = instance::State::scale_out;
-                  casual::platform::time::point::type spawnpoint;
+                  casual::platform::time::clock::type::time_point  spawnpoint;
                };
 
                struct Executable : base_process

--- a/middleware/domain/include/domain/discovery/state.h
+++ b/middleware/domain/include/domain/discovery/state.h
@@ -97,7 +97,7 @@ namespace casual
                bool accumulate() const noexcept;
 
                static const platform::size::type in_flight_window;
-               static const platform::time::unit duration;
+               static const common::chronology::duration duration;
 
                CASUAL_LOG_SERIALIZE(
                   CASUAL_SERIALIZE_NAME( pending_requests(), "pending_requests");

--- a/middleware/domain/include/domain/manager/admin/model.h
+++ b/middleware/domain/include/domain/manager/admin/model.h
@@ -119,7 +119,7 @@ namespace casual
          {
             H handle;
             instance::State state = instance::State::scale_out;
-            platform::time::point::type spawnpoint;
+            common::chronology::time_point spawnpoint;
 
             template< typename T>
             friend bool operator == ( const Instance& lhs, T&& rhs) 

--- a/middleware/domain/include/domain/manager/state.h
+++ b/middleware/domain/include/domain/manager/state.h
@@ -21,6 +21,7 @@
 #include "common/process.h"
 #include "common/communication/select.h"
 #include "common/communication/ipc/send.h"
+#include "common/chronology.h"
 
 #include "common/event/dispatch.h"
 
@@ -160,7 +161,7 @@ namespace casual
             handle_type handle;
             instance::Phase wanted = instance::Phase::running;
 
-            platform::time::point::type spawnpoint = platform::time::point::limit::zero();
+            common::chronology::time_point spawnpoint = common::chronology::empty();
 
             instance::State state() const { return policy_type::state( handle, wanted);}
             

--- a/middleware/domain/include/domain/message/discovery.h
+++ b/middleware/domain/include/domain/message/discovery.h
@@ -72,7 +72,7 @@ namespace casual
                struct Retry 
                {
                   platform::size::type count{};
-                  platform::time::unit delay{};
+                  common::chronology::duration delay{};
 
                   friend auto operator <=> ( const Retry&, const Retry&) = default;
 

--- a/middleware/domain/source/discovery/state.cpp
+++ b/middleware/domain/source/discovery/state.cpp
@@ -89,7 +89,7 @@ namespace casual
             }();
 
 
-            const platform::time::unit Heuristic::duration = []() -> platform::time::unit
+            const common::chronology::duration Heuristic::duration = []() -> common::chronology::duration
             {
                return environment::variable::get( environment::variable::name::internal::discovery::accumulate::timeout)
                   .transform( []( auto value){ return common::chronology::from::string( value);})

--- a/middleware/domain/source/manager/admin/cli.cpp
+++ b/middleware/domain/source/manager/admin/cli.cpp
@@ -399,7 +399,7 @@ namespace casual
                               auto format_ipc = []( auto& i) { return i.instance->handle.ipc;};
                               auto format_state = []( auto& i) { return i.instance->state;};
                               auto format_alias = []( auto& i) { return i.server->alias;};
-                              auto format_spawnpoint = []( auto& i) { return chronology::utc::offset( i.instance->spawnpoint);};
+                              auto format_spawnpoint = []( auto& i) { return common::chronology::utc::offset( i.instance->spawnpoint);};
 
                               return terminal::format::formatter< Type>::construct(
                                  terminal::format::column( "pid", format_pid, terminal::color::white, terminal::format::Align::right),
@@ -457,7 +457,7 @@ namespace casual
                               auto format_pid = []( auto& i) { return i.instance->handle;};
                               auto format_state = []( auto& i) { return i.instance->state;};
                               auto format_alias = []( auto& i) { return i.executable->alias;};
-                              auto format_spawnpoint = []( auto& i) { return chronology::utc::offset( i.instance->spawnpoint);};
+                              auto format_spawnpoint = []( auto& i) { return common::chronology::utc::offset( i.instance->spawnpoint);};
 
                               return terminal::format::formatter< Type>::construct(
                                  terminal::format::column( "pid", format_pid, terminal::color::white, terminal::format::Align::right),

--- a/middleware/event/include/casual/event/model.h
+++ b/middleware/event/include/casual/event/model.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "casual/platform.h"
+#include "common/chronology.h"
 
 #include "casual/xa.h"
 
@@ -63,10 +64,10 @@ namespace casual
                         transaction::ID id;
                      } transaction;
                      
-                     platform::time::point::type start{};
-                     platform::time::point::type end{};
+                     common::chronology::time_point start{};
+                     common::chronology::time_point end{};
 
-                     platform::time::unit pending{};
+                     common::chronology::duration pending{};
 
                      // outcome of the service call
                      int code{};
@@ -113,10 +114,10 @@ namespace casual
                         transaction::ID id;
                      } transaction;
                      
-                     platform::time::point::type start{};
-                     platform::time::point::type end{};
+                     common::chronology::time_point start{};
+                     common::chronology::time_point end{};
 
-                     platform::time::unit pending{};
+                     common::chronology::duration pending{};
 
                      // outcome of the service call
                      int code{};

--- a/middleware/event/source/service/monitor/server.cpp
+++ b/middleware/event/source/service/monitor/server.cpp
@@ -60,8 +60,8 @@ namespace casual
                   } service;
 
                   common::Uuid execution;
-                  platform::time::point::type start;
-                  platform::time::point::type end;
+                  common::chronology::time_point start;
+                  common::chronology::time_point end;
 
                   CASUAL_CONST_CORRECT_SERIALIZE(
                      CASUAL_SERIALIZE( service);

--- a/middleware/event/unittest/source/test_dispatch.cpp
+++ b/middleware/event/unittest/source/test_dispatch.cpp
@@ -138,7 +138,7 @@ domain:
 
          struct
          {
-            std::vector< platform::time::unit> pending{};
+            std::vector< common::chronology::duration> pending{};
          } state;
 
          constexpr auto count = 5;
@@ -211,8 +211,8 @@ domain:
          common::algorithm::sort( state.pending);
 
          // we know it has to be pending for all except the first one..
-         EXPECT_TRUE( state.pending.at( 0) == platform::time::unit::zero()) << CASUAL_NAMED_VALUE( state.pending);
-         EXPECT_TRUE( state.pending.at( 1) > platform::time::unit::zero()) << CASUAL_NAMED_VALUE( state.pending);
+         EXPECT_TRUE( state.pending.at( 0) == common::chronology::duration::zero()) << CASUAL_NAMED_VALUE( state.pending);
+         EXPECT_TRUE( state.pending.at( 1) > common::chronology::duration::zero()) << CASUAL_NAMED_VALUE( state.pending);
       }
 
 
@@ -257,7 +257,7 @@ domain:
             ASSERT_TRUE( call.metrics.size() == 1) << CASUAL_NAMED_VALUE( call.metrics.size());
             auto& metric = call.metrics.at( 0);
             EXPECT_TRUE( metric.process.pid == common::process::id().value());
-            EXPECT_TRUE( metric.pending == platform::time::unit::zero());
+            EXPECT_TRUE( metric.pending == common::chronology::duration::zero());
             EXPECT_TRUE( metric.service.name == "foo");
             EXPECT_TRUE( metric.service.type == decltype( metric.service.type)::concurrent);
             // we trigger shutdown, to trigger "end"

--- a/middleware/example/server/source/example/work.cpp
+++ b/middleware/example/server/source/example/work.cpp
@@ -31,9 +31,9 @@ namespace casual
          {
             struct
             {
-               casual::platform::time::unit startup{};
-               casual::platform::time::unit sleep{};
-               casual::platform::time::unit work{};
+               common::chronology::duration startup{};
+               common::chronology::duration sleep{};
+               common::chronology::duration work{};
                std::string forward;
             } global;
          } // <unnamed>
@@ -65,7 +65,7 @@ namespace casual
                   argument::Option{ std::tie( local::global.forward), {"--forward"}, "service that casual/example/forward should call"},
                }, argc, argv);
 
-               if( local::global.startup != platform::time::unit::zero())
+               if( local::global.startup != common::chronology::duration::zero())
                   common::process::sleep( local::global.startup);
 
                auto advertise_echo = []( std::string_view name)

--- a/middleware/gateway/include/gateway/group/tcp.h
+++ b/middleware/gateway/include/gateway/group/tcp.h
@@ -116,7 +116,7 @@ namespace casual
             common::strong::socket::id descriptor;
             common::domain::Identity domain;
             Configuration configuration;
-            platform::time::point::type created = platform::time::clock::type::now();
+            common::chronology::time_point created = platform::time::clock::type::now();
 
             inline friend bool operator == ( const Information& lhs, common::strong::socket::id rhs) { return lhs.descriptor == rhs;} 
             inline friend bool operator == ( const Information& lhs, const common::strong::domain::id& rhs) { return lhs.domain == rhs;} 

--- a/middleware/gateway/include/gateway/group/tcp/connect.h
+++ b/middleware/gateway/include/gateway/group/tcp/connect.h
@@ -130,7 +130,7 @@ namespace casual
          {
             if( ! connect.prospects.empty())
             {
-               static const auto duration = []() -> platform::time::unit
+               static const auto duration = []() -> common::chronology::duration
                {
                   // check if we're in unittest context or not.
                   if( common::environment::variable::exists( common::environment::variable::name::internal::unittest::context))

--- a/middleware/gateway/include/gateway/group/tcp/listen.h
+++ b/middleware/gateway/include/gateway/group/tcp/listen.h
@@ -31,7 +31,7 @@ namespace casual
 
                common::communication::Socket socket;
                Configuration configuration;
-               platform::time::point::type created = platform::time::clock::type::now();
+               common::chronology::time_point created = platform::time::clock::type::now();
 
                inline friend bool operator == ( const Listener& lhs, common::strong::file::descriptor::id rhs) { return lhs.descriptor() == rhs;}
 

--- a/middleware/gateway/include/gateway/manager/admin/model.h
+++ b/middleware/gateway/include/gateway/manager/admin/model.h
@@ -116,7 +116,7 @@ namespace casual
             common::domain::Identity remote;
             connection::Address address;
             common::strong::ipc::id ipc;
-            platform::time::point::type created{};
+            common::chronology::time_point created{};
             bool enabled = true;
             
             inline friend bool operator == ( const Connection& lhs, common::strong::socket::id rhs) { return lhs.descriptor == rhs;}
@@ -308,7 +308,7 @@ namespace casual
             listener::Runlevel runlevel{};
             listener::Address address;
             connection::Bound bound{};
-            platform::time::point::type created{};
+            common::chronology::time_point created{};
          
             //@ deprecated
             struct

--- a/middleware/gateway/include/gateway/message.h
+++ b/middleware/gateway/include/gateway/message.h
@@ -129,7 +129,7 @@ namespace casual
             listener::Runlevel runlevel{};
             common::communication::tcp::Address address;
             common::strong::file::descriptor::id descriptor;
-            platform::time::point::type created{};
+            common::chronology::time_point created{};
 
             CASUAL_CONST_CORRECT_SERIALIZE(
                CASUAL_SERIALIZE( runlevel);
@@ -175,7 +175,7 @@ namespace casual
             message::protocol::Version protocol{};
             Configuration configuration;
             common::strong::ipc::id ipc;
-            platform::time::point::type created{};
+            common::chronology::time_point created{};
 
             struct
             {

--- a/middleware/gateway/include/gateway/message/protocol/transform.h
+++ b/middleware/gateway/include/gateway/message/protocol/transform.h
@@ -29,7 +29,7 @@ namespace casual
          result.parent = std::move( message.parent.service);
          result.pending = message.pending;
          result.service.name = std::move( message.service.name);
-         result.service.timeout.duration = message.deadline.remaining.value_or( platform::time::unit{});
+         result.service.timeout.duration = message.deadline.remaining.value_or( common::chronology::duration{});
          result.trid = std::move( message.trid);
          return result;
       }
@@ -45,7 +45,7 @@ namespace casual
          result.pending = message.pending;
          result.service.name = std::move( message.service.name);
          
-         if( message.service.timeout.duration > platform::time::unit{})
+         if( message.service.timeout.duration > common::chronology::duration{})
             result.deadline.remaining = message.service.timeout.duration;
 
          result.trid = std::move( message.trid);
@@ -85,7 +85,7 @@ namespace casual
          result.parent = std::move( message.parent.service);
          result.pending = message.pending;
          result.service.name = std::move( message.service.name);
-         result.service.timeout.duration = message.deadline.remaining.value_or( platform::time::unit{});
+         result.service.timeout.duration = message.deadline.remaining.value_or( common::chronology::duration{});
          result.trid = std::move( message.trid);
          return result;
       }
@@ -100,7 +100,7 @@ namespace casual
          result.pending = message.pending;
          result.service.name = std::move( message.service.name);
          
-         if( message.service.timeout.duration > platform::time::unit{})
+         if( message.service.timeout.duration > common::chronology::duration{})
             result.deadline.remaining = message.service.timeout.duration;
          
          result.trid = std::move( message.trid);

--- a/middleware/gateway/source/documentation/protocol/example.cpp
+++ b/middleware/gateway/source/documentation/protocol/example.cpp
@@ -81,7 +81,7 @@ namespace casual
                {
                   constexpr auto point()
                   {
-                     return platform::time::point::type{ std::chrono::microseconds{ 1559762216552100}};
+                     return common::chronology::time_point{ std::chrono::microseconds{ 1559762216552100}};
                   }
                } // time
 

--- a/middleware/gateway/source/group/outbound/handle.cpp
+++ b/middleware/gateway/source/group/outbound/handle.cpp
@@ -189,7 +189,7 @@ namespace casual
                               std::string service;
                               execution::context::Parent parent;
                               common::transaction::ID trid;
-                              platform::time::point::type start;
+                              common::chronology::time_point start;
                            };
 
                            state.multiplex.send( message.process.ipc, reply);
@@ -220,7 +220,7 @@ namespace casual
                               execution::context::Parent parent;
                               strong::ipc::id ipc;
                               common::transaction::ID trid;
-                              platform::time::point::type start;
+                              common::chronology::time_point start;
                            };
 
                            // NOTE: the parent span in the message is our current actual span. The provided parent is the one from the caller (was in the message).
@@ -322,7 +322,7 @@ namespace casual
                               std::string service;
                               execution::context::Parent parent;
                               strong::ipc::id ipc;
-                              platform::time::point::type start;
+                              common::chronology::time_point start;
                               common::transaction::ID trid;
 
                            };

--- a/middleware/gateway/source/manager/admin/cli.cpp
+++ b/middleware/gateway/source/manager/admin/cli.cpp
@@ -84,8 +84,8 @@ namespace casual
 
                auto created = []( auto& value) -> std::string
                {
-                  if( value.created != platform::time::point::limit::zero())
-                     return chronology::utc::offset( value.created);
+                  if( value.created != common::chronology::empty())
+                     return common::chronology::utc::offset( value.created);
 
                   return "-";
                };

--- a/middleware/gateway/unittest/include/gateway/unittest/utility.h
+++ b/middleware/gateway/unittest/include/gateway/unittest/utility.h
@@ -186,7 +186,7 @@ namespace casual
                {
                   return common::algorithm::count_if( state.listeners, []( auto& listener)
                   {
-                     return listener.created > platform::time::point::type{};
+                     return listener.created > common::chronology::time_point{};
                   }) == count;
 
                };

--- a/middleware/gateway/unittest/source/test_manager.cpp
+++ b/middleware/gateway/unittest/source/test_manager.cpp
@@ -1172,7 +1172,7 @@ domain:
 
             ASSERT_TRUE( metrics.size() == count) << CASUAL_NAMED_VALUE( metrics);
             // all should be 0 pending
-            EXPECT_TRUE(( algorithm::all_of( metrics, []( auto& metric){ return metric.pending == platform::time::unit::zero();})));
+            EXPECT_TRUE(( algorithm::all_of( metrics, []( auto& metric){ return metric.pending == common::chronology::duration::zero();})));
          }
 
       }

--- a/middleware/http/include/http/outbound/state.h
+++ b/middleware/http/include/http/outbound/state.h
@@ -63,7 +63,7 @@ namespace casual
                   common::strong::correlation::id correlation;
                   common::strong::execution::id execution;
                   common::strong::execution::span::id span;
-                  platform::time::point::type start = platform::time::point::limit::zero();
+                  common::chronology::time_point start = common::chronology::empty();
                   std::string service;
                   common::execution::context::Parent parent;
                   common::transaction::ID trid;

--- a/middleware/queue/include/queue/api/message.h
+++ b/middleware/queue/include/queue/api/message.h
@@ -11,6 +11,7 @@
 #include "common/serialize/macro.h"
 #include "casual/platform.h"
 #include "common/uuid.h"
+#include "common/chronology.h"
 
 #include <string>
 
@@ -52,7 +53,7 @@ namespace casual
          std::string reply;
 
          //! When the message is available, in absolute time.
-         platform::time::point::type available = platform::time::point::limit::zero();
+         common::chronology::time_point available = common::chronology::empty();
 
          CASUAL_CONST_CORRECT_SERIALIZE(
             CASUAL_SERIALIZE( properties);
@@ -146,7 +147,7 @@ namespace casual
 
 
                size_type redelivered;
-               platform::time::point::type timestamp;
+               common::chronology::time_point timestamp;
 
 
                CASUAL_CONST_CORRECT_SERIALIZE(

--- a/middleware/queue/include/queue/common/ipc/message.h
+++ b/middleware/queue/include/queue/common/ipc/message.h
@@ -24,7 +24,7 @@ namespace casual
       struct Retry 
       {
          platform::size::type count{};
-         platform::time::unit delay{};
+         common::chronology::duration delay{};
 
          CASUAL_CONST_CORRECT_SERIALIZE(
             CASUAL_SERIALIZE( count);
@@ -275,7 +275,7 @@ namespace casual
       {
          std::string properties;
          std::string reply;
-         platform::time::point::type available;
+         common::chronology::time_point available;
 
          inline auto tie() const noexcept { return std::tie( properties, reply, available);}
          
@@ -439,7 +439,7 @@ namespace casual
                ipc::message::Attributes attributes;
                ipc::message::Payload payload;
                platform::size::type redelivered{};
-               platform::time::point::type timestamp;
+               common::chronology::time_point timestamp;
 
                CASUAL_CONST_CORRECT_SERIALIZE(
                   CASUAL_SERIALIZE( id);
@@ -665,7 +665,7 @@ namespace casual
                   platform::size::type count{};
                   platform::size::type size{};
                   platform::size::type uncommitted{};
-                  platform::time::point::type last;
+                  common::chronology::time_point last;
                   platform::size::type dequeued{};
                   platform::size::type enqueued{};
 
@@ -688,7 +688,7 @@ namespace casual
                Retry retry;
                common::strong::queue::id error;
                queue::Metric metric;
-               platform::time::point::type created;
+               common::chronology::time_point created;
 
                inline queue::Type type() const { return  error ? queue::Type::queue : queue::Type::error_queue;}
 
@@ -775,11 +775,11 @@ namespace casual
                std::string reply;
                message::State state;
                platform::binary::type trid;
-               platform::time::point::type available;
+               common::chronology::time_point available;
                platform::size::type redelivered;
                std::string type;
                platform::size::type size;
-               platform::time::point::type timestamp;
+               common::chronology::time_point timestamp;
 
                CASUAL_CONST_CORRECT_SERIALIZE(
                   CASUAL_SERIALIZE( id);
@@ -901,7 +901,7 @@ namespace casual
 
                   //! Should be set to the last browsed message timestamp (or nothing if it's the first request),
                   //! hence act as the pivot point of which messages to browse.
-                  platform::time::point::type last{};
+                  common::chronology::time_point last{};
 
                   CASUAL_CONST_CORRECT_SERIALIZE(
                      base_request::serialize( archive);
@@ -1079,7 +1079,7 @@ namespace casual
                   struct Count
                   {
                      platform::size::type count = 0;
-                     platform::time::point::type last{};
+                     common::chronology::time_point last{};
 
                      CASUAL_CONST_CORRECT_SERIALIZE(
                         CASUAL_SERIALIZE( count);
@@ -1101,7 +1101,7 @@ namespace casual
                   struct Target
                   {
                      std::string queue;
-                     platform::time::unit delay{};
+                     common::chronology::duration delay{};
 
                      CASUAL_CONST_CORRECT_SERIALIZE(
                         CASUAL_SERIALIZE( queue);

--- a/middleware/queue/include/queue/forward/state.h
+++ b/middleware/queue/include/queue/forward/state.h
@@ -82,7 +82,7 @@ namespace casual
             {
                struct Target : Source
                {
-                  platform::time::unit delay{};
+                  common::chronology::duration delay{};
 
                   CASUAL_LOG_SERIALIZE(
                      Source::serialize( archive);
@@ -126,7 +126,7 @@ namespace casual
                struct Count
                {
                   platform::size::type count = 0;
-                  platform::time::point::type last{};
+                  common::chronology::time_point last{};
 
                   CASUAL_CONST_CORRECT_SERIALIZE(
                      CASUAL_SERIALIZE( count);

--- a/middleware/queue/include/queue/group/queuebase.h
+++ b/middleware/queue/include/queue/group/queuebase.h
@@ -39,7 +39,7 @@ namespace casual
             struct Retry 
             {
                platform::size::type count{};
-               platform::time::unit delay{};
+               common::chronology::duration delay{};
 
                CASUAL_CONST_CORRECT_SERIALIZE(
                   CASUAL_SERIALIZE( count);
@@ -89,7 +89,7 @@ namespace casual
             {
                common::strong::queue::id queue;
                platform::size::type count;
-               platform::time::point::type when;
+               common::chronology::time_point when;
 
                inline friend bool operator == ( const Available& lhs, common::strong::queue::id rhs) { return lhs.queue == rhs;}
                
@@ -139,7 +139,7 @@ namespace casual
          
          queue::ipc::message::group::dequeue::Reply dequeue( 
             const queue::ipc::message::group::dequeue::Request& request, 
-            const platform::time::point::type& now);
+            const common::chronology::time_point& now);
 
          //! 'meta peek' to get information about messages
          queue::ipc::message::group::message::meta::peek::Reply peek( const queue::ipc::message::group::message::meta::peek::Request& request);
@@ -149,13 +149,13 @@ namespace casual
          //! browse the next message
          queue::ipc::message::group::message::browse::Reply browse( 
             const queue::ipc::message::group::message::browse::Request& request,
-            const platform::time::point::type& now);
+            const common::chronology::time_point& now);
 
          //! @returns all queues that is found in `queues` and has messages potentially available for dequeue
          std::vector< queuebase::message::Available> available( std::vector< common::strong::queue::id> queues) const;
 
          //! @returns the earliest available message in the queue, if any.
-         std::optional< platform::time::point::type> available( common::strong::queue::id queue) const;
+         std::optional< common::chronology::time_point> available( common::strong::queue::id queue) const;
 
          //! @return number of restored messages for the queue
          platform::size::type restore( common::strong::queue::id id);

--- a/middleware/queue/include/queue/manager/admin/model.h
+++ b/middleware/queue/include/queue/manager/admin/model.h
@@ -102,7 +102,7 @@ namespace casual
          struct Retry 
          {
             platform::size::type count = 0;
-            platform::time::unit delay{};
+            common::chronology::duration delay{};
 
             CASUAL_CONST_CORRECT_SERIALIZE(
                CASUAL_SERIALIZE( count);
@@ -146,8 +146,8 @@ namespace casual
 
          } metric;
 
-         platform::time::point::type last;
-         platform::time::point::type created;
+         common::chronology::time_point last;
+         common::chronology::time_point created;
 
          CASUAL_CONST_CORRECT_SERIALIZE(
             CASUAL_SERIALIZE( group);
@@ -191,7 +191,7 @@ namespace casual
             struct Count
             {
                platform::size::type count{};
-               platform::time::point::type last{};
+               common::chronology::time_point last{};
 
                CASUAL_CONST_CORRECT_SERIALIZE(
                   CASUAL_SERIALIZE( count);
@@ -216,7 +216,7 @@ namespace casual
             struct Target
             {
                std::string queue;
-               platform::time::unit delay{};
+               common::chronology::duration delay{};
 
                CASUAL_CONST_CORRECT_SERIALIZE(
                   CASUAL_SERIALIZE( queue);
@@ -335,8 +335,8 @@ namespace casual
          platform::size::type redelivered;
          std::string type;
 
-         platform::time::point::type available;
-         platform::time::point::type timestamp;
+         common::chronology::time_point available;
+         common::chronology::time_point timestamp;
 
          platform::size::type size;
 

--- a/middleware/queue/source/c/queue.cpp
+++ b/middleware/queue/source/c/queue.cpp
@@ -184,7 +184,7 @@ namespace casual
                   {
                      auto set( descriptor::id descriptor, std::chrono::milliseconds time)
                      {
-                        global::cache.get( descriptor).value.attributes.available = platform::time::point::type{ time};
+                        global::cache.get( descriptor).value.attributes.available = common::chronology::time_point{ time};
                         return 0;
                      }
 

--- a/middleware/queue/source/forward/handle.cpp
+++ b/middleware/queue/source/forward/handle.cpp
@@ -568,7 +568,7 @@ namespace casual
                            request.message.id = uuid::make();
 
                            
-                           if( forward->target.delay > platform::time::unit::zero())
+                           if( forward->target.delay > common::chronology::duration::zero())
                               request.message.attributes.available = platform::time::clock::type::now() + forward->target.delay;
 
                            log::debug( "enqueue request: ", request);
@@ -756,7 +756,7 @@ namespace casual
                               request.message.payload.type = std::move( message.buffer.type);
                               request.message.payload.data = std::move( message.buffer.data);
 
-                              if( reply.delay > platform::time::unit::zero())
+                              if( reply.delay > common::chronology::duration::zero())
                                  request.message.attributes.available = platform::time::clock::type::now() + reply.delay;
 
                               log::debug( "enqueue reply: ", request);

--- a/middleware/queue/source/group/queuebase.cpp
+++ b/middleware/queue/source/group/queuebase.cpp
@@ -408,7 +408,7 @@ namespace casual
 
       queue::ipc::message::group::dequeue::Reply Queuebase::dequeue( 
          const queue::ipc::message::group::dequeue::Request& message, 
-         const platform::time::point::type& now)
+         const common::chronology::time_point& now)
       {
          Trace trace{ "queue::Queuebase::dequeue"};
 
@@ -511,7 +511,7 @@ namespace casual
 
       queue::ipc::message::group::message::browse::Reply Queuebase::browse( 
          const queue::ipc::message::group::message::browse::Request& request,
-         const platform::time::point::type& now)
+         const common::chronology::time_point& now)
       {
          Trace trace{ "queue::Queuebase::browse"};
 
@@ -562,7 +562,7 @@ namespace casual
          return result;
       }
 
-      std::optional< platform::time::point::type> Queuebase::available( common::strong::queue::id queue) const
+      std::optional< common::chronology::time_point> Queuebase::available( common::strong::queue::id queue) const
       {
          Trace trace{ "queue::Queuebase::available earliest"};
          log::debug( "queue: ", queue);
@@ -573,7 +573,7 @@ namespace casual
          if( ! query.fetch( row))
             return {};
 
-         std::optional< platform::time::point::type> available;
+         std::optional< common::chronology::time_point> available;
 
          // "SELECT MIN( m.available)"
          sql::database::row::get( row, 

--- a/middleware/queue/source/manager/admin/cli.cpp
+++ b/middleware/queue/source/manager/admin/cli.cpp
@@ -65,10 +65,10 @@ namespace casual
 
             namespace normalize
             {
-               std::string timestamp( const platform::time::point::type& time)
+               std::string timestamp( const common::chronology::time_point& time)
                {
-                  if( time != platform::time::point::limit::zero())
-                     return chronology::utc::offset( time);
+                  if( time != common::chronology::empty())
+                     return common::chronology::utc::offset( time);
 
                   return "-";;
                }
@@ -650,7 +650,7 @@ namespace casual
                      {
                         return terminal::format::column( "last", [&state]( auto& group)
                         { 
-                           platform::time::point::type result{};
+                           common::chronology::time_point result{};
                            auto last = [&result, pid = group.process.pid]( auto& forward)
                            {
                               auto max = std::max( forward.metric.commit.last, forward.metric.rollback.last);
@@ -1449,7 +1449,7 @@ casual queue --peek <queue-name> <id1> <id2> | <some other part of casual-pipe> 
                            else if( name == "reply")
                               message.attributes.reply = value;
                            else if( name == "available")
-                              message.attributes.available = platform::time::point::type{ chronology::from::string( value)};
+                              message.attributes.available = common::chronology::time_point{ common::chronology::from::string( value)};
                            else
                               common::code::raise::error( common::code::casual::invalid_argument, "'", name, "' is not part of the valid set: ", attributes::names());
                         }
@@ -1494,7 +1494,7 @@ casual queue --peek <queue-name> <id1> <id2> | <some other part of casual-pipe> 
                         return algorithm::container::create< std::vector< std::string>>( attributes::names());   //{ "properties", "reply", "available"};
                      
                      if( ! values.empty() && range::back( values) == "available")
-                        return { chronology::to::string( std::chrono::duration_cast< std::chrono::seconds>( platform::time::clock::type::now().time_since_epoch()))};
+                        return { common::chronology::to::string( std::chrono::duration_cast< std::chrono::seconds>( platform::time::clock::type::now().time_since_epoch()))};
 
                      if( ! values.empty() && range::back( values) == "reply")
                         return local::queues();

--- a/middleware/queue/unittest/source/test_queue.cpp
+++ b/middleware/queue/unittest/source/test_queue.cpp
@@ -419,7 +419,7 @@ domain:
       {
          namespace
          {
-            bool compare( const platform::time::point::type& lhs, const platform::time::point::type& rhs)
+            bool compare( const common::chronology::time_point& lhs, const common::chronology::time_point& rhs)
             {
                return std::chrono::time_point_cast< std::chrono::microseconds>( lhs)
                      == std::chrono::time_point_cast< std::chrono::microseconds>( rhs);

--- a/middleware/service/include/casual/service/manager/api/model.h
+++ b/middleware/service/include/casual/service/manager/api/model.h
@@ -79,7 +79,7 @@ namespace casual
                   model::Metric invoked;
                   model::Metric pending;
 
-                  platform::time::point::type last = platform::time::point::limit::zero();
+                  platform::time::clock::type::time_point last = {};
                   platform::size::type remote = 0;
                };
 

--- a/middleware/service/include/service/call/context.h
+++ b/middleware/service/include/service/call/context.h
@@ -83,8 +83,8 @@ namespace casual
          bool pending() const;
 
          //! set deadline for calls.
-         void deadline( platform::time::point::type now, std::optional< platform::time::unit> timeout);
-         std::optional< platform::time::point::type> deadline() const;
+         void deadline( common::chronology::time_point now, std::optional< common::chronology::duration> timeout);
+         std::optional< common::chronology::time_point> deadline() const;
 
       private:
          Context();

--- a/middleware/service/include/service/call/state.h
+++ b/middleware/service/include/service/call/state.h
@@ -9,6 +9,7 @@
 #include "casual/platform.h"
 #include "common/strong/id.h"
 #include "common/strong/type.h"
+#include "common/chronology.h"
 
 #include "common/service/type.h"
 
@@ -75,7 +76,7 @@ namespace casual
       struct State
       {
          state::Pending pending;
-         std::optional< platform::time::point::type> deadline;
+         std::optional< common::chronology::time_point> deadline;
       };
 
    } // service::call

--- a/middleware/service/include/service/lookup.h
+++ b/middleware/service/include/service/lookup.h
@@ -42,12 +42,12 @@ namespace casual
       {                        
          //! Lookup an entry point for the `service`. `trid` represent the current transaction to give
          //! SM a chance to keep calls within the same transaction to end up at the same destination.
-         Lookup( std::string service, const common::transaction::ID& trid, std::optional< platform::time::point::type> deadline = {});
+         Lookup( std::string service, const common::transaction::ID& trid, std::optional< common::chronology::time_point> deadline = {});
 
          //! Lookup an entry point for the `service`. `trid` represent the current transaction to give
          //! SM a chance to keep calls within the same transaction to end up at the same destination.
          //! `context` could be used for specific semantics.
-         Lookup( std::string service, const common::transaction::ID& trid, lookup::Context context, std::optional< platform::time::point::type> deadline = {});
+         Lookup( std::string service, const common::transaction::ID& trid, lookup::Context context, std::optional< common::chronology::time_point> deadline = {});
 
          //! If pending lookup discard it.
          ~Lookup();

--- a/middleware/service/include/service/manager/admin/model.h
+++ b/middleware/service/include/service/manager/admin/model.h
@@ -106,7 +106,7 @@ namespace casual
             model::Metric invoked;
             model::Metric pending;
 
-            platform::time::point::type last = platform::time::point::limit::zero();
+            common::chronology::time_point last = common::chronology::empty();
             platform::size::type remote = 0;
 
             CASUAL_CONST_CORRECT_SERIALIZE(

--- a/middleware/service/include/service/manager/state.h
+++ b/middleware/service/include/service/manager/state.h
@@ -229,11 +229,11 @@ namespace casual
             {
                struct Lookup
                {
-                  Lookup( common::message::service::lookup::Request request, platform::time::point::type when)
+                  Lookup( common::message::service::lookup::Request request, common::chronology::time_point when)
                   : request{ std::move( request)}, when{ when} {}
 
                   common::message::service::lookup::Request request;
-                  platform::time::point::type when;
+                  common::chronology::time_point when;
 
                   inline friend bool operator == ( const Lookup& lhs, const common::strong::correlation::id& rhs) { return lhs.request == rhs;}
                   inline friend bool operator == ( const Lookup& lhs, const std::string& service) { return lhs.request.requested == service;}
@@ -248,7 +248,7 @@ namespace casual
                {
                   struct Entry
                   {   
-                     platform::time::point::type when;
+                     common::chronology::time_point when;
                      common::strong::correlation::id correlation;
                      //! The actual instance that the timeout refers to.
                      instance::sequential::id::type target;
@@ -269,16 +269,16 @@ namespace casual
 
                struct Deadline
                {      
-                  std::optional< platform::time::point::type> add( deadline::Entry entry);
-                  std::optional< platform::time::point::type> remove( const common::strong::correlation::id& correlation);
-                  std::optional< platform::time::point::type> remove( const std::vector< common::strong::correlation::id>& correlations);
+                  std::optional< common::chronology::time_point> add( deadline::Entry entry);
+                  std::optional< common::chronology::time_point> remove( const common::strong::correlation::id& correlation);
+                  std::optional< common::chronology::time_point> remove( const std::vector< common::strong::correlation::id>& correlations);
 
                   deadline::Entry* find_entry( const common::strong::correlation::id& correlation);
 
                   struct Expired
                   {
                      std::vector< deadline::Entry> entries;
-                     std::optional< platform::time::point::type> deadline;
+                     std::optional< common::chronology::time_point> deadline;
 
                      CASUAL_LOG_SERIALIZE(
                         CASUAL_SERIALIZE( entries);
@@ -286,7 +286,7 @@ namespace casual
                      )
                   };
 
-                  Expired expired( platform::time::point::type now = platform::time::point::type::clock::now());
+                  Expired expired( common::chronology::time_point now = common::chronology::time_point::clock::now());
 
                   CASUAL_LOG_SERIALIZE( 
                      CASUAL_SERIALIZE_NAME( m_entries, "entries");
@@ -369,7 +369,7 @@ namespace casual
                //! Keeps track of the pending metrics for this service
                common::Metric pending;
 
-               platform::time::point::type last = platform::time::point::limit::zero();
+               common::chronology::time_point last = common::chronology::empty();
 
                // remote invocations
                platform::size::type remote = 0;

--- a/middleware/service/source/call/context.cpp
+++ b/middleware/service/source/call/context.cpp
@@ -56,7 +56,7 @@ namespace casual
                   common::message::service::call::caller::Request message;
                };
 
-               auto lookup( std::string service, async::Flag flags, const std::optional< platform::time::point::type>& deadline)
+               auto lookup( std::string service, async::Flag flags, const std::optional< common::chronology::time_point>& deadline)
                {
                   common::Trace trace( "service::call::local::prepare::lookup");
 
@@ -375,7 +375,7 @@ namespace casual
          return ! m_state.pending.empty();
       }
 
-      void Context::deadline( platform::time::point::type now, std::optional< platform::time::unit> timeout)
+      void Context::deadline( common::chronology::time_point now, std::optional< common::chronology::duration> timeout)
       {
          if( timeout)
             m_state.deadline = now + *timeout;
@@ -383,7 +383,7 @@ namespace casual
             m_state.deadline = std::nullopt;
       }
 
-      std::optional< platform::time::point::type> Context::deadline() const
+      std::optional< common::chronology::time_point> Context::deadline() const
       {
          return m_state.deadline;
       }

--- a/middleware/service/source/lookup.cpp
+++ b/middleware/service/source/lookup.cpp
@@ -92,7 +92,7 @@ namespace casual
   
       } // lookup
 
-      Lookup::Lookup( std::string service, const common::transaction::ID& trid, lookup::Context context, std::optional< platform::time::point::type> deadline)
+      Lookup::Lookup( std::string service, const common::transaction::ID& trid, lookup::Context context, std::optional< common::chronology::time_point> deadline)
          : m_service( std::move( service))
       {
          Trace trace{ "common::service::Lookup"};
@@ -106,7 +106,7 @@ namespace casual
          m_correlation = common::communication::device::blocking::send( common::communication::instance::outbound::service::manager::device(), request);
       }
 
-      Lookup::Lookup( std::string service, const common::transaction::ID& trid, std::optional< platform::time::point::type> deadline) 
+      Lookup::Lookup( std::string service, const common::transaction::ID& trid, std::optional< common::chronology::time_point> deadline) 
          : Lookup( std::move( service), trid, lookup::Context{}, std::move( deadline)) 
       {}
 

--- a/middleware/service/source/manager/admin/cli.cpp
+++ b/middleware/service/source/manager/admin/cli.cpp
@@ -169,7 +169,7 @@ namespace casual
 
                      auto format_timeout_duration_string = []( const auto& value) -> std::string
                      {
-                        if( ! value.execution.timeout.duration || *value.execution.timeout.duration == platform::time::unit::zero())
+                        if( ! value.execution.timeout.duration || *value.execution.timeout.duration == common::chronology::duration::zero())
                            return empty_representation(); 
                         using second_t = std::chrono::duration< double>;
                         return std::to_string( std::chrono::duration_cast< second_t>( value.execution.timeout.duration.value()).count());
@@ -262,7 +262,7 @@ namespace casual
 
                      auto format_last = []( const admin::model::Service& value) -> std::string
                      {
-                        if( value.metric.last == platform::time::point::limit::zero())
+                        if( value.metric.last == common::chronology::empty())
                            return empty_representation();
 
                         return common::chronology::utc::offset( value.metric.last);

--- a/middleware/service/source/manager/handle.cpp
+++ b/middleware/service/source/manager/handle.cpp
@@ -404,7 +404,7 @@ namespace casual
 
                namespace detail
                {
-                  auto calculate_deadline( const state::Service& service, platform::time::point::type now, std::optional< platform::time::point::type> caller_deadline) -> std::optional< platform::time::point::type>
+                  auto calculate_deadline( const state::Service& service, common::chronology::time_point now, std::optional< common::chronology::time_point> caller_deadline) -> std::optional< common::chronology::time_point>
                   {
                      if( service.timeout.duration && service.timeout.duration > std::chrono::microseconds{ 0})
                      {
@@ -460,7 +460,7 @@ namespace casual
                         state.multiplex.send( message.process.ipc, reply);
                      }
 
-                     void reply( State& state, state::service::id::type service_id, auto instance_id, common::message::service::lookup::Request& message, platform::time::unit pending)
+                     void reply( State& state, state::service::id::type service_id, auto instance_id, common::message::service::lookup::Request& message, common::chronology::duration pending)
                      {
                         Trace trace{ "service::manager::handle::local::service::detail::dispatch::lookup::reply"};
                         common::log::debug( "'reserved' instance: ", instance_id);
@@ -581,7 +581,7 @@ namespace casual
                         }
                      }
 
-                     bool internal_only( State& state, state::service::id::type service_id, common::message::service::lookup::Request& message, platform::time::unit pending)
+                     bool internal_only( State& state, state::service::id::type service_id, common::message::service::lookup::Request& message, common::chronology::duration pending)
                      {
                         Trace trace{ "service::manager::handle::local::service::detail::dispatch::lookup::internal_only"};
 
@@ -603,7 +603,7 @@ namespace casual
                         return false;
                      }
 
-                     bool external_internal( State& state, state::service::id::type service_id, common::message::service::lookup::Request& message, platform::time::unit pending)
+                     bool external_internal( State& state, state::service::id::type service_id, common::message::service::lookup::Request& message, common::chronology::duration pending)
                      {
                          Trace trace{ "service::manager::handle::local::service::detail::dispatch::lookup::external_internal"};
 
@@ -651,7 +651,7 @@ namespace casual
                      
                   } // dispatch::lookup
 
-                  void lookup( State& state, common::message::service::lookup::Request& message, platform::time::unit pending = {})
+                  void lookup( State& state, common::message::service::lookup::Request& message, common::chronology::duration pending = {})
                   {
                      Trace trace{ "service::manager::handle::local::service::detail::lookup"};
                      common::log::debug( "message: ", message, ", pending: ", pending);

--- a/middleware/service/source/manager/state.cpp
+++ b/middleware/service/source/manager/state.cpp
@@ -207,7 +207,7 @@ namespace casual
             namespace pending
             {
              
-               std::optional< platform::time::point::type> Deadline::add( deadline::Entry entry)
+               std::optional< common::chronology::time_point> Deadline::add( deadline::Entry entry)
                {
                   auto inserted = m_entries.insert(
                      std::upper_bound( std::begin( m_entries), std::end( m_entries), entry),
@@ -219,7 +219,7 @@ namespace casual
                   return { inserted->when};
                }
 
-               std::optional< platform::time::point::type> Deadline::remove( const strong::correlation::id& correlation)
+               std::optional< common::chronology::time_point> Deadline::remove( const strong::correlation::id& correlation)
                {
                   if( auto found = algorithm::find( m_entries, correlation))
                   {
@@ -229,7 +229,7 @@ namespace casual
                   return {};
                }
 
-               std::optional< platform::time::point::type> Deadline::remove( const std::vector< strong::correlation::id>& correlations)
+               std::optional< common::chronology::time_point> Deadline::remove( const std::vector< strong::correlation::id>& correlations)
                {
 
                   auto [ keep, remove] = algorithm::stable::partition( m_entries, [&correlations]( auto& entry)
@@ -252,7 +252,7 @@ namespace casual
                   return algorithm::find( m_entries, correlation).data();
                }
 
-               Deadline::Expired Deadline::expired( platform::time::point::type now)
+               Deadline::Expired Deadline::expired( common::chronology::time_point now)
                {
                   auto pivot = std::find_if( std::begin( m_entries), std::end( m_entries), [now]( auto& entry)
                   {
@@ -279,7 +279,7 @@ namespace casual
 
          bool Service::timeoutable() const noexcept   
          {
-            return has_sequential() && timeout.duration > platform::time::unit::zero();
+            return has_sequential() && timeout.duration > common::chronology::duration::zero();
          }
 
          
@@ -796,7 +796,7 @@ namespace casual
             auto add_service = [&]( auto& service)
             {
                configuration::model::service::Timeout timeout;
-               if( service.timeout.duration > platform::time::unit::zero())
+               if( service.timeout.duration > common::chronology::duration::zero())
                   timeout.duration = service.timeout.duration;
 
                auto relate_service_and_instance = [ &]( auto service_id, auto instance_id)

--- a/middleware/transaction/include/transaction/context.h
+++ b/middleware/transaction/include/transaction/context.h
@@ -65,7 +65,7 @@ namespace casual
          [[nodiscard]] commit::Return get_commit_return() const noexcept;
          
          [[nodiscard]] code::tx set_transaction_control( transaction::Control control);
-         [[nodiscard]] code::tx set_transaction_timeout( platform::time::unit timeout);
+         [[nodiscard]] code::tx set_transaction_timeout( common::chronology::duration timeout);
          
          bool info( TXINFO* info);
          //! @}
@@ -152,7 +152,7 @@ namespace casual
          } m_resources;
 
 
-         platform::time::unit m_timeout{};
+         common::chronology::duration m_timeout{};
 
          Context();
          ~Context();

--- a/middleware/transaction/include/transaction/manager/admin/model.h
+++ b/middleware/transaction/include/transaction/manager/admin/model.h
@@ -22,12 +22,12 @@ namespace casual
       struct Metric
       {
          platform::size::type count = 0;
-         platform::time::unit total{};
+         common::chronology::duration total{};
 
          struct Limit 
          {
-            platform::time::unit min{};
-            platform::time::unit max{};
+            common::chronology::duration min{};
+            common::chronology::duration max{};
 
             CASUAL_CONST_CORRECT_SERIALIZE(
                CASUAL_SERIALIZE( min);
@@ -167,7 +167,7 @@ namespace casual
             common::strong::resource::id resource;
             common::strong::correlation::id correlation;
             common::message::Type type;
-            platform::time::point::type created{};
+            common::chronology::time_point created{};
 
             CASUAL_CONST_CORRECT_SERIALIZE(
                CASUAL_SERIALIZE( resource);

--- a/middleware/transaction/include/transaction/manager/log.h
+++ b/middleware/transaction/include/transaction/manager/log.h
@@ -82,8 +82,8 @@ namespace casual
          {
             common::transaction::ID trid;
             common::strong::process::id pid;
-            platform::time::point::type started;
-            platform::time::point::type updated;
+            common::chronology::time_point started;
+            common::chronology::time_point updated;
             State state = State::prepared;
          };
 

--- a/middleware/transaction/include/transaction/manager/state.h
+++ b/middleware/transaction/include/transaction/manager/state.h
@@ -90,7 +90,7 @@ namespace casual
 
                   void reserve();
                   //! used when requests has been pending.
-                  void reserve( platform::time::point::type requested);
+                  void reserve( common::chronology::time_point requested);
                   void unreserve( const common::message::Statistics& statistics);
 
                   common::strong::resource::id id;
@@ -115,10 +115,10 @@ namespace casual
                   )
 
                private:
-                  void general_reserve( platform::time::point::type now);
+                  void general_reserve( common::chronology::time_point now);
 
                   instance::State m_state{};
-                  platform::time::point::type m_reserved{};
+                  common::chronology::time_point m_reserved{};
                   Metrics m_metrics;
                   common::Metric m_pending;
                };
@@ -312,8 +312,8 @@ namespace casual
 
             common::process::Handle owner;
 
-            platform::time::point::type started;
-            platform::time::point::type deadline;
+            common::chronology::time_point started;
+            common::chronology::time_point deadline;
 
 
 
@@ -343,7 +343,7 @@ namespace casual
 
                inline explicit operator bool() const noexcept { return common::predicate::boolean( complete);}
 
-               platform::time::point::type created{};
+               common::chronology::time_point created{};
                common::communication::ipc::message::Complete complete;
 
                inline const auto& correlation() const noexcept { return complete.correlation();}

--- a/middleware/transaction/include/transaction/transaction.h
+++ b/middleware/transaction/include/transaction/transaction.h
@@ -37,7 +37,7 @@ namespace casual
          explicit Transaction( ID trid);
 
          ID trid;
-         std::optional< platform::time::point::type> deadline;
+         std::optional< common::chronology::time_point> deadline;
          State state = State::active;
 
          //! @return true if `trid` is _active_ 

--- a/middleware/transaction/source/context.cpp
+++ b/middleware/transaction/source/context.cpp
@@ -261,11 +261,11 @@ namespace casual
                   return transaction;
                }
 
-               Transaction transaction( platform::time::unit timeout)
+               Transaction transaction( common::chronology::duration timeout)
                {
                   auto transaction = start::transaction();
 
-                  if( timeout > platform::time::unit{})
+                  if( timeout > common::chronology::duration{})
                      transaction.deadline = platform::time::clock::type::now() + timeout;
 
                   return transaction;
@@ -985,9 +985,9 @@ namespace casual
          return code::tx::ok;
       }
 
-      code::tx Context::set_transaction_timeout( platform::time::unit timeout)
+      code::tx Context::set_transaction_timeout( common::chronology::duration timeout)
       {
-         if( timeout < platform::time::unit{})
+         if( timeout < common::chronology::duration{})
             return local::log::code( code::tx::argument, "set_transaction_timeout - timeout value has to be 0 or greater");
 
          m_timeout = timeout;

--- a/middleware/transaction/source/manager/log.cpp
+++ b/middleware/transaction/source/manager/log.cpp
@@ -153,8 +153,8 @@ namespace casual
                   result.pid = common::strong::process::id{ row.get< platform::process::native::type>( 3)};
                   result.state = static_cast< Log::State>( row.get< long>( 4));
 
-                  result.started = platform::time::point::type{ std::chrono::microseconds{ row.get< platform::time::point::type::rep>( 5)}};
-                  result.updated = platform::time::point::type{ std::chrono::microseconds{ row.get< platform::time::point::type::rep>( 6)}};
+                  result.started = common::chronology::time_point{ std::chrono::microseconds{ row.get< common::chronology::time_point::rep>( 5)}};
+                  result.updated = common::chronology::time_point{ std::chrono::microseconds{ row.get< common::chronology::time_point::rep>( 6)}};
 
                   return result;
                }

--- a/middleware/transaction/source/manager/state.cpp
+++ b/middleware/transaction/source/manager/state.cpp
@@ -56,7 +56,7 @@ namespace casual
 
                } // instance
 
-               void Instance::general_reserve( platform::time::point::type now)
+               void Instance::general_reserve( common::chronology::time_point now)
                {
                   if( m_state != instance::State::idle)
                      common::code::raise::error( common::code::casual::invalid_semantics, "trying to reserve rm instance: ", process.pid, " in state: ", m_state);
@@ -70,7 +70,7 @@ namespace casual
                   general_reserve( platform::time::clock::type::now());
                }
 
-               void Instance::reserve( platform::time::point::type requested)
+               void Instance::reserve( common::chronology::time_point requested)
                {
                   auto now = platform::time::clock::type::now();
                   general_reserve( now);

--- a/middleware/transaction/unittest/include/transaction/unittest/rm.h
+++ b/middleware/transaction/unittest/include/transaction/unittest/rm.h
@@ -53,9 +53,9 @@ namespace casual
          std::vector< common::code::xa> errors;
          std::vector< state::Invoke> invocations;
 
-         std::optional< platform::time::unit> sleep_prepare;
-         std::optional< platform::time::unit> sleep_commit;
-         std::optional< platform::time::unit> sleep_rollback;
+         std::optional< common::chronology::duration> sleep_prepare;
+         std::optional< common::chronology::duration> sleep_commit;
+         std::optional< common::chronology::duration> sleep_rollback;
 
          CASUAL_LOG_SERIALIZE(
             CASUAL_SERIALIZE( id);

--- a/middleware/transaction/unittest/source/manager/test_state.cpp
+++ b/middleware/transaction/unittest/source/manager/test_state.cpp
@@ -18,7 +18,7 @@ namespace casual
       {
          namespace
          {
-            auto resource_roundtrip( platform::time::unit duration)
+            auto resource_roundtrip( common::chronology::duration duration)
             {
                // transport tm -> rm
                process::sleep( duration);
@@ -91,7 +91,7 @@ namespace casual
 
          auto pending = instance.pending();
          EXPECT_TRUE( pending.count == 0);
-         EXPECT_TRUE( pending.total == platform::time::unit{});
+         EXPECT_TRUE( pending.total == common::chronology::duration{});
       }
 
       TEST( transaction_manager_state, proxy_instance_pending)


### PR DESCRIPTION
This patch:
* defined time_point and duration in `chronology`
* serialize and stream customization defined in `chronology`
* use `chronology::time_point/duration` everywhere, instead of the removed platform definitions

This ensures when a time_point or duration is used, we serialize and stream (log) to correct format/representation

Resolves #552