### PR TITLE
domain: task events are not propagated correctly

### DIFF
--- a/middleware/administration/unittest/source/cli/test_domain.cpp
+++ b/middleware/administration/unittest/source/cli/test_domain.cpp
@@ -93,14 +93,27 @@ domain:
 
          // boot
          {
-            auto capture = administration::unittest::cli::command::execute( "casual domain --boot ", configuration);
+            auto capture = administration::unittest::cli::command::execute( "casual --color false domain --boot ", configuration);
             EXPECT_TRUE( capture) << CASUAL_NAMED_VALUE( capture);
+            
+            // test a few strings we expect in the output
+            EXPECT_TRUE( capture.standard.out.contains( "task: boot domain: A - started")) << CASUAL_NAMED_VALUE( capture.standard.out);
+            EXPECT_TRUE( capture.standard.out.contains( "  sub task: .casual.queue - started")) << CASUAL_NAMED_VALUE( capture.standard.out);
+            EXPECT_TRUE( capture.standard.out.contains( "  sub task: .casual.queue - done")) << CASUAL_NAMED_VALUE( capture.standard.out);
+            EXPECT_TRUE( capture.standard.out.contains( "task: boot domain: A - done")) << CASUAL_NAMED_VALUE( capture.standard.out);
+            
          }
 
          // shutdown
          {
-            auto capture = administration::unittest::cli::command::execute( "casual domain --shutdown");
+            auto capture = administration::unittest::cli::command::execute( "casual --color false domain --shutdown");
             EXPECT_TRUE( capture) << CASUAL_NAMED_VALUE( capture);
+
+            // test a few strings we expect in the output
+            EXPECT_TRUE( capture.standard.out.contains( "task: shutdown domain: A - started")) << CASUAL_NAMED_VALUE( capture.standard.out);
+            EXPECT_TRUE( capture.standard.out.contains( "  sub task: .casual.queue - started")) << CASUAL_NAMED_VALUE( capture.standard.out);
+            EXPECT_TRUE( capture.standard.out.contains( "  sub task: .casual.queue - done")) << CASUAL_NAMED_VALUE( capture.standard.out);
+            EXPECT_TRUE( capture.standard.out.contains( "task: shutdown domain: A - done")) << CASUAL_NAMED_VALUE( capture.standard.out);
          }
 
       }
@@ -368,6 +381,80 @@ z      error         -  -
          }
 
       }
+
+      TEST( cli_domain, scale_aliases)
+      {
+         common::unittest::Trace trace;
+         
+         auto domain = local::domain( R"(
+domain:
+   servers:
+      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+         memberships: [ user]
+         instances: 1
+)");
+            
+         {
+            auto capture = administration::unittest::cli::command::execute( "casual --color false domain --scale-aliases casual-example-server 2");
+            EXPECT_TRUE( capture) << CASUAL_NAMED_VALUE( capture);
+
+            // test a few strings we expect in the output
+            EXPECT_TRUE( capture.standard.out.contains( "task: scale aliases - started"));
+            EXPECT_TRUE( capture.standard.out.contains( "  sub task: scale - started"));
+            EXPECT_TRUE( capture.standard.out.contains( "  alias spawn: casual-example-server"));
+            EXPECT_TRUE( capture.standard.out.contains( "  sub task: scale - done"));
+            EXPECT_TRUE( capture.standard.out.contains( "task: scale aliases - done"));
+         }
+      }
+
+      TEST( cli_domain, restart_aliases)
+      {
+         common::unittest::Trace trace;
+         
+         auto domain = local::domain( R"(
+domain:
+   servers:
+      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+         memberships: [ user]
+         instances: 2
+)");
+            
+         {
+            auto capture = administration::unittest::cli::command::execute( "casual --color false domain --restart-aliases casual-example-server");
+            EXPECT_TRUE( capture) << CASUAL_NAMED_VALUE( capture);
+
+            // test a few strings we expect in the output
+            EXPECT_TRUE( capture.standard.out.contains( "task: restart aliases - started"));
+            EXPECT_TRUE( capture.standard.out.contains( "  sub task: casual-example-server - started"));
+            EXPECT_TRUE( capture.standard.out.contains( "  sub task: casual-example-server - done"));
+            EXPECT_TRUE( capture.standard.out.contains( "task: restart aliases - done"));
+
+         }
+         
+      }
+
+      TEST( cli_domain, restart_groups)
+      {
+         common::unittest::Trace trace;
+         
+         auto domain = local::domain( R"(
+domain:
+   servers:
+      -  path: "${CASUAL_MAKE_SOURCE_ROOT}/middleware/example/server/bin/casual-example-server"
+         memberships: [ user]
+         instances: 2
+)");
+
+         auto capture = administration::unittest::cli::command::execute( "casual --color false domain --restart-groups user");
+         EXPECT_TRUE( capture) << CASUAL_NAMED_VALUE( capture);
+
+         // test a few strings we expect in the output
+         EXPECT_TRUE( capture.standard.out.contains( "task: restart groups - started"));
+         EXPECT_TRUE( capture.standard.out.contains( "  sub task: casual-example-server - started"));
+         EXPECT_TRUE( capture.standard.out.contains( "  sub task: casual-example-server - done"));
+         EXPECT_TRUE( capture.standard.out.contains( "task: restart groups - done"));
+      }
+
 
       TEST( cli_domain, scale_out_to_5__expected_configured_instances_5)
       {

--- a/middleware/domain/include/domain/manager/state.h
+++ b/middleware/domain/include/domain/manager/state.h
@@ -301,8 +301,8 @@ namespace casual
             struct Group
             {
                std::string description;
-               std::vector< Server::id_type> servers;
-               std::vector< Executable::id_type> executables;
+               std::vector< strong::server::id> servers;
+               std::vector< strong::executable::id> executables;
 
                inline explicit operator bool() const noexcept { return ! servers.empty() || ! executables.empty();}
 

--- a/middleware/domain/source/manager/handle.cpp
+++ b/middleware/domain/source/manager/handle.cpp
@@ -149,8 +149,6 @@ namespace casual
                }
 
             } // scale
