### PR TITLE
domain: if server exit during boot the task might get stuck

### DIFF
--- a/documentation/changelog.md
+++ b/documentation/changelog.md
@@ -1,6 +1,12 @@
 # Changelog
 This is the changelog for `casual` and all changes are listed in this document.
 
+## [1.8.4] - 2025-11-04
+
+### Fixes
+- domain: if server exit during boot the task might get stuck ([#624](https://github.com/casualcore/casual/issues/624))
+
+
 ## [1.8.3] - 2025-10-06
 
 ### Fixes

--- a/middleware/domain/include/domain/manager/state.h
+++ b/middleware/domain/include/domain/manager/state.h
@@ -43,6 +43,15 @@ namespace casual
 
       namespace state
       {
+         enum class Runlevel : short
+         {
+            startup,
+            running,
+            shutdown,
+            error,
+         };
+         std::string_view description( Runlevel value);
+
          struct Group
          {
             strong::group::id id = strong::group::id::generate();
@@ -240,7 +249,7 @@ namespace casual
             const_instances_range shutdownable() const;
 
             void scale( platform::size::type instances);
-            void remove( common::strong::process::id instance, common::process::lifetime::exit::Reason reason);
+            void remove( common::strong::process::id instance, common::process::lifetime::exit::Reason reason, Runlevel runlevel);
 
             friend bool operator == ( const Executable& lhs, common::strong::process::id rhs);
             inline friend bool operator == ( common::strong::process::id lhs, const Executable& rhs) { return rhs == lhs;}
@@ -283,7 +292,7 @@ namespace casual
             const instance_type* instance( common::strong::process::id pid) const;
 
             //! @returns 'null handle' if not found
-            common::process::Handle remove( common::strong::process::id pid, common::process::lifetime::exit::Reason reason);
+            common::process::Handle remove( common::strong::process::id pid, common::process::lifetime::exit::Reason reason, Runlevel runlevel);
 
             bool connect( const common::process::Handle& process);
 
@@ -407,15 +416,6 @@ namespace casual
          {
             bool singleton( common::strong::process::id pid);
          } // is
-
-         enum class Runlevel : short
-         {
-            startup,
-            running,
-            shutdown,
-            error,
-         };
-         std::string_view description( Runlevel value);
 
          using Grandchild = common::message::domain::process::Information;
 

--- a/middleware/domain/source/manager/handle.cpp
+++ b/middleware/domain/source/manager/handle.cpp
@@ -987,12 +987,12 @@ namespace casual
 
                            if( auto server = state.server( message.information.handle.pid))
                            {
-                              server->remove( message.information.handle.pid, common::process::lifetime::exit::Reason::exited);
+                              server->remove( message.information.handle.pid, common::process::lifetime::exit::Reason::exited, state.runlevel());
                               server->scale( 1);
                            }
                            else if( auto executable = state.executable( message.information.handle.pid))
                            {
-                              executable->remove( message.information.handle.pid, common::process::lifetime::exit::Reason::exited);
+                              executable->remove( message.information.handle.pid, common::process::lifetime::exit::Reason::exited, state.runlevel());
                               executable->scale( 1);
                            }
                            

--- a/middleware/domain/source/manager/state.cpp
+++ b/middleware/domain/source/manager/state.cpp
@@ -38,6 +38,18 @@ namespace casual
 
       namespace state
       {
+         std::string_view description( Runlevel value)
+         {
+            switch( value)
+            {
+               case Runlevel::error: return "error";
+               case Runlevel::running: return "running";
+               case Runlevel::shutdown: return "shutdown";
+               case Runlevel::startup: return "startup";
+            }
+            return "<unknown>";
+         }
+
          namespace instance
          {
             std::string_view description( State value) noexcept
@@ -187,7 +199,7 @@ namespace casual
             local::instance::scale( *this, count);
          }
 
-         void Executable::remove( strong::process::id pid, common::process::lifetime::exit::Reason reason)
+         void Executable::remove( strong::process::id pid, common::process::lifetime::exit::Reason reason, Runlevel runlevel)
          {
             Trace trace{ "domain::manager::state::Executable::remove"};
 
@@ -212,7 +224,8 @@ namespace casual
                   }
                   case instance::Wanted::running:
                   {
-                     if( restart)
+                     // we only restart if we are in running runlevel
+                     if( restart && runlevel == Runlevel::running)
                         initiated_restarts++;
                      else
                         found->wanted = instance::Wanted::lingered;
@@ -234,7 +247,7 @@ namespace casual
             return algorithm::find_if( instances, [pid]( auto& p){ return p.handle.pid == pid;}).data();
          }
 
-         common::process::Handle Server::remove( common::strong::process::id pid, common::process::lifetime::exit::Reason reason)
+         common::process::Handle Server::remove( common::strong::process::id pid, common::process::lifetime::exit::Reason reason, Runlevel runlevel)
          {
             Trace trace{ "domain::manager::state::Server::remove"};
 
@@ -254,7 +267,8 @@ namespace casual
                      return algorithm::container::extract( instances, std::begin( found)).handle;
                   case instance::Wanted::running:
                   {
-                     if( restart)
+                     // we only restart if we are in running runlevel
+                     if( restart && runlevel == Runlevel::running)
                         initiated_restarts++;
                      else
                         found->wanted = instance::Wanted::lingered;
@@ -307,18 +321,6 @@ namespace casual
             return lhs.instance( rhs) != nullptr;
          }
 
-         std::string_view description( Runlevel value)
-         {
-            switch( value)
-            {
-               case Runlevel::error: return "error";
-               case Runlevel::running: return "running";
-               case Runlevel::shutdown: return "shutdown";
-               case Runlevel::startup: return "startup";
-            }
-            return "<unknown>";
-         }
-
       } // state
 
 
@@ -357,7 +359,7 @@ namespace casual
             log::debug( "found: ", *found);
 
             // we know the instance exists...
-            auto process = found->remove( pid, reason);
+            auto process = found->remove( pid, reason, runlevel());
 
             log::debug( "remove server instance: ", process);
 
@@ -373,7 +375,7 @@ namespace casual
          {
             log::debug( "found: ", *found);
 
-            found->remove( pid, reason);
+            found->remove( pid, reason, runlevel());
             log::debug( "remove executable instance: ", pid);
 
             if( found->restart && runlevel == state::Runlevel::running)

--- a/middleware/domain/unittest/source/manager/test_manager.cpp
+++ b/middleware/domain/unittest/source/manager/test_manager.cpp
@@ -80,6 +80,7 @@ namespace casual
                };
             } // find
 
+
          } // <unnamed>
       } // local
 
@@ -523,6 +524,35 @@ domain:
          auto server = local::get_global_state( local::find::alias( state.servers, "foo")->instances.at( 0).handle);
          EXPECT_TRUE( server.instance.alias == "foo") << "server.instance.alias: " << server.instance.alias;
          EXPECT_TRUE( server.instance.index == 0) << "server.instance.index: " << server.instance.index;
+
+      }
+
+      TEST( domain_manager, faulty_server___expect_restart_ignored_during_boot)
+      {
+         common::unittest::Trace trace;
+
+         constexpr auto configuration = R"(
+domain:
+   name: A
+   servers:
+      -  alias: faulty
+         path: ./bin/test-simple-server
+         arguments: [ --terminate ]
+         instances: 1
+         restart: true
+
+)";
+
+         
+         auto domain = local::domain( configuration);
+
+         auto state = unittest::state();
+
+         auto server = common::algorithm::find( state.servers, "faulty");
+         ASSERT_TRUE( server) << CASUAL_NAMED_VALUE( state.servers);
+         EXPECT_TRUE( server->instances.size() == 1 ) << CASUAL_NAMED_VALUE( server->instances.size());
+         // expect the instance to be in error state since restart is ignored during boot
+         EXPECT_TRUE( server->instances.at( 0).state == decltype( server->instances.at( 0).state)::error);
 
       }
 

