### PR TITLE
service: SM doesn't remove pending deadlines when an instance dies

### DIFF
--- a/documentation/changelog.md
+++ b/documentation/changelog.md
@@ -1,6 +1,11 @@
 # Changelog
 This is the changelog for `casual` and all changes are listed in this document.
 
+## [1.8.5] - 2025-11-07
+
+### Fixes
+- service: SM doesn't remove pending deadlines when an instance dies ([#631](https://github.com/casualcore/casual/issues/631))
+
 ## [1.8.4] - 2025-11-04
 
 ### Fixes

--- a/middleware/service/include/service/manager/admin/model.h
+++ b/middleware/service/include/service/manager/admin/model.h
@@ -196,6 +196,24 @@ namespace casual
          )
       };
 
+      namespace pending
+      {
+         struct Deadline
+         {
+            common::chronology::time_point when;
+            common::process::Handle target;
+            std::string service;
+
+            CASUAL_CONST_CORRECT_SERIALIZE(
+               CASUAL_SERIALIZE( when);
+               CASUAL_SERIALIZE( target);
+               CASUAL_SERIALIZE( service);
+            )
+         };
+         
+      } // pending
+
+      //! TODO this should be moved to pending::Request
       struct Pending
       {
          std::string requested;
@@ -255,7 +273,11 @@ namespace casual
 
 
          std::vector< Service> services;
+         
+         // TODO should be pending.deadlines and pending.requests
          std::vector< Pending> pending;
+         std::vector< pending::Deadline> deadlines;
+
          std::vector< Route> routes;
          std::vector< Reservation> reservations;
 
@@ -263,6 +285,7 @@ namespace casual
             CASUAL_SERIALIZE( instances);
             CASUAL_SERIALIZE( services);
             CASUAL_SERIALIZE( pending);
+            CASUAL_SERIALIZE( deadlines);
             CASUAL_SERIALIZE( routes);
             CASUAL_SERIALIZE( reservations);
          )

--- a/middleware/service/include/service/manager/state.h
+++ b/middleware/service/include/service/manager/state.h
@@ -272,6 +272,7 @@ namespace casual
                   std::optional< common::chronology::time_point> add( deadline::Entry entry);
                   std::optional< common::chronology::time_point> remove( const common::strong::correlation::id& correlation);
                   std::optional< common::chronology::time_point> remove( const std::vector< common::strong::correlation::id>& correlations);
+                  std::optional< common::chronology::time_point> remove( instance::sequential::id::type instance);
 
                   deadline::Entry* find_entry( const common::strong::correlation::id& correlation);
 
@@ -287,6 +288,8 @@ namespace casual
                   };
 
                   Expired expired( common::chronology::time_point now = common::chronology::time_point::clock::now());
+
+                  const auto& entries() const noexcept { return m_entries;}
 
                   CASUAL_LOG_SERIALIZE( 
                      CASUAL_SERIALIZE_NAME( m_entries, "entries");
@@ -501,11 +504,29 @@ namespace casual
             void remove_service( instance::sequential::id::type instance_id, service::id::type service_id);
             inline void remove_service( instance::concurrent::id::type, service::id::type) { /*no op*/}
 
+            //! @returns the sequential id for the given `pid`, or 'nil-id' if not found
+            instance::sequential::id::type find_sequential( common::strong::process::id pid) const;
+
             CASUAL_LOG_SERIALIZE(
                CASUAL_SERIALIZE( sequential);
                CASUAL_SERIALIZE( concurrent);
             )
          };
