### PR TITLE
refactoring: improved and simplified terminal::format

### DIFF
--- a/middleware/administration/source/cli.cpp
+++ b/middleware/administration/source/cli.cpp
@@ -96,7 +96,7 @@ namespace casual
                      };
                      common::algorithm::for_each( managers, dispatch);
 
-                     common::terminal::formatter::key::value().print( std::cout, information);
+                     common::terminal::format::pair::print( information);
                   };
 
                   constexpr auto description = R"(collect general aggregated information about the domain
@@ -136,7 +136,7 @@ valid directives:
                         { "compiler", build_version.compiler}
                      };
 
-                     common::terminal::formatter::key::value().print( std::cout, version);
+                     common::terminal::format::pair::print( version);
                   };
                   return argument::Option{
                      std::move( invoke),
@@ -259,13 +259,11 @@ Note: only works for 'servers' with a message pump)"
 
                         auto reply = common::communication::ipc::call( address.at( 0).ipc, common::message::counter::Request( common::process::handle()));
 
-                        auto formatter = common::terminal::format::formatter< common::message::counter::Entry>::construct(
+                        common::terminal::format::print( reply.entries,
                            common::terminal::format::column( "type", []( auto& entry){ return entry.type;}, common::terminal::color::yellow),
                            common::terminal::format::column( "sent", []( auto& entry){ return entry.sent;}, common::terminal::color::cyan, common::terminal::format::Align::right),
                            common::terminal::format::column( "received", []( auto& entry){ return entry.received;}, common::terminal::color::cyan, common::terminal::format::Align::right)
-                        );  
-
-                        formatter.print( std::cout, reply.entries);
+                        );
                      };
 
                      return argument::Option{

--- a/middleware/common/include/common/terminal.h
+++ b/middleware/common/include/common/terminal.h
@@ -14,6 +14,7 @@
 
 #include <string>
 #include <ostream>
+#include <iostream>
 #include <iomanip>
 #include <vector>
 #include <sstream>
@@ -34,7 +35,7 @@ namespace casual
             bool header() const;
             //! user has used --header true explicitly
             //! @note this is to enable print header with porcelain -> not break backward compatible
-            bool explict_header() const;
+            bool explicit_header() const;
             inline auto precision() const { return m_precision;}
             inline auto block() const { return m_block;}
             inline auto verbose() const { return m_verbose;}
@@ -73,7 +74,7 @@ namespace casual
 
       struct Color
       {
-         explicit Color( const char* color) : m_color{ color} {}
+         explicit Color( std::string_view color) : m_color{ color} {}
 
          struct Proxy
          {
@@ -97,8 +98,10 @@ namespace casual
 
          friend Proxy operator << ( std::ostream& out, const Color& color);
 
+         auto value() const { return m_color; }
+
       private:
-         const char* m_color;
+         std::string_view m_color;
 
       };
 
@@ -106,15 +109,15 @@ namespace casual
       {
          namespace value
          {
-            constexpr auto no_color = "\033[0m";
-            constexpr auto black = "\033[0;30m";
-            constexpr auto red = "\033[0;31m";
-            constexpr auto green = "\033[0;32m";
-            constexpr auto yellow = "\033[0;33m";
-            constexpr auto blue = "\033[0;34m";
-            constexpr auto magenta = "\033[0;35m";
-            constexpr auto cyan = "\033[0;36m";
-            constexpr auto white = "\033[0;37m";
+            constexpr std::string_view no_color = "\033[0m";
+            constexpr std::string_view black = "\033[0;30m";
+            constexpr std::string_view red = "\033[0;31m";
+            constexpr std::string_view green = "\033[0;32m";
+            constexpr std::string_view yellow = "\033[0;33m";
+            constexpr std::string_view blue = "\033[0;34m";
+            constexpr std::string_view magenta = "\033[0;35m";
+            constexpr std::string_view cyan = "\033[0;36m";
+            constexpr std::string_view white = "\033[0;37m";
          } // value
 
          extern Color no_color;
@@ -147,19 +150,19 @@ namespace casual
 
       namespace format
       {
-         namespace customize
+         namespace ostream
          {
-            struct Stream
+            struct scope
             {
-               Stream( std::ostream& stream);
-               ~Stream();
+               scope( std::ostream& stream);
+               ~scope();
 
             private:
                std::ostream* m_stream;
                std::ios::fmtflags m_flags;
                std::streamsize m_precision;
             };
-         }
+         } // ostream
 
          enum class Align
          {
@@ -167,230 +170,11 @@ namespace casual
             right
          };
 
-         template< typename T>
-         struct formatter
+         //! explicit type to denote a delimiter
+         struct Delimiter
          {
-            using value_type = T;
-
-            template< typename... Columns>
-            static auto construct( Columns&&... columns)
-            {
-               return formatter{ "  ", initialize( std::forward< Columns>( columns)...)};
-            }
-
-            template< typename... Columns>
-            static auto construct( std::string delimiter, Columns&&... columns)
-            {
-               return formatter{ std::move( delimiter), initialize( std::forward< Columns>( columns)...)};
-            }
-
-
-            template< typename R>
-            void calculate_width( R&& range, const std::ostream& out)
-            {
-               for( auto& column : m_columns)
-                  column.calculate_width( range, out);
-            }
-
-            void print_headers( std::ostream& out)
-            {
-               if( output::directive().header())
-               {
-                  auto print_delimiter = [&](){
-                     out << m_delimiter;
-                  };
-
-                  out << std::setfill( ' ');
-                  {
-                     auto print_name = [&out]( const column_holder& c){
-                        out << std::left << std::setw( c.width()) << c.name();
-                     };
-
-                     algorithm::for_each_interleave( m_columns, print_name, print_delimiter);
-                     out << '\n';
-                  }
-
-                  {
-                     auto print_row = [&out]( const column_holder& c){
-                        out << std::string( c.width(), '-');
-                     };
-                     algorithm::for_each_interleave( m_columns, print_row, print_delimiter);
-                     out << '\n';
-                  }
-               }
-            }
-
-            void print_porcelain_headers( std::ostream& out)
-            {
-               auto print_delimiter = [&](){
-                  out << '|';
-               };
-
-               auto print_name = [&out]( const column_holder& c){
-                  out << c.name();
-               };
-
-               algorithm::for_each_interleave( m_columns, print_name, print_delimiter);
-               out << '\n';
-            }
-
-
-
-            template< typename R>
-            std::ostream& print_rows( std::ostream& out, R&& rows)
-            {
-               if( output::directive().porcelain())
-               {
-                  for( auto& row : rows)
-                  {
-                     auto print_delimiter = [&out](){
-                        out << '|';
-                     };
-
-                     auto print_column = [&out,&row]( const column_holder& c){
-                        c.print( out, row, false);
-                     };
-
-                     algorithm::for_each_interleave( m_columns, print_column, print_delimiter);
-                     out << '\n';
-                  }
-               }
-               else
-               {
-                  for( auto& row : rows)
-                  {
-                     auto print_delimiter = [&](){
-                        out << m_delimiter;
-                     };
-
-                     auto print_column = [&out,&row]( const column_holder& c){
-                        c.print( out, row);
-                     };
-
-                     algorithm::for_each_interleave( m_columns, print_column, print_delimiter);
-                     out << '\n';
-                  }
-               }
-               return out;
-            }
-
-
-            template< typename R>
-            std::ostream& print( std::ostream& out, R&& range)
-            {
-               customize::Stream stream( out);
-
-               if( ! output::directive().porcelain())
-               {
-                  calculate_width( range, out);
-                  print_headers( out);
-               }
-               else if( output::directive().explict_header())
-               {
-                  print_porcelain_headers( out);
-               }
-
-               print_rows( out, range);
-
-               return out;
-            }
-
-            template< typename Iter>
-            std::ostream& print( std::ostream& out, Iter first, Iter last)
-            {
-               return print( out, range::make( first, last));
-            }
-
-
-            struct Concept
-            {
-               virtual ~Concept() = default;
-               virtual std::string name() const = 0;
-               virtual std::size_t width( const value_type& value, const std::ostream& out) const = 0;
-               virtual void print( std::ostream& out, const value_type& value, std::size_t size) const = 0;
-            };
-
-
-            struct column_holder
-            {
-               column_holder( std::unique_ptr< Concept> column)
-                  : m_column( std::move( column)), m_width( m_column->name().size()) {}
-
-               template< typename Range>
-               void calculate_width( Range&& range, const std::ostream& out)
-               {
-                  for( auto& row : range)
-                  {
-                     m_width = std::max( m_width, m_column->width( row, out));
-                  }
-               }
-
-               std::string name() const
-               {
-                  return m_column->name();
-               }
-
-               void print( std::ostream& out, const value_type& value, bool width = true) const
-               {
-                  m_column->print( out, value, width ? m_width : 0);
-               }
-
-
-               std::size_t width() const
-               {
-                  return m_width;
-               }
-
-               std::unique_ptr< Concept> m_column;
-               std::size_t m_width;
-            };
-
-
-            template< typename I>
-            struct basic_column : Concept
-            {
-               using implementation_type = I;
-               basic_column( implementation_type implementation) : m_implementation( std::move( implementation)) {}
-
-               std::string name() const override { return m_implementation.name();}
-               void print( std::ostream& out, const value_type& value, std::size_t width) const override
-               {
-                  m_implementation.print( out, value, width);
-               }
-
-               std::size_t width( const value_type& value, const std::ostream& out) const override { return m_implementation.width( value, out);}
-
-               I m_implementation;
-            };
-
-            using columns_type = std::vector< column_holder>;
-
-            static columns_type initialize()
-            {
-               return {};
-            }
-
-            template< typename C, typename... Cs>
-            static columns_type initialize( C&& column, Cs&&... columns)
-            {
-               auto result = initialize( std::forward< Cs>( columns)...);
-
-               auto basic = std::make_unique< basic_column< typename std::decay< C>::type>>( std::forward< C>( column));
-
-               result.emplace( std::begin( result), std::move( basic));
-               return result;
-            }
-
-         protected:
-            formatter( std::string delimiter, columns_type columns)
-               : m_delimiter( std::move( delimiter)), 
-               m_columns( std::move( columns))
-            {
-
-            }
-            
-            std::string m_delimiter;
-            columns_type m_columns;
+            explicit Delimiter( std::string_view value) : value( value) {}
+            std::string_view value;
          };
 
          template< typename B>
@@ -411,22 +195,21 @@ namespace casual
          {
             using binder_type = B;
 
-            default_column( binder_type binder,
-                  Align align = Align::left,
-                  common::terminal::Color color = common::terminal::color::red)
-            : m_color( std::move( color)),
-               m_align( align == Align::left ? std::left : std::right),
-               binder( std::move( binder)) {}
+            default_column( binder_type binder, Align align = Align::left, common::terminal::Color color = common::terminal::color::red)
+               : m_color( std::move( color)),
+                  m_align( align == Align::left ? std::left : std::right),
+                  binder( std::move( binder)) 
+            {}
 
 
             template< typename VT>
             std::size_t width( VT&& value, const std::ostream& out) const
             {
-               std::ostringstream repsentation;
-               repsentation.flags( out.flags());
-               repsentation.precision( out.precision());
-               stream::write( repsentation, binder( value));
-               return std::move( repsentation.str()).size();
+               std::ostringstream representation;
+               representation.flags( out.flags());
+               representation.precision( out.precision());
+               stream::write( representation, binder( value));
+               return std::move( representation.str()).size();
             }
 
             template< typename VT>
@@ -492,31 +275,198 @@ namespace casual
             return value;
          }
 
-      } // format      
-
-      namespace formatter
-      {
-         namespace key
+         namespace detail
          {
-            //! returns a formatter for `std::tuple< std::string, std::string>`, with column-names
-            //! 'key' and 'value'. 
-            inline auto value()
+            struct Bookkeeping
             {
-               // TODO maintainence: we use this in cli::information, but should it be declared here? If so,
-               // should other "general" formatters be here too? 
-               // The whole 'terminal' stuff is not that good to begin with, make this dission if and when we
-               // rewrite the 'terminal' stuff.
+               std::size_t width = 0;
+            };
+
+            auto calculate_width( std::ostream& out, concepts::range auto&& range, const auto&... columns)
+            {
+               std::array< detail::Bookkeeping, sizeof...( columns)> bookkeeping;
+
+               // first calculate widths for each column name. We know that we need at least that width
+               {
+                  std::size_t index = 0;
+                  ( ( bookkeeping[ index++].width = columns.name().size()), ...);
+               }
+
+               // then possibly expand widths based on column data
+
+               auto calculate = [ &out]( const auto& row, std::size_t index, auto& bookkeeping, const auto& column)
+               {
+                  bookkeeping[ index].width = std::max( bookkeeping[ index].width, column.width( row, out));
+               };
+
+               for( auto& row : range)
+               {
+                  std::size_t index = 0;
+                  ( ( calculate( row, index++, bookkeeping, columns)), ...);
+               }
+
+               return bookkeeping;
+            }
+
+            void print_headers( std::ostream& out, Delimiter delimiter, const auto& bookkeeping, const auto&... columns)
+            {
+               if( ! output::directive().header())
+                  return;
+
+               {
+                  auto print_names = [ &]( std::size_t index, const auto& column)
+                  {
+                     out << std::left << std::setw( bookkeeping[ index].width) << column.name();
+
+                     // if not last index, print delimiter
+                     if( index < bookkeeping.size() - 1)
+                        out << delimiter.value;
+                  };
+
+                  std::size_t index = 0;
+                  ( ( print_names( index++, columns)), ...);
+
+                  out << '\n';
+               }
+
+               {
+                  auto print_separators = [ &]( const auto& meta)
+                  {
+                     out << std::string( meta.width, '-');
+                  };
+
+                  auto print_delimiter = [ &]() { out << delimiter.value;};
+
+                  algorithm::for_each_interleave( bookkeeping, print_separators, print_delimiter);
+
+                  out << '\n';
+               }
+            }
+
+            void print_porcelain_headers( std::ostream& out, const auto&... columns)
+            {
+               constexpr auto column_count = sizeof...( columns);
+
+               auto print_name = [&]( std::size_t index, const auto& column)
+               {
+                  if( index < column_count - 1)
+                     out << column.name() << '|';
+                  else
+                     out << column.name();
+               };
+
+               std::size_t index = 0;
+               ( ( print_name( index++, columns)), ...);
+
+               out << '\n';
+            }
+
+            void print_rows( std::ostream& out, Delimiter delimiter, concepts::range auto&& range, const auto& bookkeeping, const auto&... columns)
+            {
+               auto print_row = [&]( const auto& row)
+               {
+                  auto print_column = [&]( std::size_t index, const auto& column)
+                  {
+                     column.print( out, row, bookkeeping[ index].width);
+
+                     // if not last index, print delimiter
+                     if( index < bookkeeping.size() - 1)
+                        out << delimiter.value;
+                  };
+
+                  std::size_t index = 0;
+                  ( ( print_column( index++, columns)), ...);
+
+                  out << '\n';
+               };
+
+               std::ranges::for_each( range, print_row);
+            }
+
+            void print_porcelain_rows( std::ostream& out, concepts::range auto&& range, const auto&... columns)
+            {
+               auto print_row = [&]( const auto& row)
+               {
+                  auto print_column = [&]( std::size_t index, const auto& column)
+                  {
+                     column.print( out, row, false);
+
+                     // if not last index, print delimiter
+                     if( index < sizeof...( columns) - 1)
+                        out << '|';
+                  };
+
+                  std::size_t index = 0;
+                  ( ( print_column( index++, columns)), ...);
+
+                  out << '\n';
+               };
+
+               std::ranges::for_each( range, print_row);
+            }
+
+         } // detail
+
+
+         void print( std::ostream& out, Delimiter delimiter, concepts::range auto&& range, auto&&... columns)
+         {
+            static_assert( sizeof...( columns) > 0, "at least one column must be specified");
+
+            // set user defined stream settings
+            ostream::scope scope( out);
+
+            if( ! output::directive().porcelain())
+            {
+               auto bookkeeping = detail::calculate_width( out, range, columns...);
+               detail::print_headers( out, delimiter, bookkeeping, columns...);
+               detail::print_rows( out, delimiter, range, bookkeeping, columns...);
+            }
+            else
+            {
+               if( output::directive().explicit_header())
+                  detail::print_porcelain_headers( out, columns...);
+               
+               detail::print_porcelain_rows( out, range, columns...);
+            }
+         }
+
+         void print( std::ostream& out, concepts::range auto&& range, auto&&... columns)
+         {
+            print( out, Delimiter{ "  "}, range, columns...);
+         }
+
+         void print( Delimiter delimiter, concepts::range auto&& range, auto&&... columns)
+         {
+            print( std::cout, delimiter, range, columns...);
+         }
+
+
+         void print( concepts::range auto&& range, auto&&... columns)
+         {
+            print( std::cout, range, columns...);
+         }
+
+         namespace pair
+         {
+            void print( std::ostream& out, concepts::range auto&& range)
+            {
                auto get_first = []( auto& pair) -> const std::string& { return std::get< 0>( pair);};
                auto get_second = []( auto& pair) -> const std::string& { return std::get< 1>( pair);};
 
-               return terminal::format::formatter< std::tuple< std::string, std::string>>::construct(
+               format::print( out, range,
                   terminal::format::column( "key", get_first, terminal::color::yellow, terminal::format::Align::left),
                   terminal::format::column( "value", get_second, terminal::color::no_color, terminal::format::Align::left)
                );
             }
-         } // key
 
-      } // formatter
+            void print( concepts::range auto&& range)
+            {
+               print( std::cout, std::forward< decltype( range)>( range));
+            }
+
+         } // pair
+
+      } // format
       
    } // common::terminal
 } // casual

