### PR TITLE
http: Looking for header Accept along with Content-Type to deduce buffer

### DIFF
--- a/middleware/buffer/include/casual/buffer/octet.h
+++ b/middleware/buffer/include/casual/buffer/octet.h
@@ -20,6 +20,20 @@
 #define CASUAL_OCTET_OUT_OF_MEMORY 4
 #define CASUAL_OCTET_INTERNAL_FAILURE 128
 
+
+#ifdef __cplusplus
+
+#include <string_view>
+
+namespace casual::buffer::octet
+{
+   constexpr std::string_view key = CASUAL_OCTET "/";
+} // casual::buffer::octet
+
+extern "C" {
+#endif
+
+
 const char* casual_octet_description( int code);
 
 
@@ -29,4 +43,7 @@ int casual_octet_set( char** buffer, const char* data, long size);
 int casual_octet_get( const char* buffer, const char** data, long* size);
 
 
+#ifdef __cplusplus
+}
+#endif
 

--- a/middleware/http/include/http/code.h
+++ b/middleware/http/include/http/code.h
@@ -23,6 +23,7 @@ namespace casual
          // 4xx
          bad_request = 400,
          not_found = 404,
+         not_acceptable = 406,
          request_timeout = 408,
          
 

--- a/middleware/http/include/http/common.h
+++ b/middleware/http/include/http/common.h
@@ -65,21 +65,20 @@ namespace casual
          constexpr std::string_view x_octet = "application/casual-x-octet";
          constexpr std::string_view binary = "application/casual-binary";
          constexpr std::string_view json = "application/json";
+         constexpr std::string_view yaml = "application/yaml";
+         constexpr std::string_view toml = "application/toml";
          constexpr std::string_view xml = "application/xml";
          constexpr std::string_view field = "application/casual-field";
+         constexpr std::string_view order = "application/casual-order";
          constexpr std::string_view string = "application/casual-string";
-         constexpr std::string_view null = "application/casual-null";
+         constexpr std::string_view null = "application/casual-null"; 
 
          namespace convert
          {
-            namespace from
-            {
-               std::string buffer( std::string_view buffer);
-            } // from
-
             namespace to
             {
-               std::string buffer( std::string_view content);
+               std::string_view content( std::string_view buffer);
+               std::string_view buffer( std::string_view content);
             } // to
          } // convert
       } //protocol

--- a/middleware/http/include/http/inbound/call.h
+++ b/middleware/http/include/http/inbound/call.h
@@ -137,7 +137,10 @@ namespace casual
          
       };
 
-
+      namespace buffer
+      {
+         auto type( const std::vector< header::Field>& headers) -> std::string_view;
+      } // buffer
 
    } // http::inbound::call
 } // casual

--- a/middleware/http/source/code.cpp
+++ b/middleware/http/source/code.cpp
@@ -32,6 +32,7 @@ namespace casual
 
                      case code::bad_request: return "Bad Request";
                      case code::not_found: return "Not Found";
+                     case code::not_acceptable: return "Not Acceptable";
                      case code::request_timeout: return "Request Timeout";
 
                      case code::internal_server_error: return "Internal Server Error";
@@ -39,7 +40,6 @@ namespace casual
                   }
                   return "<unknown>";
                }
-
 
             };
 

--- a/middleware/http/source/common.cpp
+++ b/middleware/http/source/common.cpp
@@ -7,7 +7,6 @@
 
 #include "http/common.h"
 
-#include "common/algorithm.h"
 #include "common/algorithm/compare.h"
 #include "common/algorithm/container.h"
 #include "common/buffer/type.h"
@@ -15,6 +14,7 @@
 #include "common/log/line.h"
 
 #include "casual/buffer/field.h"
+#include "casual/buffer/order.h"
 #include "casual/buffer/string.h"
 
 namespace casual