+
+         namespace remove
+         {
+            struct Result
+            {
+               std::vector< state::instance::Reservation> reservations;
+               //! potentially new deadline to be set.
+               std::optional< common::chronology::time_point> next_deadline;
+
+               CASUAL_LOG_SERIALIZE(
+                  CASUAL_SERIALIZE( reservations);
+                  CASUAL_SERIALIZE( next_deadline);
+               )
+            };
+         } // remove
 
          enum struct Runlevel : short
          {
@@ -604,9 +625,9 @@ namespace casual
          
          //! removes the instance (deduced from `pid`) and remove the instance from all services 
          //! @returns possible reservations of the removed instance (in practice 0..1)
-         [[nodiscard]] std::vector< state::instance::Reservation> remove( common::strong::process::id pid);
+         [[nodiscard]] state::remove::Result remove( common::strong::process::id pid);
          //! @returns possible reservations of the removed instance
-         std::vector< state::instance::Reservation> remove( common::strong::ipc::id ipc);
+         state::remove::Result remove( common::strong::ipc::id ipc);
 
          //! Tries to reserve a sequential instance for the given `service`
          //! @return id of the instance, or 'nil-id' if no idle is found

--- a/middleware/service/source/manager/handle.cpp
+++ b/middleware/service/source/manager/handle.cpp
@@ -288,8 +288,13 @@ namespace casual
 
                         state.pending.shutdown.failed( event.state.pid);
 
+                        auto removed = state.remove( event.state.pid);
+
+                        if( removed.next_deadline)
+                           common::signal::timer::set( *removed.next_deadline);
+
                         // we need to check if the dead process has anyone waiting for a reply
-                        for( auto reservation : state.remove( event.state.pid))
+                        for( auto reservation : removed.reservations)
                         {
                            common::log::error( common::code::casual::invalid_semantics, " callee terminated with pending reply to caller - callee: ", 
                                  event.state.pid, " - caller: ", reservation.caller.process.pid);

--- a/middleware/service/source/manager/state.cpp
+++ b/middleware/service/source/manager/state.cpp
@@ -247,6 +247,22 @@ namespace casual
                   return {};
                }
 
+               std::optional< common::chronology::time_point> Deadline::remove( instance::sequential::id::type instance)
+               {
+                  auto has_instance = [ instance]( auto& entry){ return entry.target == instance;};
+
+                  auto [ keep, remove] = algorithm::stable::partition( m_entries, predicate::negate( has_instance));
+
+                  // has the next deadline been postponed?
+                  if( remove && keep && range::front( remove) < range::front( keep))
+                  {
+                     algorithm::container::trim( m_entries, keep);
+                     return { m_entries.front().when};
+                  }
+                  algorithm::container::trim( m_entries, keep);
+                  return {};
+               }
+
                deadline::Entry* Deadline::find_entry( const common::strong::correlation::id& correlation)
                {
                   return algorithm::find( m_entries, correlation).data();
@@ -412,6 +428,15 @@ namespace casual
          {
             if( sequential.contains( instance_id))
                sequential[ instance_id].remove( service_id);
+         }
+
+         instance::sequential::id::type Instances::find_sequential( common::strong::process::id pid) const
+         {
+            for( auto id : sequential.indexes())
+               if( sequential[ id].process.pid == pid)
+                  return id;
+
+            return {};
          }
 
          std::string_view description( Runlevel value)
@@ -580,7 +605,7 @@ namespace casual
          } // <unnamed>
       } // local
 
-      std::vector< state::instance::Reservation> State::remove( common::strong::process::id pid)
+      state::remove::Result State::remove( common::strong::process::id pid)
       {
          Trace trace{ "service::manager::State::remove"};
          log::debug( "pid: ", pid);
@@ -588,15 +613,30 @@ namespace casual
          if( forward.pid == pid)
             forward.clear();
 
-         return local::remove( *this, pid);
+         state::remove::Result result;
+      
+         if( auto id = instances.find_sequential( pid))
+            result.next_deadline = pending.deadline.remove( id);
+
+         result.reservations = local::remove( *this, pid);
+
+         return result;
       }
 