--- a/middleware/common/source/terminal.cpp
+++ b/middleware/common/source/terminal.cpp
@@ -119,7 +119,7 @@ Hence, column order can differ between `porcelain` and "regular".
                return local::deduce::option( local::option::header_default());
          }
 
-         bool Directive::explict_header() const
+         bool Directive::explicit_header() const
          {
             return ! m_header.empty() && m_header != "auto" && local::deduce::option( m_header);
          }
@@ -220,7 +220,7 @@ Hence, column order can differ between `porcelain` and "regular".
 
       namespace format
       {
-         namespace customize
+         namespace ostream
          {
             namespace local
             {
@@ -236,7 +236,7 @@ Hence, column order can differ between `porcelain` and "regular".
                } // <unnamed>
             } // local
 
-            Stream::Stream( std::ostream& stream)
+            scope::scope( std::ostream& stream)
                : m_stream( &stream),
                   m_flags( stream.flags( local::flags())),
                   m_precision( stream.precision( output::directive().precision()))
@@ -244,12 +244,12 @@ Hence, column order can differ between `porcelain` and "regular".
 
             }
 
-            Stream::~Stream()
+            scope::~scope()
             {
                m_stream->flags( m_flags);
                m_stream->precision( m_precision);
             }
-         }
+         } // ostream
 
       } // format
 