@@ -92,85 +92,47 @@ namespace casual
             {
                namespace
                {
-                  template< typename C, typename K, typename G>
-                  std::string find( C& container, const K& key, G&& generic)
+                  constexpr std::size_t buffer_type = 0;
+                  constexpr std::size_t content_type = 1;
+
+                  template< std::size_t key_index, std::size_t value_index>
+                  auto find( const auto& key) -> std::string_view
                   {
-                     auto found = common::algorithm::find( container, key);
+                     static const std::array mapping
+                     {
+                        std::pair{ common::buffer::type::x_octet, protocol::x_octet},
+                        std::pair{ common::buffer::type::binary, protocol::binary},
+                        std::pair{ common::buffer::type::json, protocol::json},
+                        std::pair{ common::buffer::type::yaml, protocol::yaml},
+                        std::pair{ common::buffer::type::toml, protocol::toml},
+                        std::pair{ common::buffer::type::xml, protocol::xml},
+                        std::pair{ casual::buffer::field::key, protocol::field},
+                        std::pair{ casual::buffer::order::key, protocol::order},
+                        std::pair{ casual::buffer::string::key, protocol::string},
+                        std::pair{ common::buffer::type::null, protocol::null},
+                     };
 
-                     if( found)
-                        return std::string{ found->second};
+                     auto result = std::ranges::find( mapping, key, [] ( const auto& value) -> decltype(auto) { return std::get< key_index>( value);});
 
-                     log::debug( "failed to find key: ", key, " - using generic buffer type protocol");
-                     return generic( key);
+                     if( result != std::end( mapping))
+                        return std::get< value_index>( *result);
+                     else
+                        return {};
                   }
 
-                  namespace buffer
-                  {
-                     namespace type
-                     {
-                        constexpr auto fielded() { return casual::buffer::field::key;}
-                        constexpr auto string() { return casual::buffer::string::key;}
-                        constexpr auto null() { return common::buffer::type::null;}
-                     } // type
-                  } // buffer
-
-                  constexpr std::string_view generic_prefix = "application/casual-generic/";
-
-               } // <unnamed>
+               } //
             } // local
-
-            namespace from
-            {
-               std::string buffer( std::string_view buffer)
-               {
-                  static const std::map< std::string_view, std::string_view> mapping{
-                     { common::buffer::type::x_octet, protocol::x_octet},
-                     { common::buffer::type::binary, protocol::binary},
-                     { common::buffer::type::json, protocol::json},
-                     { common::buffer::type::xml, protocol::xml},
-                     { local::buffer::type::fielded(), protocol::field},
-                     { local::buffer::type::string(), protocol::string},
-                     { local::buffer::type::null(), protocol::null},
-                  };
-
-                  auto generic = []( auto& buffer)
-                  {
-                     return common::string::compose( local::generic_prefix, buffer);
-                  };
-
-                  return local::find( mapping, buffer, generic);
-               }
-            } // from
 
             namespace to
             {
-               std::string buffer( std::string_view content)
+               std::string_view buffer( std::string_view content)
                {
-                  static const std::map< std::string_view, std::string_view> mapping{
-                     { protocol::x_octet, common::buffer::type::x_octet},
-                     { protocol::binary, common::buffer::type::binary},
-                     { protocol::json, common::buffer::type::json},
-                     { protocol::xml, common::buffer::type::xml},
-                     { protocol::field, local::buffer::type::fielded()},
-                     { protocol::string, local::buffer::type::string()},
-                     { protocol::null, local::buffer::type::null()},
-                  };
+                  return local::find< local::content_type, local::buffer_type>( content);
+               }
 
-                  // tries to deduce the buffer type generic
-                  auto generic = []( auto& content) -> std::string
-                  {
-                     auto prefix = common::algorithm::search( content, local::generic_prefix);
-
-                     if( std::begin( prefix) != std::begin( content))
-                     {
-                        log::line( common::log::category::error , "failed to deduce casual generic content - content: ", content);
-                        return {};
-                     }
-
-                     return { std::begin( content) + local::generic_prefix.size(), std::end( content)};
-                  };
-
-                  return local::find( mapping, content, generic);
+               std::string_view content( std::string_view buffer)
+               {
+                  return local::find< local::buffer_type, local::content_type>( buffer);
                }
             } // to
          } // convert

