### PR TITLE
file: make sure to expand paths in order to catch some bad input

### DIFF
--- a/middleware/file/documentation/file.development.md
+++ b/middleware/file/documentation/file.development.md
@@ -29,7 +29,7 @@ Multiple access to the same (original) path within the same transaction if of co
 ...
 
    const auto path = casual::file::reserve( the_path);
-   std::ofstream{ path} << data;
+   std::ofstream{ path, std::ios::noreplace} << data;
 
 ...
    tx_commit();
@@ -45,7 +45,7 @@ Multiple access to the same (original) path within the same transaction if of co
 ...
 
    const auto path = casual::file::reserve( the_path);
-   std::ofstream{ path} << data;
+   std::ofstream{ path, std::ios::in} << data;
 
 ...
    tx_commit();

--- a/middleware/file/documentation/file.operation.md
+++ b/middleware/file/documentation/file.operation.md
@@ -7,6 +7,6 @@
 
 ## configuration
 
-`casual-file` requires no configuration
+`casual-file` requires no configuration (except for adding it to servers)
 
 

--- a/middleware/file/source/manager/resource.cpp
+++ b/middleware/file/source/manager/resource.cpp
@@ -82,7 +82,7 @@ namespace casual::file::resource
                if( std::filesystem::exists( rushes))
                   std::filesystem::rename( rushes, request.path);
                else
-                  std::filesystem::remove_all( request.path);
+                  std::filesystem::remove( request.path);
             }
 
             void rollback( const Request& request)
@@ -90,7 +90,7 @@ namespace casual::file::resource
                const auto rushes = local::temporary( request.trid, request.path);
 
                if( std::filesystem::exists( rushes))
-                  std::filesystem::remove_all( rushes);
+                  std::filesystem::remove( rushes);
             }
 
             void mitigate( const Request& request)
@@ -98,7 +98,7 @@ namespace casual::file::resource
                rollback( request);
             }
 
-            auto reserve( State& state, const Request& request) -> std::expected<std::filesystem::path, code>
+            auto reserve( State& state, Request& request) -> std::expected<std::filesystem::path, code>
             {
                if( state.runlevel == State::Runlevel::shutdown)
                {
@@ -106,19 +106,22 @@ namespace casual::file::resource
                   return std::unexpected( code::error);
                }
    
-               if( const auto work = std::ranges::find( state.working, request.path, &Request::path); work != state.working.end())
-               {
-                  //
-                  // requested path is involved
-   
-                  if( work->trid == request.trid)
-                     return temporary( request.trid, request.path);
-                  else
-                     return std::unexpected( code::busy);
-               }
-   
                try
                {
+                  request.time = std::chrono::system_clock::now();
+                  request.path = std::filesystem::weakly_canonical( std::filesystem::absolute( request.path));
+                  
+                  if( const auto work = std::ranges::find( state.working, request.path, &Request::path); work != state.working.end())
+                  {
+                     //
+                     // requested path is involved
+      
+                     if( work->trid == request.trid)
+                        return temporary( request.trid, request.path);
+                     else
+                        return std::unexpected( code::busy);
+                  }
+      
                   auto result = reserve( request);
    
                   if( std::ranges::find( state.working, request.trid, &Request::trid) == state.working.end())
@@ -141,26 +144,28 @@ namespace casual::file::resource
    
          } // detail
 
-         void reserve( State& state, Request request)
+         void reserve( State& state, const Reserve& request)
          {
-            auto reply = common::message::reverse::type( static_cast<const Reserve&>(request));
+            auto reply = common::message::reverse::type( request);
 
-            if(auto result = detail::reserve( state, request))
+            Request query{request};
+
+            if(auto result = detail::reserve( state, query))
                reply.path = std::move( result.value());
             else
                reply.code = std::move( result.error());
-      
+
             switch( reply.code)
             {
             break; case code::ok:
                // push to work load
-               state.working.push_back( std::move( request));
+               state.working.push_back( std::move( query));
                // send the reply
                state.multiplex.send( request.process.ipc, std::move( reply));
             break; case code::busy:
                if( request.wait)
                   // push to wait list
-                  state.pending.push_back( std::move( request));
+                  state.pending.push_back( std::move( query));
                else
                   // send the reply
                   state.multiplex.send( request.process.ipc, std::move( reply));
@@ -211,11 +216,7 @@ namespace casual::file::resource
 
    void reserve( State& state, const Reserve& request)
    {
-      Request work{request};
-      work.path = work.path.lexically_normal();
-      work.time = std::chrono::system_clock::now();
-
-      local::reserve( state, std::move( work));
+      local::reserve( state, request);
    }
 
    void prepare( State& state, const Prepare& request)

--- a/middleware/file/unittest/source/resource/test_resource.cpp
+++ b/middleware/file/unittest/source/resource/test_resource.cpp
@@ -81,6 +81,26 @@ domain:
          EXPECT_EQ( after, result) << result;
       }
 
+      TEST( casual_file_resource, reserve_folder__expecting_error)
+      {
+         common::unittest::Trace trace;
+
+         auto domain = local::domain();
+
+         const auto path = std::filesystem::current_path();
+
+         {
+            EXPECT_EQ( transaction::context().begin(), common::code::tx::ok);
+
+            EXPECT_THROW({
+               const auto work = file::blocking::reserve( path);
+            }, std::system_error);
+
+            EXPECT_EQ( transaction::context().commit(), common::code::tx::ok);
+         }
+
+      }
+
       TEST( casual_file_resource, update_file__rollback__expect_earlier_file)
       {
          common::unittest::Trace trace;


### PR DESCRIPTION
The changes implicitly adds some extra controls and as a consequence paths are represented as absolute paths that probably is better in cli

Some minor refactoring was also made in order to catch any possible std::bad_alloc when doing some lexically work

Solves issue #638