### PR TITLE
http: make sure to accept the Accept header suitable for GET requests

### DIFF
--- a/middleware/http/source/inbound/call.cpp
+++ b/middleware/http/source/inbound/call.cpp
@@ -35,8 +35,10 @@ namespace casual
                {
                   if( auto found = algorithm::find( header, "content-type"))
                       return protocol::convert::to::buffer( found->value());
+                  if( auto found = algorithm::find( header, "accept"))
+                      return protocol::convert::to::buffer( found->value());
 
-                  common::code::raise::error( code::bad_request, "content-type header is mandatory");                 
+                  common::code::raise::error( code::bad_request, "content-type or accept header is mandatory");
                }
             } // buffer
 


### PR DESCRIPTION
In a GET request there's typically no body and thus the Content-Type header is a bit ambigious but the Accept header is then the correct one in order to tell the server what you can handle

As for this commit, it doesn't expect multiple values, e.g. `Accept: application/xml,application/json`

Resolves #623