--- a/middleware/domain/unittest/source/manager/test_state.cpp
+++ b/middleware/domain/unittest/source/manager/test_state.cpp
@@ -288,7 +288,7 @@ domain:
          auto pids = common::algorithm::transform( executable.instances, []( auto& instance){ return instance.handle;});
 
          for( auto pid : common::algorithm::random::shuffle( pids))
-            executable.remove( pid, common::process::lifetime::exit::Reason::exited);
+            executable.remove( pid, common::process::lifetime::exit::Reason::exited, state::Runlevel::running);
 
          EXPECT_TRUE( common::algorithm::all_of( executable.instances, has_state( state::instance::State::disabled)));
       }

--- a/middleware/domain/unittest/source/simple_server.cpp
+++ b/middleware/domain/unittest/source/simple_server.cpp
@@ -13,6 +13,8 @@
 #include "common/environment.h"
 #include "common/signal.h"
 
+#include "casual/argument.h"
+
 #include "common/signal.h"
 
 namespace casual
@@ -22,9 +24,24 @@ namespace casual
    {
       namespace
       {
-         void main(int argc, char **argv)
+         struct Settings
          {
-            
+            bool terminate = false;
+
+            CASUAL_LOG_SERIALIZE(
+               CASUAL_SERIALIZE( terminate);
+            )
+
+         };
+
+         void run( Settings settings)
+         {
+            if( settings.terminate)
+            {
+               log::information( "terminating as per settings");
+               std::terminate();
+            }
+
             signal::callback::registration< code::signal::hangup>( []()
             {
                log::line( log::category::information, "signal callback - ", code::signal::hangup);
@@ -53,6 +70,18 @@ namespace casual
             );
 
             message::dispatch::pump( handler, ipc);
+         }
+
+         void main(int argc, char **argv)
+         {
+            Settings settings;
+            { 
+               casual::argument::parse( "simple server", {
+                  casual::argument::Option( argument::option::flag( settings.terminate), { "--terminate"}, "if set, the server will terminate directly" ), 
+               }, argc, argv);
+            }
+
+            run( std::move( settings));
          }
 
       } // <unnamed>


### PR DESCRIPTION
Before: When a server instance exit during boot/startup and the server has `restart`. The state for the instance remains _scale-out_, but no restart will happen (due to boot/startup runlevel). This will render the task 'stuck', and a lot of things will not work (all stuff that also uses task to get their job done, since they're blocked by the stuck task.

Now: If we're in another runleveln than `running` we just set wanted 'state' of the instance to _linger_, which the task will consider to be done. The instance state becomes `error` in the cli, which is the correct state for the instance in this scenario.

Resolves #624