### PR TITLE
file: Send correct information to TM during prepare

### DIFF
--- a/middleware/file/makefile.cmk
+++ b/middleware/file/makefile.cmk
@@ -15,6 +15,7 @@ make.IncludePaths( [
    '../transaction/include',
    '../xatmi/include',
    '../domain/unittest/include',
+   '../queue/include',
    ]
    + dsl.paths().include.gtest
 )
@@ -31,6 +32,8 @@ make.LibraryPaths(
       '../service/bin',
       '../transaction/bin',
       '../xatmi/bin',
+      '../server/bin',
+      '../queue/bin',
    ]
    + make.optional_library_paths()
    + dsl.paths().library.gtest
@@ -108,6 +111,7 @@ test_casual_file = make.LinkUnittest( 'unittest/bin/test-casual-file',
       'casual-service',
       'casual-service-unittest',
       'casual-transaction',
+      'casual-queue-api',
    ]  
 )
 

--- a/middleware/file/source/manager/resource.cpp
+++ b/middleware/file/source/manager/resource.cpp
@@ -211,6 +211,17 @@ namespace casual::file::resource
 
             return result;
          }
+
+         namespace xa::reverse
+         {
+            auto type( const auto& request)
+            {
+               auto reply = common::message::reverse::type( request);
+               reply.resource = request.resource;
+               reply.trid = request.trid;
+               return reply;
+            }
+         } // xa::reverse
       } // 
    } // local
 