-      std::vector< state::instance::Reservation> State::remove( common::strong::ipc::id ipc)
+
+      state::remove::Result State::remove( common::strong::ipc::id ipc)
       {
          Trace trace{ "service::manager::State::remove"};
          log::debug( "ipc: ", ipc);
 
-         return local::remove( *this, ipc);
+         state::remove::Result result;
+
+         if( auto index = instances.sequential.lookup( ipc))
+            result.next_deadline = pending.deadline.remove( index);
+
+         result.reservations = local::remove( *this, ipc);
+
+         return result;
       }
 
       state::instance::sequential::id::type State::reserve_sequential( state::instance::Caller caller)
@@ -756,7 +796,16 @@ namespace casual
          if( message.directive == decltype( message.directive)::reset)
          {
             // remove the instance and it's associations
-            remove( message.process.ipc);
+            auto removed = remove( message.process.ipc);
+
+            // When we remove a concurrent instance, we do not expect any reservations
+            // or any timeouts to be affected. Since callers don't ever wait for concurrent
+            // instances, and timeouts are not in play for concurrent instances.
+            if( ! std::empty( removed.reservations))
+               log::error( code::casual::internal_unexpected_value, "concurrent instance ", message.process.ipc, " had reservations - ", removed.reservations);
+
+            if( removed.next_deadline)
+               log::error( code::casual::internal_unexpected_value, "removed concurrent instance ", message.process.ipc, " resulted in a deadline update");
 
             // we're removing stuff, no new services can be available.
             return {};

--- a/middleware/service/source/manager/transform.cpp
+++ b/middleware/service/source/manager/transform.cpp
@@ -32,6 +32,24 @@ namespace casual
                };
             };
 
+            auto deadlines( const manager::State& state)
+            {
+               return [ &state]( const auto& entry)
+               {
+                  auto result = manager::admin::model::pending::Deadline{
+                     .when = entry.when
+                  };
+
+                  if( state.instances.sequential.contains( entry.target))
+                     result.target = state.instances.sequential[ entry.target].process;
+
+                  if( state.services.contains( entry.service))
+                     result.service = state.services[ entry.service].information.name;
+
+                  return result;
+               };
+            }
+
             void services( const manager::State& state, auto& target)
             {
                state.services.for_each( [ &state, &target]( auto id, auto& name, auto& service)
@@ -145,6 +163,8 @@ namespace casual
 
       manager::admin::model::State state( const manager::State& state)
       {
+         Trace trace{ "service::manager::transform::state"};
+
          manager::admin::model::State result;
 
          auto transform_index = []( auto& index, auto& result, auto transformer)
@@ -160,6 +180,7 @@ namespace casual
          local::services( state, result.services);
 
          common::algorithm::transform( state.pending.lookups, result.pending, local::pending());
+         common::algorithm::transform( state.pending.deadline.entries(), result.deadlines, local::deadlines( state));
 
          common::algorithm::for_each( state.routes, [&result]( auto& pair)
          {

--- a/middleware/service/unittest/source/manager/test_manager.cpp
+++ b/middleware/service/unittest/source/manager/test_manager.cpp
@@ -1354,7 +1354,14 @@ domain:
       {
          common::unittest::Trace trace;
 
-         auto domain = local::domain();
+         auto domain = local::domain( R"(
+domain:
+   services:
+      -  name: a
+         execution:
+            timeout:
+               duration: 500ms
+)");
 
          // a fake process that advertises some arbitrary service
          auto callee_inbound = common::communication::ipc::inbound::Device{};
@@ -1397,6 +1404,12 @@ domain:
             EXPECT_TRUE( metric.process.pid == callee.pid);
             EXPECT_TRUE( metric.code.result == common::code::xatmi::service_error);
             EXPECT_TRUE( metric.trid == casual::transaction::context().current().trid);
+         }
+
+         // expect no deadlines left
+         {
+            auto state = unittest::state();
+            EXPECT_TRUE( state.deadlines.empty()) << CASUAL_NAMED_VALUE( state.deadlines);
          }
       }
 


### PR DESCRIPTION
Before: SM did not remove associated pending deadlines to an exited instance -> when the deadline kicks in SM fails to correlate the deadline and error log.

Now: SM removes associated pending deadlines when an instance exit

Resolves #630