-
-
          } // <unnamed>
       } // local
 
@@ -260,27 +258,29 @@ namespace casual
             return event;
          });
 
-         // we need to send task event with the supplied correlation -> caller able to correlate
-         manager::task::event::dispatch( state, [ &correlation]()
+         auto description = string::compose( "boot domain: ", common::domain::identity().name);
+
+         // potentially send a "start event" for boot
+         manager::task::event::dispatch( state, [ &correlation, &description]()
          {
-               common::message::event::Task event{ common::process::handle()};
-               event.correlation = correlation;
-               event.description = "boot domain";
-               event.state = decltype( event.state)::started;
-               return event;
+            common::message::event::Task event{ common::process::handle()};
+            event.correlation = correlation;
+            event.description = description;
+            event.state = decltype( event.state)::started;
+            return event;
          });
 
          // make sure we sett runlevel when we're done.
-         auto done_callback = [ &state, correlation]( casual::task::unit::id)
+         auto done_callback = [ &state, correlation, description = std::move( description)]( casual::task::unit::id) mutable
          {
             state.runlevel = decltype( state.runlevel())::running;
 
             // we ignore the actual id of the task unit and use the supplied correlation -> caller able to correlate
-            manager::task::event::dispatch( state, [ &correlation]()
+            manager::task::event::dispatch( state, [ &correlation, &description]()
             {
                   common::message::event::Task event{ common::process::handle()};
                   event.correlation = correlation;
-                  event.description = "boot domain";
+                  event.description = description;
                   event.state = decltype( event.state)::done;
                   return event;
             });
@@ -301,8 +301,22 @@ namespace casual
          // abort all abortable running or pending task
          state.tasks.cancel();
 
+         // we send a 'start' task to the user. Only for CLI output purposes
+         auto correlation = strong::correlation::id::generate();
+         auto description = string::compose( "shutdown domain: ", common::domain::identity().name);
 
-         auto done_event = task::create::event::parent( state, string::compose( "shutdown domain: ", common::domain::identity()));
+         // potentially send a "start event" for shutdown
+         manager::task::event::dispatch( state, [ correlation, &description]()
+         {
+            common::message::event::Task event{ common::process::handle()};
+            event.correlation = correlation;
+            event.description = description;
+            event.state = decltype( event.state)::started;
+            return event;
+         });
+
+
+         auto done_event = task::create::event::parent( state, description);
 
          // prepare scaling to 0
          auto prepare_shutdown = []( auto& entity)
@@ -324,11 +338,19 @@ namespace casual
 
       namespace scale
       {
-
          void aliases( casual::manager::service::protocol::concurrent::Finalize< void> finalize, State& state, state::scale::Instances instances)
          {
             Trace trace{ "domain::manager::handle::scale::aliases"};
             log::debug( "instances: ", instances);
+
+            // potentially send a "start event" for scale aliases
+            manager::task::event::dispatch( state, []()
+            {
+               common::message::event::Task event{ common::process::handle()};
+               event.description = "scale aliases";
+               event.state = decltype( event.state)::started;
+               return event;
+            });
 
             auto done_event = task::create::event::parent( state, "scale aliases", [ finalize = std::move( finalize)]( const State&) mutable
             {
@@ -339,16 +361,19 @@ namespace casual
             {
                auto transform_id = []( auto& entity){ return entity.id;};
 
-               group.description = "scale aliases";
+               group.description = "scale";
                algorithm::transform( instances.servers, group.servers, transform_id);
                algorithm::transform( instances.executables, group.executables, transform_id);
             }
 
             auto prepare_task = manager::task::create::scale::prepare( state, std::move( instances));
 
-            auto scale_tasks = manager::task::create::scale::groups( state, { std::move( group)}); 
+            auto scale_tasks = manager::task::create::scale::groups( state, { std::move( group)});
 
-            state.tasks.then( std::move( prepare_task)).then( std::move( scale_tasks)).then( std::move( done_event));
+            state.tasks
+               .then( std::move( prepare_task))
+               .then( std::move( scale_tasks))
+               .then( std::move( done_event));
          }
 
          void shutdown( State& state, std::vector< common::process::Handle> processes)
@@ -410,6 +435,15 @@ namespace casual
             Trace trace{ "domain::manager::handle::restart::aliases"};
             log::debug( "aliases: ", aliases);
 
+            // potentially send a "start event" for restart aliases
+            manager::task::event::dispatch( state, []()
+            {
+               common::message::event::Task event{ common::process::handle()};
+               event.description = "restart aliases";
+               event.state = decltype( event.state)::started;
+               return event;
+            });
+            
             auto done_event = task::create::event::parent( state, "restart aliases", [ finalize = std::move( finalize)]( const State&) mutable
             {
                finalize();
@@ -418,6 +452,8 @@ namespace casual
             auto scalables = state.scalables( std::move( aliases));
 
             state::dependency::Group group{
+               // description is only used for the restart-exit scaling
+               .description = "resurrection",
                .servers = scalables.servers,
                .executables = scalables.executables,
             };
@@ -437,6 +473,15 @@ namespace casual
          {
             Trace trace{ "domain::manager::handle::restart::groups"};
             log::debug( "names: ", names);
+
+            // potentially send a "start event" for restart groups
+            manager::task::event::dispatch( state, []()
+            {
+               common::message::event::Task event{ common::process::handle()};
+               event.description = "restart groups";
+               event.state = decltype( event.state)::started;
+               return event;
+            });
 
             auto filter_groups = []( auto groups, const std::vector< std::string>& names)
             {

--- a/middleware/domain/source/manager/task/create.cpp
+++ b/middleware/domain/source/manager/task/create.cpp
@@ -38,12 +38,6 @@ namespace casual
                   auto task = casual::task::create::unit( 
                      [ &state, description, done = std::move( done)]( casual::task::unit::id id) mutable
                      {
-                        if( done)
-                           exception::guard( [ &state, &done]()
-                           {
-                              done( state);
-                           });
-
                         manager::task::event::dispatch( state, [ &id, &description]()
                         {
                            Event event{ common::process::handle()};
@@ -52,6 +46,14 @@ namespace casual
                            event.state = decltype( event.state)::done;
                            return event;
                         });
+
+                        if( done)
+                        {
+                           exception::guard( [ &state, &done]()
+                           {
+                              done( state);
+                           });
+                        }
 
                         return casual::task::unit::action::Outcome::abort;
                      }
@@ -445,6 +447,8 @@ namespace casual
                            Trace trace{ "domain::manager::task::create::scale::local::group::create_task action"};
                            log::debug( "action: ", id);
 
+                           *shared = action( state);
+
                            manager::task::event::dispatch( state, [&]()
                            {
                               common::message::event::sub::Task event{ common::process::handle()};
@@ -453,8 +457,6 @@ namespace casual
                               event.state = decltype( event.state)::started;
                               return event;
                            });
-
-                           *shared = action( state);
 
                            group::scale( state, *shared);
 
@@ -489,7 +491,7 @@ namespace casual
                   Trace trace{ "domain::manager::task::create::scale::prepare action"};
 
                   state.scale( instances);
-                  
+
                   // indicate that the whole task is done. via `abort` 
                   return casual::task::unit::action::Outcome::abort;
                }));


### PR DESCRIPTION
Before: We did not send `event::Task` _started_ during `boot`, `shutdown` `scale-aliases` and `scale-groups`
Now: We do

Added a few unittest to make sure we don't miss this in the future.