--- a/middleware/http/source/inbound/call.cpp
+++ b/middleware/http/source/inbound/call.cpp
@@ -31,13 +31,39 @@ namespace casual
             
             namespace buffer
             {
-               auto type( const std::vector< header::Field>& header)
+               //! @returns string pieces (views) owned by the caller
+               auto type( const std::vector< header::Field>& headers) -> std::vector< std::string_view>
                {
-                  if( auto found = algorithm::find( header, "content-type"))
-                      return protocol::convert::to::buffer( found->value());
+                  auto content = algorithm::find( headers, "content-type");
 
-                  common::code::raise::error( code::bad_request, "content-type header is mandatory");                 
+                  if( auto accept = algorithm::find( headers, "accept"))
+                  {
+                     auto accepts = 
+                        accept->value() |
+                        std::views::split(',') | 
+                        std::views::transform( []( auto type){ return std::string_view{ common::string::trim( type)};});
+                     
+                     if( content)
+                     {
+                        if( algorithm::find( accepts, content->value()))
+                           return { content->value()};
+
+                        // HTTP behaviour is normally to allow different content-type than what is accepted 
+                        // ... but currently, the source and target buffer need to be of the same type
+                        return {};
+                     }
+
+                     return accepts | std::ranges::to< std::vector>();
+                  }
+
+                  if( content)
+                     return { content->value()};
+
+                  // HTTP behaviour is normally to assume '*/*' if no content-type is given
+                  // ... but currently, the buffer type must be explicit
+                  return {};
                }
+
             } // buffer
 
             namespace extract::header
@@ -194,7 +220,7 @@ namespace casual
                      // extract execution and span from the traceparent header
                      std::tie( result.execution, result.parent.span) = extract::header::trace( request.payload.header);
 
-                     result.buffer.type = buffer::type( request.payload.header);
+                     result.buffer.type = call::buffer::type( request.payload.header);
                      result.buffer.data = std::move( request.payload.body);
                      result.header = std::move( request.payload.header);
 
@@ -206,10 +232,10 @@ namespace casual
                      Reply result;
                      result.payload.body = std::move( reply.buffer.data);
                      result.payload.header.emplace_back( "content-length", std::to_string( result.payload.body.size()));
-                     result.payload.header.emplace_back( "content-type", http::protocol::convert::from::buffer( reply.buffer.type));
+                     result.payload.header.emplace_back( "content-type", http::protocol::convert::to::content( reply.buffer.type));
                      result.payload.header.emplace_back( http::header::name::result::code, http::header::value::result::code( reply.code.result));
                      result.payload.header.emplace_back( http::header::name::result::user::code, http::header::value::result::user::code( reply.code.user));
-                     result.code = local::transform::reply::code( reply.code.result);
+                     result.code = transform::reply::code( reply.code.result);
 
                      return result;
                   }
@@ -272,7 +298,7 @@ namespace casual
                         if( reply.code.user != 0)
                            return static_cast< http::code>( reply.code.user);
 
-                        return local::transform::reply::code( reply.code.result);
+                        return transform::reply::code( reply.code.result);
                      };
 
                      result.payload.body = std::move( reply.buffer.data);
@@ -383,6 +409,21 @@ namespace casual
          
          return result;
       }
+
+      namespace buffer
+      {
+         auto type( const std::vector< header::Field>& headers) -> std::string_view
+         {
+            auto source = local::buffer::type( headers);
+            auto target = source | std::views::transform( []( auto value){ return protocol::convert::to::buffer( value);});
+            auto result = std::ranges::find_if( target, [] ( auto value) { return ! value.empty();});
+            
+            if(result != std::end( target)) 
+               return *result;
+
+            common::code::raise::error( code::not_acceptable, "invalid or missing 'content-type'/'accept' headers");
+         }
+      } // buffer
 
    } // http::inbound::call
 } // casual