@@ -221,14 +232,12 @@ namespace casual::file::resource
 
    void prepare( State& state, const Prepare& request)
    {
-      state.multiplex.send( request.process.ipc, common::message::reverse::type( request));
+      state.multiplex.send( request.process.ipc, local::xa::reverse::type( request));
    }
 
    void commit( State& state, const Commit& request)
    {
-      auto reply = common::message::reverse::type( request);
-      reply.resource = request.resource;
-      reply.trid = request.trid;
+      auto reply = local::xa::reverse::type( request);
 
       //
       // pick the requests involved and finalize them
@@ -241,9 +250,7 @@ namespace casual::file::resource
 
    void rollback( State& state, const Rollback& request)
    {
-      auto reply = common::message::reverse::type( request);
-      reply.resource = request.resource;
-      reply.trid = request.trid;
+      auto reply = local::xa::reverse::type( request);
 
       //
       // pick the requests involved and finalize them

--- a/middleware/file/unittest/source/resource/test_resource.cpp
+++ b/middleware/file/unittest/source/resource/test_resource.cpp
@@ -13,6 +13,7 @@
 #include "transaction/context.h"
 
 #include "file/api/file.h"
+#include "queue/api/queue.h"
 
 #include "file/resource/unittest/utility.h"
 
@@ -30,11 +31,9 @@ namespace casual
       {
          namespace
          {
-            auto domain()
-            {
-               constexpr auto servers = R"(
+            constexpr auto file = R"(
 domain: 
-   name: file-domain
+   name: test-domain
 
    groups: 
       - name: base
@@ -50,17 +49,40 @@ domain:
         memberships: [ file]
 )";
 
-               return domain::unittest::manager( servers);
+            auto file_domain()
+            {
+               return domain::unittest::manager( file);
+            }
+
+         constexpr auto queue = R"(
+domain: 
+   groups: 
+      - name: queuee
+        dependencies: [ base]
+
+   servers:
+      - path: ${CASUAL_MAKE_SOURCE_ROOT}/middleware/queue/bin/casual-queue-manager
+        memberships: [ queuee]
+   queue:
+      groups:
+         -  alias: Q
+            queues:
+               - name: a
+)";
+
+            auto file_queue_domain()
+            {
+               return domain::unittest::manager( file, queue);
             }
          } // 
       } // local
 
 
-      TEST( casual_file_resource, update_file__commit__expect_updated_file)
+      TEST( casual_file_resource, update_file_and_write_message__commit__expect_updated_file)
       {
          common::unittest::Trace trace;
 
-         auto domain = local::domain();
+         auto domain = local::file_queue_domain();
 
          const auto path = common::unittest::file::temporary::name( ".txt");
 
@@ -69,10 +91,23 @@ domain:
 
          std::ofstream{ path} << afore;
 
+         //
+         // make some work in multiple resources
          {
             EXPECT_EQ( transaction::context().begin(), common::code::tx::ok);
-            const auto reserved = file::blocking::reserve( path);
-            std::ofstream{ reserved} << after;
+
+            {
+               const auto reserved = file::blocking::reserve( path);
+               std::ofstream{ reserved} << after;
+            }
+
+            {
+               queue::Message message;
+               message.payload.type = "X_OCTET/";
+               common::algorithm::copy( std::as_bytes( std::span{ std::string_view{ "Hello"}}), message.payload.data);
+               queue::enqueue( "a", message);
+            }
+
             EXPECT_EQ( transaction::context().commit(), common::code::tx::ok);
          }
 
@@ -85,7 +120,7 @@ domain:
       {
          common::unittest::Trace trace;
 
-         auto domain = local::domain();
+         auto domain = local::file_domain();
 
          const auto path = std::filesystem::current_path();
 
@@ -105,7 +140,7 @@ domain:
       {
          common::unittest::Trace trace;
 
-         auto domain = local::domain();
+         auto domain = local::file_domain();
 
          const auto path = common::unittest::file::temporary::name( ".txt");
 
@@ -130,7 +165,7 @@ domain:
       {
          common::unittest::Trace trace;
 
-         auto domain = local::domain();
+         auto domain = local::file_domain();
 
          const auto path = common::unittest::file::temporary::content( ".txt", "aaa");
 
@@ -148,7 +183,7 @@ domain:
       {
          common::unittest::Trace trace;
 
-         auto domain = local::domain();
+         auto domain = local::file_domain();
 
          const auto path = common::unittest::file::temporary::content( ".txt", "aaa");
 
@@ -166,7 +201,7 @@ domain:
       {
          common::unittest::Trace trace;
 
-         auto domain = local::domain();
+         auto domain = local::file_domain();
 
          const auto source = common::unittest::file::temporary::name( ".txt");
          const auto target = common::unittest::file::temporary::name( ".txt");
@@ -189,7 +224,7 @@ domain:
       {
          common::unittest::Trace trace;
 
-         auto domain = local::domain();
+         auto domain = local::file_domain();
 
          const auto source = common::unittest::file::temporary::name( ".txt");
          const auto target = common::unittest::file::temporary::name( ".txt");
@@ -212,7 +247,7 @@ domain:
       {
          common::unittest::Trace trace;
 
-         auto domain = local::domain();
+         auto domain = local::file_domain();
 
          const auto original = common::unittest::file::temporary::content( ".txt", "abc");
 
@@ -228,7 +263,7 @@ domain:
       {
          common::unittest::Trace trace;
 
-         auto domain = local::domain();
+         auto domain = local::file_domain();
 
          const auto original = common::unittest::file::temporary::content( ".txt", "abc");
 
@@ -244,7 +279,7 @@ domain:
       {
          common::unittest::Trace trace;
 
-         auto domain = local::domain();
+         auto domain = local::file_domain();
 
          const auto path = common::unittest::file::temporary::name( ".txt");
 
@@ -261,7 +296,7 @@ domain:
       {
          common::unittest::Trace trace;
 
-         auto domain = local::domain();
+         auto domain = local::file_domain();
 
          const auto path = common::unittest::file::temporary::name( ".txt");
 
@@ -279,7 +314,7 @@ domain:
       {
          common::unittest::Trace trace;
 
-         auto domain = local::domain();
+         auto domain = local::file_domain();
 
          const auto path = common::unittest::file::temporary::name( ".txt");
 
@@ -297,7 +332,7 @@ domain:
       {
          common::unittest::Trace trace;
 
-         auto domain = local::domain();
+         auto domain = local::file_domain();
 
          const auto path = common::unittest::file::temporary::name( ".txt");
 
@@ -326,7 +361,7 @@ domain:
       {
          common::unittest::Trace trace;
 
-         auto domain = local::domain();
+         auto domain = local::file_domain();
 
          const auto path = common::unittest::file::temporary::name( ".txt");
 


### PR DESCRIPTION
Without this fix casual-file-manager cannot be used with other RM's