--- a/middleware/domain/source/discovery/admin/cli.cpp
+++ b/middleware/domain/source/discovery/admin/cli.cpp
@@ -82,12 +82,12 @@ namespace casual
                {
                   auto option()
                   {
-                     static constexpr auto create_formatter = []()
+                     static constexpr auto format_provider = []( auto& providers)
                      {
                         auto format_pid = []( auto& provider) { return provider.process.pid;};
                         auto format_abilities = []( auto& provider) { return provider.abilities;};
 
-                        return terminal::format::formatter< model::Provider >::construct(
+                        terminal::format::print( providers,
                            terminal::format::column( "pid", format_pid, terminal::color::white, terminal::format::Align::right),
                            terminal::format::column( "abilities", format_abilities, terminal::color::yellow, terminal::format::Align::left)
                         );
@@ -96,7 +96,7 @@ namespace casual
                      auto invoke = []()
                      {
                         auto state = local::call::state();
-                        create_formatter().print( std::cout, state.providers);
+                        format_provider( state.providers);
                      };
 
                      return argument::Option{
@@ -119,12 +119,12 @@ These are the providers that has registered them self with discovery abilities
                {
                   auto option()
                   {
-                     static constexpr auto create_formatter = []()
+                     static constexpr auto format_services = []( auto& services)
                      {
                         auto format_name = []( auto& service) { return service.name;};
                         auto format_hops = []( auto& service) { return service.property.hops;};
 
-                        return terminal::format::formatter< message::discovery::reply::content::Service>::construct(
+                        terminal::format::print( services,
                            terminal::format::column( "name", format_name, terminal::color::yellow, terminal::format::Align::left),
                            terminal::format::column( "hops", format_hops, terminal::color::white, terminal::format::Align::right)
                         );
@@ -133,7 +133,7 @@ These are the providers that has registered them self with discovery abilities
                      auto invoke = []( std::vector< std::string> services)
                      {
                         auto reply = local::call::discover( std::move( services), {});
-                        create_formatter().print( std::cout, reply.content.services);
+                        format_services( reply.content.services);
                      };
 
                      return argument::Option{
@@ -152,11 +152,11 @@ Will try to find provided services in other domains.
                {
                   auto option()
                   {
-                     static constexpr auto create_formatter = []()
+                     static constexpr auto format_queues = []( auto& queues)
                      {
                         auto format_name = []( auto& queue) { return queue.name;};
 
-                        return terminal::format::formatter< message::discovery::reply::content::Queue>::construct(
+                        terminal::format::print( queues,
                            terminal::format::column( "name", format_name, terminal::color::yellow, terminal::format::Align::left)
                         );
                      };
@@ -164,7 +164,7 @@ Will try to find provided services in other domains.
                      auto invoke = []( std::vector< std::string> queues)
                      {
                         auto reply = local::call::discover( {}, std::move( queues));
-                        create_formatter().print( std::cout, reply.content.queues);
+                        format_queues( reply.content.queues);
                      };
 
                      return argument::Option{
@@ -240,9 +240,9 @@ Will try to find provided queues in other domains.
 
                auto option()
                {
-                  static constexpr auto create_formatter = []()
+                  static constexpr auto format_rows = []( auto&& rows)
                   {
-                     return terminal::format::formatter< metric::Row>::construct(
+                     terminal::format::print( rows,
                         terminal::format::column( "name", std::mem_fn( &Row::name), terminal::color::yellow, terminal::format::Align::left),
                         terminal::format::column( "completed", std::mem_fn( &Row::completed), terminal::color::white, terminal::format::Align::right),
                         terminal::format::column( "pending", std::mem_fn( &Row::pending), terminal::color::white, terminal::format::Align::right)
@@ -253,7 +253,7 @@ Will try to find provided queues in other domains.
                   {
                      communication::instance::outbound::detail::optional::Device device{ discovery::instance::identity};
                      auto reply = communication::ipc::call( device, common::message::counter::Request( process::handle()));
-                     create_formatter().print( std::cout, metric::transform( reply));
+                     format_rows( metric::transform( reply));
                   };
 
                   return argument::Option{

--- a/middleware/domain/source/manager/admin/cli.cpp
+++ b/middleware/domain/source/manager/admin/cli.cpp
@@ -267,10 +267,14 @@ namespace casual
 
             namespace format
             {
-               template< typename P>
-               auto process()
+               auto processes( auto& processes)
                {
-                  auto format_configured_instances = []( const P& entity)
+                  auto format_alias = []( const auto& entity)
+                  {
+                     return entity.alias;
+                  };
+
+                  auto format_configured_instances = []( const auto& entity)
                   {
                      return algorithm::count_if( entity.instances, []( auto& instances)
                      {
@@ -280,7 +284,7 @@ namespace casual
                      });
                   };
 
-                  auto format_running_instances = []( const P& entity)
+                  auto format_running_instances = []( const auto& entity)
                   {
                      return common::algorithm::count_if( entity.instances, []( auto& instance)
                      {
@@ -288,14 +292,14 @@ namespace casual
                      });
                   };
 
-                  auto format_restart = []( const P& entity)
+                  auto format_restart = []( const auto& entity)
                   {
                      if( entity.restart) 
                         return "true";
                      return "false";
                   };
 
-                  auto format_state = []( const P& entity)
+                  auto format_state = []( const auto& entity)
                   {
                      if( ! entity.enabled) 
                         return "disabled";
@@ -308,32 +312,37 @@ namespace casual
                      return "enabled";
                   };
 
-                  auto format_restarts = []( const P& entity)
+                  auto format_restarts = []( const auto& entity)
                   {
                      return entity.restarts;
                   };
 
+                  auto format_path = []( const auto& entity)
+                  {
+                     return entity.path;
+                  };
+
                   if( ! terminal::output::directive().porcelain())
                   {
-                     return terminal::format::formatter< P>::construct(
-                        terminal::format::column( "alias", std::mem_fn( &P::alias), terminal::color::yellow, terminal::format::Align::left),
+                     terminal::format::print( processes,
+                        terminal::format::column( "alias", format_alias, terminal::color::yellow, terminal::format::Align::left),
                         terminal::format::column( "CI", format_configured_instances, terminal::color::no_color, terminal::format::Align::right),
                         terminal::format::column( "I", format_running_instances, terminal::color::white, terminal::format::Align::right),
                         terminal::format::column( "state", format_state, terminal::color::white, terminal::format::Align::left),
                         terminal::format::column( "restart", format_restart, terminal::color::blue, terminal::format::Align::right),
                         terminal::format::column( "#r", format_restarts, terminal::color::red, terminal::format::Align::right),
-                        terminal::format::column( "path", std::mem_fn( &P::path), terminal::color::blue, terminal::format::Align::left)
+                        terminal::format::column( "path", format_path, terminal::color::blue, terminal::format::Align::left)
                      );
                   }
                   else
                   {
-                     return terminal::format::formatter< P>::construct(
-                        terminal::format::column( "alias", std::mem_fn( &P::alias)),
+                     terminal::format::print( processes,
+                        terminal::format::column( "alias", format_alias),
                         terminal::format::column( "CI", format_configured_instances),
                         terminal::format::column( "I", format_running_instances),
                         terminal::format::column( "restart", format_restart),
                         terminal::format::column( "#r", format_restarts),
-                        terminal::format::column( "path", std::mem_fn( &P::path)),
+                        terminal::format::column( "path", format_path),
                         terminal::format::column( "state", format_state)
                      );
                   }
@@ -341,20 +350,6 @@ namespace casual
 
 
             } // format
-
-            namespace print
-            {
-               template< typename VO>
-               void processes( std::ostream& out, std::vector< VO>& processes)
-               {
-                  out << std::boolalpha;
-
-                  auto formatter = format::process< VO>();
-
-                  formatter.print( std::cout, processes);
-               }
-
-            } // print
 
             namespace predicate
             {
@@ -412,7 +407,7 @@ namespace casual
                   void invoke( std::vector< std::string> aliases)
                   {
                      // make sure we set precision and such for cout.
-                     terminal::format::customize::Stream scope{ std::cout};
+                     terminal::format::ostream::scope scope{ std::cout};
 
                      auto state = local::call::state();
 
@@ -578,7 +573,7 @@ namespace casual
 
                   void invoke()
                   {
-                     terminal::formatter::key::value().print( std::cout, call());
+                     terminal::format::pair::print( call());
                   }
 
                   constexpr auto description = R"(collect aggregated general information about this domain)";
@@ -768,7 +763,7 @@ With supplied configuration files, in the form of glob patterns.
                      {
                         auto state = call::state();
 
-                        print::processes( std::cout, algorithm::sort( state.servers, predicate::less::alias));
+                        format::processes( algorithm::sort( state.servers, predicate::less::alias));
                      };
 
                      return argument::Option{
@@ -785,7 +780,7 @@ With supplied configuration files, in the form of glob patterns.
                      {
                         auto state = call::state();
 
-                        print::processes( std::cout, algorithm::sort( state.executables, predicate::less::alias));
+                        format::processes( algorithm::sort( state.executables, predicate::less::alias));
                      };
 
                      return argument::Option{
@@ -846,7 +841,6 @@ With supplied configuration files, in the form of glob patterns.
                               return std::tie( lhs.alias, lhs.spawnpoint) < std::tie( rhs.alias, rhs.spawnpoint);
                            });
 
-                           auto create_formatter = []()
                            {
                               auto format_alias = []( auto& instance) { return instance.alias;};
                               auto format_pid = []( auto& instance) { return to_string( instance.handle.pid);};
@@ -856,7 +850,7 @@ With supplied configuration files, in the form of glob patterns.
 
                               if( ! terminal::output::directive().porcelain())
                               {
-                                 return terminal::format::formatter< Type>::construct(
+                                 terminal::format::print( instances,
                                     terminal::format::column( "alias", format_alias, terminal::color::yellow, terminal::format::Align::left),
                                     terminal::format::column( "state", format_state, terminal::color::cyan, terminal::format::Align::left),
                                     terminal::format::column( "pid", format_pid, terminal::color::no_color, terminal::format::Align::right),
@@ -866,7 +860,7 @@ With supplied configuration files, in the form of glob patterns.
                               }
                               else
                               {
-                                 return terminal::format::formatter< Type>::construct(
+                                 terminal::format::print( instances,
                                     terminal::format::column( "pid", format_pid),
                                     terminal::format::column( "ipc", format_ipc),
                                     terminal::format::column( "state", format_state),
@@ -875,8 +869,6 @@ With supplied configuration files, in the form of glob patterns.
                                  );
                               }
                            };
-
-                           create_formatter().print( std::cout, instances);
                         };
 
                         return argument::Option{ 
@@ -916,7 +908,6 @@ With supplied configuration files, in the form of glob patterns.
                               return std::tie( lhs.alias, lhs.spawnpoint) < std::tie( rhs.alias, rhs.spawnpoint);
                            });
 
-                           auto create_formatter = []()
                            {
                               auto format_pid = []( auto& instance) { return to_string( instance.handle);};
                               auto format_state = []( auto& instance) { return instance.state;};
@@ -925,7 +916,7 @@ With supplied configuration files, in the form of glob patterns.
 
                               if( ! terminal::output::directive().porcelain())
                               {
-                                 return terminal::format::formatter< Type>::construct(
+                                 terminal::format::print( instances,
                                     terminal::format::column( "alias", format_alias, terminal::color::yellow, terminal::format::Align::left),
                                     terminal::format::column( "state", format_state, terminal::color::cyan, terminal::format::Align::left),
                                     terminal::format::column( "pid", format_pid, terminal::color::no_color, terminal::format::Align::right),
@@ -934,16 +925,14 @@ With supplied configuration files, in the form of glob patterns.
                               }
                               else
                               {
-                                 return terminal::format::formatter< Type>::construct(
+                                 terminal::format::print( instances,
                                     terminal::format::column( "pid", format_pid),
                                     terminal::format::column( "state", format_state),
                                     terminal::format::column( "alias", format_alias),
                                     terminal::format::column( "spawnpoint", format_spawnpoint)
                                  );
                               }
-                           };
-
-                           create_formatter().print( std::cout, instances);
+                           }
                         };
 
                         return argument::Option{ 
@@ -1112,20 +1101,17 @@ note: some aliases are unrestartable
 
                         algorithm::sort( instances);
 
-                        auto create_formatter = []()
                         {
                            auto format_pid = []( auto& i) { return i.pid;};
                            auto format_alias = []( auto& i) { return i.alias;};
                            auto format_path = []( auto& i) { return i.path;};
 
-                           return terminal::format::formatter< Type>::construct(
+                           terminal::format::print( instances,
                               terminal::format::column( "pid", format_pid, terminal::color::white, terminal::format::Align::right),
                               terminal::format::column( "alias", format_alias, terminal::color::cyan, terminal::format::Align::left),
                               terminal::format::column( "path", format_path, terminal::color::blue, terminal::format::Align::left)
                            );
-                        };
-
-                        create_formatter().print( std::cout, instances);
+                        }
                      };
 
                      return argument::Option{

--- a/middleware/file/source/manager/admin/cli.cpp
+++ b/middleware/file/source/manager/admin/cli.cpp
@@ -55,12 +55,13 @@ namespace casual
                {
                   auto requests( const manager::admin::model::State& state)
                   {
-                     return common::terminal::format::formatter< manager::admin::model::Request>::construct(
+                     common::terminal::format::print( state.requests, 
                         common::terminal::format::column( "path", []( const auto& r){ return r.path;}, common::terminal::color::yellow),
                         common::terminal::format::column( "pid", []( const auto& r){ return r.pid;}, common::terminal::color::white),
                         common::terminal::format::column( "gtrid", []( const auto& r){ return r.gtrid;}),
                         common::terminal::format::column( "stage", []( const auto& r){ return description( r.stage);}),
-                        common::terminal::format::column( "time", []( const auto& r){ return std::chrono::floor< std::chrono::microseconds>( r.time);}, common::terminal::color::blue));
+                        common::terminal::format::column( "time", []( const auto& r){ return std::chrono::floor< std::chrono::microseconds>( r.time);}, common::terminal::color::blue)
+                     );
                   }
                } // format
 
@@ -75,10 +76,7 @@ namespace casual
                      auto invoke = []()
                      {
                         auto state = detail::call::state();
-
-                        auto formatter = detail::format::requests( state);
-
-                        formatter.print( std::cout, state.requests);
+                        detail::format::requests( state);
                      };
 
                      return argument::Option{

--- a/middleware/gateway/source/documentation/protocol/markdown.cpp
+++ b/middleware/gateway/source/documentation/protocol/markdown.cpp
@@ -330,8 +330,8 @@ namespace casual
 
             namespace format
             {
-
-               auto type_info()
+               template< typename T>
+               void type( std::ostream& out, T&& value, std::initializer_list< type::Name> roles)
                {
                   auto format_size = []( const type::Info& info)
                   {
@@ -341,21 +341,14 @@ namespace casual
                         return common::string::compose( '[', info.network.size.min, "..*]");
                      return common::string::compose( '[', info.network.size.min, "..", info.network.size.max, ']');
                   };
-                  return common::terminal::format::formatter< type::Info>::construct( 
-                     std::string{ " | "},
+
+                  common::terminal::format::print( common::terminal::format::Delimiter{ " | " },
+                     extract::types( std::forward< T>( value), std::move( roles)),
                      common::terminal::format::column( "role name", []( const type::Info& i) { return i.name.role;}, common::terminal::color::no_color),
                      common::terminal::format::column( "network type", []( const type::Info& i) { return i.network.type;}, common::terminal::color::no_color),
                      common::terminal::format::column( "network size", format_size, common::terminal::color::no_color, common::terminal::format::Align::right),
                      common::terminal::format::column( "description", []( const type::Info& i) { return i.name.description;}, common::terminal::color::no_color)
                   );
-               }
-
-               template< typename T>
-               void type( std::ostream& out, T&& value, std::initializer_list< type::Name> roles)
-               {
-                  auto formatter = type_info();
-
-                  formatter.print( out, extract::types( std::forward< T>( value), std::move( roles)));
                }
 
 

--- a/middleware/gateway/source/manager/admin/cli.cpp
+++ b/middleware/gateway/source/manager/admin/cli.cpp
@@ -100,7 +100,7 @@ namespace casual
                   return value.alias;
                };
 
-               auto connections()
+               auto connections( auto&& connections)
                {
                   auto format_domain_name = []( auto& value)
                   { 
@@ -177,11 +177,9 @@ namespace casual
                      }
                   };
 
-                  using Formatter = terminal::format::formatter<  manager::admin::model::Connection>;
-
                   if( ! terminal::output::directive().porcelain())
                   {
-                     return Formatter::construct( 
+                     terminal::format::print( connections,
                         terminal::format::column( "name", format_domain_name, terminal::color::yellow),
                         terminal::format::column( "id", format_domain_id, terminal::color::no_color),
                         terminal::format::column( "group", format::group, terminal::color::yellow),
@@ -216,7 +214,7 @@ namespace casual
                      auto format_ipc = []( auto& value){ return value.process.ipc;};
 
                      
-                     return Formatter::construct( 
+                     terminal::format::print( connections,
                         terminal::format::column( "name", format_domain_name),
                         terminal::format::column( "id", format_domain_id),
                         terminal::format::column( "bound", format_bound),
@@ -232,9 +230,8 @@ namespace casual
                   }
                }
 
-               auto listeners() 
+               auto listeners( auto&& listeners) 
                {
-                  using Formatter = terminal::format::formatter<  manager::admin::model::Listener>;
 
                   if( ! terminal::output::directive().porcelain())
                   {
@@ -271,7 +268,7 @@ namespace casual
                         }
                      };
 
-                     return Formatter::construct( 
+                     terminal::format::print( listeners,
                         terminal::format::column( "group", format::group, terminal::color::yellow),
                         terminal::format::custom::column( "runlevel", format_runlevel{}),
                         terminal::format::column( "address", format_address, terminal::color::white),
@@ -311,7 +308,7 @@ namespace casual
                         return "<unknown>";
                      };
 
-                     return Formatter::construct( 
+                     terminal::format::print( listeners, 
                         terminal::format::column( "host", format_host),
                         terminal::format::column( "port", format_port),
                         terminal::format::column( "limit size", format_limit_size),
@@ -341,7 +338,7 @@ namespace casual
                      return value.connect;
                   };
 
-                  auto inbound()
+                  auto inbound( auto&& groups)
                   {
                      auto format_limit = []( auto& value) -> std::string
                      { 
@@ -350,9 +347,8 @@ namespace casual
                         return "-";
                      };
 
-                     using Formatter = terminal::format::formatter< manager::admin::model::inbound::Group>;
 
-                     return Formatter::construct( 
+                     terminal::format::print( groups,
                         terminal::format::column( "alias", format::alias, terminal::color::yellow),
                         terminal::format::column( "pid", format_pid, terminal::color::white),
                         terminal::format::column( "runlevel", format_runlevel, terminal::color::no_color),
@@ -361,16 +357,14 @@ namespace casual
                      );
                   }
 
-                  auto outbound()
+                  auto outbound( auto&& groups)
                   {
                      auto format_order = []( auto& value)
                      { 
                         return value.order;
                      };
 
-                     using Formatter = terminal::format::formatter< manager::admin::model::outbound::Group>;
-
-                     return Formatter::construct( 
+                     terminal::format::print( groups,
                         terminal::format::column( "alias", format::alias, terminal::color::yellow),
                         terminal::format::column( "pid", format_pid, terminal::color::white),
                         terminal::format::column( "runlevel", format_runlevel, terminal::color::no_color),
@@ -392,7 +386,7 @@ namespace casual
                      {
                         auto invoke = []()
                         {
-                           format::connections().print( std::cout, call::state().connections);
+                           format::connections( call::state().connections);
                         };
 
                         return argument::Option{ 
@@ -436,7 +430,7 @@ created
                   {
                      auto invoke = []()
                      {
-                        format::listeners().print( std::cout, call::state().listeners);
+                        format::listeners( call::state().listeners);
                      };
 
                      return argument::Option{ 
@@ -451,7 +445,7 @@ created
                      {
                         auto invoke = []()
                         {
-                           format::groups::inbound().print( std::cout, call::state().inbound.groups);
+                           format::groups::inbound( call::state().inbound.groups);
                         };
 
                         return argument::Option{ 
@@ -464,7 +458,7 @@ created
                      {
                         auto invoke = []()
                         {
-                           format::groups::outbound().print( std::cout, call::state().outbound.groups);
+                           format::groups::outbound( call::state().outbound.groups);
                         };
 
                         return argument::Option{ 

--- a/middleware/queue/source/manager/admin/cli.cpp
+++ b/middleware/queue/source/manager/admin/cli.cpp
@@ -199,7 +199,7 @@ namespace casual
                   return value;
                }
 
-               auto messages()
+               auto messages( auto&& messages)
                {
                   auto format_state = []( auto& message)
                   {
@@ -218,7 +218,7 @@ namespace casual
                   auto format_timestamp = []( auto& message) { return normalize::timestamp( message.timestamp);};
                   auto format_available = []( auto& message) { return normalize::timestamp( message.available);};
 
-                  return terminal::format::formatter< manager::admin::model::Message>::construct(
+                  terminal::format::print( messages,
                      terminal::format::column( "id", []( auto& message) { return message.id;}, terminal::color::yellow),
                      terminal::format::column( "S", format_state, terminal::color::no_color),
                      terminal::format::column( "size", []( auto& message) { return message.size;}, terminal::color::cyan, terminal::format::Align::right),
@@ -231,7 +231,7 @@ namespace casual
                   );
                }
 
-               auto groups()
+               auto groups( auto&& groups)
                {
                   auto format_alias = []( auto& group) { return hyphen_if_empty( group.alias);};
                   auto format_pid = []( auto& group) { return group.process.pid;};
@@ -245,7 +245,7 @@ namespace casual
                      return "-";
                   };
 
-                  return terminal::format::formatter< manager::admin::model::Group>::construct(
+                  terminal::format::print( groups,
                      terminal::format::column( "alias", format_alias, terminal::color::yellow),
                      terminal::format::column( "pid", format_pid, terminal::color::white, terminal::format::Align::right),
                      terminal::format::column( "ipc", format_ipc, terminal::color::no_color, terminal::format::Align::right),
@@ -255,18 +255,18 @@ namespace casual
                   );
                }
 
-               auto affected()
+               auto affected( auto&& affected)
                {
                   auto format_name = []( auto& value) { return value.queue;};
 
-                  return terminal::format::formatter< queue::restore::Affected>::construct(
+                  terminal::format::print( affected,
                      terminal::format::column( "name", format_name, terminal::color::yellow, terminal::format::Align::right),
                      terminal::format::column( "count", std::mem_fn( &queue::restore::Affected::count), terminal::color::green)
                   );
                }
 
 
-               auto queues( const manager::admin::model::State& state)
+               auto queues( const manager::admin::model::State& state, auto&& queues)
                {
                   using second_t = std::chrono::duration< double>;
 
@@ -300,7 +300,7 @@ namespace casual
                   
                   if( ! terminal::output::directive().porcelain())
                   {
-                     return terminal::format::formatter< manager::admin::model::Queue>::construct(
+                     terminal::format::print( queues,
                         terminal::format::column( "name", []( const auto& q){ return q.name;}, terminal::color::yellow),
                         terminal::format::column( "group", format_group),
                         terminal::format::column( "rc", []( const auto& q){ return q.retry.count;}, common::terminal::color::blue, terminal::format::Align::right),
@@ -317,7 +317,7 @@ namespace casual
                   }
                   else
                   {
-                     return terminal::format::formatter< manager::admin::model::Queue>::construct(
+                     terminal::format::print( queues,
                         terminal::format::column( "name", []( const auto& q){ return q.name;}),
                         terminal::format::column( "group", format_group),
                         terminal::format::column( "rc", []( const auto& q){ return q.retry.count;}),
@@ -338,14 +338,14 @@ namespace casual
                namespace remote
                {
                   //! @deprecated
-                  auto queues( const manager::admin::model::State& state)
+                  auto queues( auto&& queues)
                   {
                      auto format_pid = [&]( auto& queue){ return queue.process.pid;};
 
                      auto format_name = []( auto& queue){ return queue.name;};
          
          
-                     return terminal::format::formatter< manager::admin::model::remote::Queue>::construct(
+                     terminal::format::print( queues,
                         terminal::format::column( "name", format_name, terminal::color::yellow),
                         terminal::format::column( "pid", format_pid, common::terminal::color::blue)
                      );
@@ -355,7 +355,7 @@ namespace casual
 
                namespace queue
                {
-                  auto instances()
+                  auto instances( auto&& instances)
                   {
                      struct format_state
                      {
@@ -385,7 +385,7 @@ namespace casual
                      
                      auto format_description = []( auto& instance){ return hyphen_if_empty( instance.description);};
          
-                     return terminal::format::formatter< local::normalize::Instance>::construct(
+                     terminal::format::print( instances,
                         terminal::format::column( "queue", format_queue, terminal::color::yellow),
                         terminal::format::custom::column( "state", format_state{}),
                         terminal::format::column( "pid", format_pid, terminal::color::white, terminal::format::Align::right),
@@ -469,7 +469,7 @@ namespace casual
 
                   using time_type = std::chrono::duration< double>;
 
-                  auto services( const manager::admin::model::State& state)
+                  auto services( const manager::admin::model::State& state, auto&& services)
                   {
                      auto column_target = []()
                      {
@@ -500,7 +500,7 @@ namespace casual
 
                      if( ! terminal::output::directive().porcelain())
                      {
-                        return terminal::format::formatter< manager::admin::model::forward::Service>::construct(
+                        terminal::format::print( services,
                            column_alias(),
                            column_group( state.forward.groups),
                            column_source(),
@@ -517,7 +517,7 @@ namespace casual
                      }
                      else
                      {
-                        return terminal::format::formatter< manager::admin::model::forward::Service>::construct(
+                        terminal::format::print( services,
                            column_alias(),
                            column_group( state.forward.groups),
                            column_source(),
@@ -534,7 +534,7 @@ namespace casual
                      }
                   }
    
-                  auto queues( const manager::admin::model::State& state)
+                  auto queues( const manager::admin::model::State& state, auto&& queues)
                   {
                      auto column_target = []()
                      {
@@ -551,7 +551,7 @@ namespace casual
 
                      if( ! terminal::output::directive().porcelain())
                      {
-                        return terminal::format::formatter< manager::admin::model::forward::Queue>::construct(
+                        terminal::format::print( queues,
                            column_alias(),
                            column_group( state.forward.groups),
                            column_source(),
@@ -567,7 +567,7 @@ namespace casual
                      }
                      else
                      {
-                        return terminal::format::formatter< manager::admin::model::forward::Queue>::construct(
+                        terminal::format::print( queues,
                            column_alias(),
                            column_group( state.forward.groups),
                            column_source(),
@@ -583,7 +583,7 @@ namespace casual
                      }
                   }
 
-                  auto groups( const manager::admin::model::State& state)
+                  auto groups( const manager::admin::model::State& state, auto&& groups)
                   {
                      auto column_pid = []()
                      {
@@ -669,7 +669,7 @@ namespace casual
 
                      if( ! terminal::output::directive().porcelain())
                      {
-                        return terminal::format::formatter< manager::admin::model::forward::Group>::construct(
+                        terminal::format::print( groups,
                            column_alias(),
                            column_pid(),
                            column_services(),
@@ -681,7 +681,7 @@ namespace casual
                      }
                      else
                      {
-                        return terminal::format::formatter< manager::admin::model::forward::Group>::construct(
+                        terminal::format::print( groups,
                            column_alias(),
                            column_pid(),
                            column_services(),
@@ -951,9 +951,7 @@ The following options has legend:
                      {
                         auto state = call::state();
 
-                        auto formatter = format::queues( state);
-
-                        formatter.print( std::cout, algorithm::sort( state.queues));
+                        format::queues( state, algorithm::sort( state.queues));
                      };
 
                      return argument::Option{
@@ -973,9 +971,8 @@ The following options has legend:
                      {
                         auto state = call::state();
 
-                        auto formatter = format::queues( state);
+                        format::queues( state, algorithm::sort( state.zombies));
 
-                        formatter.print( std::cout, algorithm::sort( state.zombies));
                      };
 
                      return argument::Option{
@@ -994,9 +991,7 @@ The following options has legend:
                      auto invoke = []()
                      {
                         auto state = call::state();
-                        auto instances = normalize::instances( state);
-                        auto formatter = format::queue::instances();
-                        formatter.print( std::cout, instances);
+                        format::queue::instances( normalize::instances( state));
                      };
                      
                      return argument::Option{
@@ -1015,7 +1010,7 @@ The following options has legend:
                      auto invoke = []()
                      {
                         auto state = call::state();
-                        format::groups().print( std::cout, state.groups);
+                        format::groups( state.groups);
                      };
                      
                      return argument::Option{
@@ -1033,8 +1028,7 @@ The following options has legend:
                      auto invoke = []( const std::string& queue)
                      {
                         auto messages = call::messages( queue);
-                        auto formatter = format::messages();
-                        formatter.print( std::cout, messages);
+                        format::messages( messages);
                      };
                      
                      return argument::Option{
@@ -1055,7 +1049,7 @@ The following options has legend:
                         auto invoke = []()
                         {
                            auto state = call::state();
-                           format::forward::services( state).print( std::cout, state.forward.services);
+                           format::forward::services( state, state.forward.services);
                         };
                         
                         return argument::Option{
@@ -1073,7 +1067,7 @@ The following options has legend:
                         auto invoke = []()
                         {
                            auto state = call::state();
-                           format::forward::queues( state).print( std::cout, state.forward.queues);
+                           format::forward::queues( state, state.forward.queues);
                         };
                         
                         return argument::Option{
@@ -1091,7 +1085,7 @@ The following options has legend:
                         auto invoke = []()
                         {
                            auto state = call::state();
-                           format::forward::groups( state).print( std::cout, state.forward.groups);
+                           format::forward::groups( state, state.forward.groups);
                         };
                         
                         return argument::Option{
@@ -1509,7 +1503,7 @@ Example:
                {
                   auto invoke = []( const std::vector< std::string>& queues)
                   {
-                     format::affected().print( std::cout, queue::restore::queue( queues));
+                     format::affected( queue::restore::queue( queues));
                   };
 
                   return argument::Option{
@@ -1627,7 +1621,7 @@ if used with `--force true` messages will be removed regardless of state.)";
                {
                   auto invoke = []( const std::vector< std::string>& queues)
                   {
-                     format::affected().print( std::cout, queue::clear::queue( queues));
+                     format::affected( queue::clear::queue( queues));
                   };
 
                   return argument::Option{
@@ -1792,7 +1786,7 @@ casual queue --metric-reset a b)"
                {
                   auto invoke = []()
                   {
-                     terminal::formatter::key::value().print( std::cout, information::call());
+                     terminal::format::pair::print( information::call());
                   };
 
                   return argument::Option{
@@ -1810,8 +1804,7 @@ casual queue --metric-reset a b)"
                   auto invoke = []()
                   {
                      auto state = call::state();
-                     auto formatter = format::remote::queues( state);
-                     formatter.print( std::cout, algorithm::sort( state.remote.queues));
+                     format::remote::queues( algorithm::sort( state.remote.queues));
                   };
                   
                   return argument::Option{

--- a/middleware/service/source/manager/admin/cli.cpp
+++ b/middleware/service/source/manager/admin/cli.cpp
@@ -164,7 +164,7 @@ namespace casual
                      return value;
                   }
 
-                  auto services()
+                  auto services( std::span< const admin::model::Service> services)
                   {
 
                      auto format_timeout_duration_string = []( const auto& value) -> std::string
@@ -272,7 +272,7 @@ namespace casual
 
                      if( ! terminal::output::directive().porcelain())
                      {
-                        return terminal::format::formatter< admin::model::Service>::construct( 
+                        terminal::format::print( services,
                            terminal::format::column( "name", std::mem_fn( &admin::model::Service::name), terminal::color::yellow, terminal::format::Align::left),
                            terminal::format::column( "category", format_category, terminal::color::no_color, terminal::format::Align::left),
                            terminal::format::column( "V", format_visibility, terminal::color::no_color, terminal::format::Align::left),
@@ -293,7 +293,7 @@ namespace casual
                      }
                      else
                      {
-                        return terminal::format::formatter< admin::model::Service>::construct( 
+                        terminal::format::print( services,
                            terminal::format::column( "name", std::mem_fn( &admin::model::Service::name)),
                            terminal::format::column( "category", format_category),
                            terminal::format::column( "mode", std::mem_fn( &admin::model::Service::transaction)),
@@ -315,16 +315,16 @@ namespace casual
                   }
 
 
-                  auto routes()
+                  auto routes( std::span< const admin::model::Route> routes)
                   {
-                     return terminal::format::formatter< model::Route>::construct( 
+                     terminal::format::print( routes,
                         terminal::format::column( "name", std::mem_fn( &model::Route::service), terminal::color::yellow, terminal::format::Align::left),
                         terminal::format::column( "target", std::mem_fn( &model::Route::target), terminal::color::no_color, terminal::format::Align::left)
                      );
                   }
 
 
-                  auto instances()
+                  auto instances( std::span< const normalized::Instance> instances)
                   {
                      auto format_pid = []( auto& instance){ return instance.process.pid;};
 
@@ -371,7 +371,7 @@ namespace casual
 
                      if( ! terminal::output::directive().porcelain())
                      {
-                        return terminal::format::formatter< normalized::Instance>::construct(
+                        terminal::format::print( instances,
                            terminal::format::column( "service", format_service_name, terminal::color::yellow),
                            terminal::format::custom::column( "state", format_state{}),
                            terminal::format::column( "hops", format_hops, terminal::color::no_color, terminal::format::Align::right),
@@ -382,7 +382,7 @@ namespace casual
                      }
                      else
                      {
-                        return terminal::format::formatter< normalized::Instance>::construct(
+                        terminal::format::print( instances,
                            terminal::format::column( "service", format_service_name),
                            terminal::format::column( "pid", format_pid),
                            terminal::format::custom::column( "state", format_state{}),
@@ -459,7 +459,7 @@ namespace casual
                            auto state = manager::admin::api::state();
                            auto services = algorithm::sort( algorithm::filter( state.services, filter));
 
-                           format::services().print( std::cout, services);
+                           format::services( services);
                         };
 
                         auto flag = argument::Option{ [ shared]()
@@ -503,8 +503,7 @@ namespace casual
 
                            auto filtered = algorithm::sort( algorithm::filter( instances, filter));
 
-                           auto formatter = format::instances();
-                           formatter.print( std::cout, filtered);
+                           format::instances( filtered);
                         };
 
                         auto flag = argument::Option{ [ shared]()
@@ -527,9 +526,7 @@ namespace casual
                         auto invoke = []()
                         {
                            auto state = admin::api::state();
-
-                           auto formatter = format::routes();
-                           formatter.print( std::cout, state.routes);
+                           format::routes( state.routes);
                         };
 
                         return argument::Option{ 
@@ -677,7 +674,7 @@ The following options has legend:
                   {
                      auto invoke = []()
                      {
-                        terminal::formatter::key::value().print( std::cout, information::compose());
+                        terminal::format::pair::print( information::compose());
                      };
 
                      return argument::Option{ 
@@ -704,7 +701,7 @@ The following options has legend:
                            auto state = manager::admin::api::state();
                            auto services = algorithm::sort( algorithm::filter( state.services, is_hidden));
 
-                           format::services().print( std::cout, services);
+                           format::services( services);
                         };
 
                         return argument::Option{ 

--- a/middleware/transaction/source/manager/admin/cli.cpp
+++ b/middleware/transaction/source/manager/admin/cli.cpp
@@ -207,7 +207,7 @@ namespace casual
                   return result;
                }
 
-               auto transaction()
+               auto transaction( auto&& transactions)
                {
                   auto format_global = []( auto& value) { return value.global.id;};
                   auto format_number_of_branches = []( auto& value) { return value.branches.size();};
@@ -241,7 +241,7 @@ namespace casual
 
                   if( ! terminal::output::directive().porcelain())
                   {
-                     return common::terminal::format::formatter< admin::model::Transaction>::construct(
+                     common::terminal::format::print( transactions,
                         common::terminal::format::column( "global", format_global, common::terminal::color::yellow),
                         common::terminal::format::column( "#branches", format_number_of_branches, common::terminal::color::no_color),
                         common::terminal::format::column( "owner", format_owner, common::terminal::color::white, common::terminal::format::Align::right),
@@ -253,7 +253,7 @@ namespace casual
                   }
                   else
                   {
-                     return common::terminal::format::formatter< admin::model::Transaction>::construct(
+                     common::terminal::format::print( transactions,
                         common::terminal::format::column( "global", format_global),
                         common::terminal::format::column( "#branches", format_number_of_branches),
                         common::terminal::format::column( "owner", format_owner),
@@ -282,7 +282,7 @@ resources:
    the resources involved in the transaction, as a comma separated list of resource ids
 )";
 
-               auto resource_proxy( const std::map< common::strong::resource::id, platform::size::type>& branch_count)
+               auto resource_proxy( auto&& resources, const std::map< common::strong::resource::id, platform::size::type>& branch_count)
                {
 
                   struct format_number_of_instances
@@ -351,7 +351,7 @@ resources:
 
                   if( ! terminal::output::directive().porcelain())
                   {
-                     return common::terminal::format::formatter< admin::model::resource::Proxy>::construct(
+                     return common::terminal::format::print( resources,
                         common::terminal::format::column( "name", std::mem_fn( &admin::model::resource::Proxy::name), common::terminal::color::yellow),
                         common::terminal::format::column( "id", std::mem_fn( &admin::model::resource::Proxy::id), common::terminal::color::yellow, terminal::format::Align::right),
                         common::terminal::format::column( "key", std::mem_fn( &admin::model::resource::Proxy::key), common::terminal::color::yellow),
@@ -370,7 +370,7 @@ resources:
                   else
                   {
                      // we need to keep compatibility with porcelain
-                     return common::terminal::format::formatter< admin::model::resource::Proxy>::construct(
+                     return common::terminal::format::print( resources,
                         common::terminal::format::column( "name", std::mem_fn( &admin::model::resource::Proxy::name)),
                         common::terminal::format::column( "id", std::mem_fn( &admin::model::resource::Proxy::id)),
                         common::terminal::format::column( "key", std::mem_fn( &admin::model::resource::Proxy::key)),
@@ -420,7 +420,7 @@ PAT:
 )";
 
 
-               auto internal_instances()
+               auto internal_instances( auto&& instances)
                {
                   auto format_pid = []( const admin::model::resource::Instance& value) 
                   {
@@ -474,7 +474,7 @@ PAT:
                      return std::chrono::duration_cast< time_type>( value.metrics.resource.total / value.metrics.resource.count).count();
                   };
 
-                  return common::terminal::format::formatter< admin::model::resource::Instance>::construct(
+                  return common::terminal::format::print( instances,
                      terminal::format::column( "id", std::mem_fn( &admin::model::resource::Instance::id), common::terminal::color::yellow, terminal::format::Align::right),
                      terminal::format::column( "pid", format_pid, common::terminal::color::white, terminal::format::Align::right),
                      terminal::format::column( "ipc", format_ipc, common::terminal::color::no_color, terminal::format::Align::right),
@@ -515,7 +515,7 @@ rm-avg:
 )";
 
 
-               auto external_instances()
+               auto external_instances( auto&& instances)
                {
                   auto format_id = []( auto& value) { return value.id;};
                   auto format_pid = []( auto& value) { return value.process.pid;};
@@ -524,7 +524,7 @@ rm-avg:
                   auto format_description = []( auto& value) { return terminal::format::guard_empty( value.description);}; 
 
                   if( ! terminal::output::directive().porcelain())
-                     return common::terminal::format::formatter< local::normalized::Instance>::construct(
+                     common::terminal::format::print( instances,
                         common::terminal::format::column( "id", format_id, common::terminal::color::yellow, terminal::format::Align::left),
                         common::terminal::format::column( "alias", format_alias, common::terminal::color::blue, terminal::format::Align::left),
                         common::terminal::format::column( "pid", format_pid, common::terminal::color::no_color, terminal::format::Align::right),
@@ -532,7 +532,7 @@ rm-avg:
                         common::terminal::format::column( "description", format_description, common::terminal::color::yellow, terminal::format::Align::left)
                      );
                   else
-                     return common::terminal::format::formatter< local::normalized::Instance>::construct(
+                     common::terminal::format::print( instances,
                         common::terminal::format::column( "id", format_id),
                         common::terminal::format::column( "alias", format_alias),
                         common::terminal::format::column( "pid", format_pid),
@@ -555,7 +555,7 @@ description:
    this will hold the name of the other domain.
 )";
 
-               auto instances()
+               auto instances( auto&& instances)
                {
                   struct format_state
                   {
@@ -589,7 +589,7 @@ description:
 
                   if( ! terminal::output::directive().porcelain())
                   {
-                     return terminal::format::formatter< local::normalized::Instance>::construct(
+                     terminal::format::print( instances,
                         terminal::format::column( "id", format_id, terminal::color::yellow, terminal::format::Align::left),
                         terminal::format::column( "alias", format_alias, terminal::color::blue, terminal::format::Align::left),
                         terminal::format::custom::column( "state", format_state{}),
@@ -600,7 +600,7 @@ description:
                   }
                   else
                   {
-                     return terminal::format::formatter< local::normalized::Instance>::construct(
+                     terminal::format::print( instances,
                         terminal::format::column( "id", format_id),
                         terminal::format::custom::column( "state", format_state{}),
                         terminal::format::column( "pid", format_pid),
@@ -639,7 +639,7 @@ description:
                         []()
                         {
                            auto state = call::state();
-                           format::transaction().print( std::cout, state.transactions);
+                           format::transaction( state.transactions);
                         },
                         { "-lt", "--list-transactions"},
                         R"(list current transactions)"
@@ -658,7 +658,7 @@ description:
 
                            const auto branch_count = normalized::compute_branch_count( state);
 
-                           format::resource_proxy( branch_count).print( std::cout, algorithm::sort( state.resources));
+                           format::resource_proxy( algorithm::sort( state.resources), branch_count);
                         },
                         { "-lr", "--list-resources" },
                         R"(list all resources)"
@@ -682,7 +682,7 @@ description:
                      };
 
                      auto instances = transform( call::state().resources);
-                     format::internal_instances().print( std::cout, algorithm::sort( instances));
+                     format::internal_instances( algorithm::sort( instances));
                   }
 
                   void external()
@@ -692,7 +692,7 @@ description:
                      auto instances = normalized::instances();
 
                      auto externals = algorithm::filter( instances, is_external);
-                     format::external_instances().print( std::cout, externals);
+                     format::external_instances( externals);
                   }
 
                   enum struct Flag
@@ -730,7 +730,7 @@ description:
                         else // Flag::all (or none)
                         {
                            auto instances = normalized::instances();
-                           format::instances().print( std::cout, instances);
+                           format::instances( instances);
                         }
                      };
 
@@ -920,7 +920,7 @@ description:
                auto option()
                {
                   return argument::Option{
-                     [](){ terminal::formatter::key::value().print( std::cout, call());},
+                     [](){ terminal::format::pair::print( call());},
                      { "--information"},
                      R"(collect aggregated information about transactions in this domain)"
                   };


### PR DESCRIPTION
This patch: we use the _column-formatters_ parameter pack directly when calculating width and printing, with help of fold-expression. Now it's a function api that is easier to use.