--- a/middleware/http/source/outbound/request.cpp
+++ b/middleware/http/source/outbound/request.cpp
@@ -107,12 +107,12 @@ namespace casual
                      // add content header
                      if( ! result.state().payload.type.empty())
                      {
-                        auto content = protocol::convert::from::buffer( result.state().payload.type);
+                        auto content = protocol::convert::to::content( result.state().payload.type);
 
                         common::log::debug( "content: ", content);
 
                         if( ! content.empty())
-                           result.state().header.request.add( "content-type: " + content);
+                           result.state().header.request.add( "content-type: " + std::string{ content});
                      }
 
                      return result;

--- a/middleware/http/unittest/source/inbound/test_call.cpp
+++ b/middleware/http/unittest/source/inbound/test_call.cpp
@@ -358,8 +358,79 @@ domain:
 
             communication::device::blocking::send( request.process.ipc, message::reverse::type( request));
          }
-
   
+      }
+
+      TEST( http_inbound_call_buffer_type, missing_content_type__expect_exception)
+      {
+         const std::vector< call::header::Field> headers{
+            };
+
+            EXPECT_THROW({
+            call::buffer::type( headers);
+         }, std::system_error);
+      }
+
+      TEST( http_inbound_call_buffer_type, invalid_content_type__expect_exception)
+      {
+         const std::vector< call::header::Field> headers{
+            { "Content-Type", "application/qwerty"},
+            };
+
+         EXPECT_THROW({
+            call::buffer::type( headers);
+         }, std::system_error);
+      }
+
+      TEST( http_inbound_call_buffer_type, valid_content_type__expect_buffer)
+      {
+         const std::vector< call::header::Field> headers{
+            { "Content-Type", "application/json"},
+            };
+
+         EXPECT_TRUE( call::buffer::type( headers) == ".json/") << call::buffer::type( headers);
+      }
+
+      TEST( http_inbound_call_buffer_type, invalid_accept_type__expect_exception)
+      {
+         const std::vector< call::header::Field> headers{
+            { "Accept", "application/qwerty"},
+            };
+
+         EXPECT_THROW({
+            call::buffer::type( headers);
+         }, std::system_error);
+      }
+
+      TEST( http_inbound_call_buffer_type, valid_accept_type__expect_buffer)
+      {
+         const std::vector< call::header::Field> headers{
+            { "Accept", "application/qwerty, application/json"},
+            };
+
+         EXPECT_TRUE( call::buffer::type( headers) == ".json/") << call::buffer::type( headers);
+      }
+
+      TEST( http_inbound_call_buffer_type, different_accept_and_content_type__expect_exception)
+      {
+         const std::vector< call::header::Field> headers{
+            { "Accept", "application/toml, application/yaml"},
+            { "Content-Type", "application/json"},
+            };
+
+         EXPECT_THROW({
+            call::buffer::type( headers);
+         }, std::system_error);
+      }
+
+      TEST( http_inbound_call_buffer_type, intersect_content_and_accept_type__expect_buffer)
+      {
+         const std::vector< call::header::Field> headers{
+            { "Accept", "application/toml, application/json, application/yaml"},
+            { "Content-Type", "application/json"},
+            };
+
+         EXPECT_TRUE( call::buffer::type( headers) == ".json/") << call::buffer::type( headers);
       }
 
    } // http::inbound


### PR DESCRIPTION
I'm not too happy with the implementation, but the added unit tests shows the intention

I also removed the casual-generic-application content-type-handling

I added a few buffer - and content types and removed the null buffer


If were gonna support null buffer we need to reinsert that and if we need the casual-generic-handling we need to reinsert that as well


I also fixed some bad makefile in http component