### PR TITLE
archive: Reintroducing INI archive in order to be backward compatible

### DIFF
--- a/middleware/buffer/sample/field.toml
+++ b/middleware/buffer/sample/field.toml
@@ -1,0 +1,110 @@
+[[groups]]
+base = 1_000
+
+[[groups.fields]]
+id = 1
+name = "FLD_SHORT1"
+type = "short"
+
+[[groups.fields]]
+id = 2
+name = "FLD_SHORT2"
+type = "short"
+
+[[groups.fields]]
+id = 3
+name = "FLD_SHORT3"
+type = "short"
+
+[[groups.fields]]
+id = 1
+name = "FLD_LONG1"
+type = "long"
+
+[[groups.fields]]
+id = 2
+name = "FLD_LONG2"
+type = "long"
+
+[[groups.fields]]
+id = 3
+name = "FLD_LONG3"
+type = "long"
+
+[[groups.fields]]
+id = 1
+name = "FLD_CHAR1"
+type = "char"
+
+[[groups.fields]]
+id = 2
+name = "FLD_CHAR2"
+type = "char"
+
+[[groups.fields]]
+id = 3
+name = "FLD_CHAR3"
+type = "char"
+
+[[groups]]
+base = 2_000
+
+[[groups.fields]]
+id = 1
+name = "FLD_FLOAT1"
+type = "float"
+
+[[groups.fields]]
+id = 2
+name = "FLD_FLOAT2"
+type = "float"
+
+[[groups.fields]]
+id = 3
+name = "FLD_FLOAT3"
+type = "float"
+
+[[groups.fields]]
+id = 1
+name = "FLD_DOUBLE1"
+type = "double"
+
+[[groups.fields]]
+id = 2
+name = "FLD_DOUBLE2"
+type = "double"
+
+[[groups.fields]]
+id = 3
+name = "FLD_DOUBLE3"
+type = "double"
+
+[[groups.fields]]
+id = 1
+name = "FLD_STRING1"
+type = "string"
+
+[[groups.fields]]
+id = 2
+name = "FLD_STRING2"
+type = "string"
+
+[[groups.fields]]
+id = 3
+name = "FLD_STRING3"
+type = "string"
+
+[[groups.fields]]
+id = 1
+name = "FLD_BINARY1"
+type = "binary"
+
+[[groups.fields]]
+id = 2
+name = "FLD_BINARY2"
+type = "binary"
+
+[[groups.fields]]
+id = 3
+name = "FLD_BINARY3"
+type = "binary"

--- a/middleware/common/include/common/serialize/ini.h
+++ b/middleware/common/include/common/serialize/ini.h
@@ -1,0 +1,44 @@
+//! 
+//! Copyright (c) 2015, The casual project
+//!
+//! This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+//!
+
+
+#pragma once
+
+
+#include "common/serialize/archive.h"
+#include "casual/platform.h"
+
+#include <string>
+#include <iosfwd>
+
+namespace casual
+{
+   namespace common
+   {
+      namespace serialize
+      {
+         namespace ini
+         {
+            namespace strict
+            {
+               serialize::Reader reader( const std::string& source);
+               serialize::Reader reader( std::istream& source);
+               serialize::Reader reader( const platform::binary::type& source);
+            } // strict
+
+            namespace relaxed
+            {
+               serialize::Reader reader( const std::string& source);
+               serialize::Reader reader( std::istream& source);
+               serialize::Reader reader( const platform::binary::type& source);
+            } // relaxed
+
+            serialize::Writer writer();
+
+         } // ini
+      } // serialize
+   } // common
+} // casual

--- a/middleware/common/makefile.cmk
+++ b/middleware/common/makefile.cmk
@@ -143,6 +143,7 @@ casual_common_objectfiles = [
     make.Compile( 'source/serialize/log.cpp'),
     make.Compile( 'source/serialize/json.cpp'),
     make.Compile( 'source/serialize/toml.cpp'),
+    make.Compile( 'source/serialize/ini.cpp'),
     make.Compile( 'source/serialize/xml.cpp'),
     make.Compile( 'source/serialize/yaml.cpp'),
     make.Compile( 'source/serialize/binary.cpp'),
@@ -274,6 +275,7 @@ unittest_objectfiles = [
     make.Compile( 'unittest/source/serialize/test_json.cpp'),
     make.Compile( 'unittest/source/serialize/test_log.cpp'),
     make.Compile( 'unittest/source/serialize/test_toml.cpp'),
+    make.Compile( 'unittest/source/serialize/test_ini.cpp'),
     make.Compile( 'unittest/source/serialize/test_xml.cpp'),
     make.Compile( 'unittest/source/serialize/test_yaml.cpp'),
     make.Compile( 'unittest/source/serialize/test_relaxed_write_read.cpp'),
@@ -299,8 +301,3 @@ make.Dependencies( target_test_common, [ target_simple_process ])
 # Install 
 make.Install( install_libs,  dsl.paths().install + '/lib')
 make.Install( install_headers,  dsl.paths().install + '/include')
-
-
-
-
-

--- a/middleware/common/source/serialize/ini.cpp
+++ b/middleware/common/source/serialize/ini.cpp
@@ -1,0 +1,657 @@
+//! 
+//! Copyright (c) 2015, The casual project
+//!
+//! This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+//!
+
+
+#include "common/serialize/ini.h"
+#include "common/serialize/create.h"
+
+#include "common/transcode.h"
+#include "common/buffer/type.h"
+
+#include "common/code/raise.h"
+#include "common/code/casual.h"
+
+#include "common/flag.h"
+
+#include <sstream>
+#include <iterator>
+#include <algorithm>
+#include <locale>
+#include <string>
+
+namespace casual::common::serialize
+{
+   namespace ini
+   {
+      namespace local
+      {
+         namespace
+         {
+            constexpr auto keys() 
+            {
+               using namespace std::string_view_literals; 
+               return array::make( "ini"sv, ".ini"sv, buffer::type::ini);
+            };
+
+            struct tree
+            {
+               std::multimap<std::string,tree> children;
+               std::multimap<std::string,std::string> values;
+            };
+
+            namespace reader
+            {
+               std::string trim( std::string string)
+               {
+                  const auto trimmer = [] ( const std::string::value_type character)
+                  { return ! std::isspace( character, std::locale::classic()); };
+
+                  string.erase( string.begin(), std::find_if( string.begin(), string.end(), trimmer));
+                  string.erase( std::find_if( string.rbegin(), string.rend(), trimmer).base(), string.end());
+
+                  return string;
+               }
+
+               // TODO: Make it streamable
+               std::string decode( const std::string& data)
+               {
+                  std::ostringstream stream;
+
+                  for( std::string::size_type idx = 0; idx < data.size(); ++idx)
+                  {
+                     if( data[ idx] == '\\')
+                     {
+                        // TODO: handle all control-characters (and back-slash)
+
+                        switch( data.at( ++idx))
+                        {
+                        case '\\': stream.put( '\\'); break;
+                        case '0': stream.put( '\0');  break;
+                        case 'a': stream.put( '\a');  break;
+                        case 'b': stream.put( '\b');  break;
+                        case 'f': stream.put( '\f');  break;
+                        case 'n': stream.put( '\n');  break;
+                        case 'r': stream.put( '\r');  break;
+                        case 't': stream.put( '\t');  break;
+                        case 'v': stream.put( '\v');  break;
+                        default: code::raise::error( code::casual::invalid_document, "Invalid content");
+                        }
+                     }
+                     else
+                     {
+                        stream.put( data[ idx]);
+                     }
+
+                  }
+
+                  return stream.str();
+               }
+
+               void parse_flat( tree& document, std::istream& stream)
+               {
+                  // This function would make Sean Parent cry !!!
+
+                  auto composite = &document;
+
+                  std::vector<std::string> last;
+
+                  std::string line;
+                  while( std::getline( stream, line))
+                  {
+                     const auto candidate = trim( line);
+
+                     if( candidate.empty())
+                     {
+                        // Found nothing and we just ignore it
+                        continue;
+                     }
+
+                     if( candidate.find_first_of( "#;") == 0)
+                     {
+                        // Found a comment and we just ignore it
+                        continue;
+                     }
+
+                     const auto separator = line.find_first_of( '=');
+
+                     if( separator != std::string::npos)
+                     {
+                        // We found a (potential) value and some data
+
+                        auto name = trim( line.substr( 0, separator));
+                        auto data = line.substr( separator + 1);
+
+                        // Add it to the tree after some unmarshalling
+                        composite->values.emplace( std::move( name), decode( data));
+
+                        continue;
+                     }
+
+
+                     if( candidate.front() == '[' && candidate.back() == ']')
+                     {
+                        // Found a potential section (a.k.a. composite a.k.a. serializable)
+
+
+                        // An internal lambda-helper to split a qualified name
+                        const auto splitter = [] ( std::string qualified)
+                        {
+                           std::vector<std::string> result;
+
+                           std::istringstream stream( std::move( qualified));
+                           std::string name;
+                           while( std::getline( stream, name, '.'))
+                           {
+                              auto candidate = trim( std::exchange( name, {}));
+
+                              if( candidate.empty())
+                                 code::raise::error( code::casual::invalid_document, "invalid name");
+                              else
+                                 result.push_back( std::move( candidate));
+                           }
+
+                           if( result.empty())
+                              code::raise::error( code::casual::invalid_document, "invalid name");
+
+                           return result;
+                        };
+
+                        // An internal lambda-helper to help out where to add this section
+                        const auto finder = [] ( const std::vector<std::string>& last, const std::vector<std::string>& next)
+                        {
+                           if( next.size() > last.size())
+                           {
+                              return std::mismatch( last.begin(), last.end(), next.begin()).second;
+                           }
+
+                           auto match = std::mismatch( next.begin(), next.end(), last.begin());
+
+                           return match.first != next.end() ? match.first : std::prev( match.first);
+                        };
+
+                        // First we split the string (e.g. 'foo.bar' into 'foo' and 'bar')
+                        auto next = splitter( { candidate.begin() + 1, candidate.end() - 1 } );
+
+
+                        const auto inserter = finder( last, next);
+
+                        composite = &document;
+
+                        // Search from root to find out where this should be added
+                        for( auto name = next.begin(); name != inserter; ++name)
+                        {
+                           composite = &std::prev( composite->children.upper_bound( *name))->second;
+                        }
+
+                        // Add all names where they should be added
+                        for( auto name = inserter; name != next.end(); ++name)
+                        {
+                           composite = &composite->children.emplace( *name, tree())->second;
+                        }
+
+                        // Keep this qualified name until next time
+                        std::swap( last, next);
+
+                        continue;
+                     }
+
+
+                     if( candidate.back() == '\\')
+                     {
+                        // TODO: Possibly append to previous data
+                        //
+                        // Can be done by using 'inserter' and previous.back()
+                     }
+
+                     // Unknown content
+                     code::raise::error( code::casual::invalid_document, "invalid document");
+                  }
+               }
+
+               tree parse_flat( std::istream& stream)
+               {
+                  tree document;
+                  parse_flat( document, stream);
+                  return document;
+               }
+
+               tree parse_flat( const std::string& ini)
+               {
+                  std::istringstream stream( ini);
+                  return parse_flat( stream);
+               }
+
+               tree parse_flat( const char* ini, platform::size::type size)
+               {
+                  std::istringstream stream( std::string( ini, size));
+                  return parse_flat( stream);
+               }
+
+
+               tree parse_flat( const platform::binary::type& ini)
+               {
+                  auto span = binary::span::to_string_like( ini);
+                  return parse_flat( span.data(), span.size());
+               }
+
+               struct Implementation
+               {
+                  constexpr static auto archive_properties() { return common::serialize::archive::Property::named;}
+
+                  constexpr static auto keys() { return local::keys();}
+
+                  using data = std::string;
+
+                  Implementation( tree&& document) : m_document( std::move( document)), m_node_stack{ &m_document} {}
+
+                  template< typename S>
+                  Implementation( S&& source) : Implementation( parse_flat( std::forward< S>( source))) {};
+
+                  std::tuple< platform::size::type, bool> container_start( const platform::size::type size, const char* const name)
+                  {
+
+                     if( name)
+                     {
+                        // We do not know whether it's a node or data
+
+                        const auto node = get_node()->children.equal_range( name);
+
+                        if( node.first != node.second)
+                        {
+                           // Transform backwards
+                           for( auto iterator = node.second; iterator != node.first; --iterator)
+                           {
+                              m_node_stack.push_back( &std::prev( iterator)->second);
+                           }
+
+                           return std::make_tuple( std::distance( node.first, node.second), true);
+                        }
+
+                        const auto data = get_node()->values.equal_range( name);
+
+                        if( data.first != data.second)
+                        {
+                           // Transform backwards
+                           for( auto iterator = data.second; iterator != data.first; --iterator)
+                              m_data_stack.push_back( &std::prev( iterator)->second);
+
+                           return std::make_tuple( std::distance( data.first, data.second), true);
+                        }
+
+                     }
+                     else
+                     {
+                        // An idea to handle this is by creating fake serializable
+                        //
+                        // E.g. [@name], [@name.@name], etc or something
+                        code::raise::error( code::casual::invalid_node, "nested containers not supported");
+                     }
+
+                     return std::make_tuple( 0, false);
+
+                  }
+
+                  void container_end( const char* const name) {}
+
+                  bool composite_start( const char* const name)
+                  {
+                     if( name)
+                     {
+                        const auto node = get_node()->children.find( name);
+
+                        if( node != get_node()->children.end())
+                           m_node_stack.push_back( &node->second);
+                        else
+                           return false;
+                     }
+
+                     // Either we found the node or we assume it's an 'unnamed' container
+                     // element that is already pushed to the stack
+
+                     return true;
+
+                  }
+
+                  void composite_end(  const char* const name)
+                  {
+                     pop_node();
+                  }
+
+                  bool value_start( const char* name)
+                  {
+                     if( name)
+                     {
+                        const auto data = get_node()->values.find( name);
+
+                        if( data != get_node()->values.end())
+                           m_data_stack.push_back( &data->second);
+                        else
+                           return false;
+                     }
+
+                     // Either we found the node or we assume it's an 'unnamed' container
+                     // element that is already pushed to the stack
+
+                     return true;
+
+                  }
+
+                  void value_end( const char* name)
+                  {
+                     pop_data();
+                  }
+
+                  template< typename T>
+                  bool read( T& value, const char* const name)
+                  {
+                     if( ! value_start( name))
+                     {
+                        return false;
+                     }
+
+                     read( value);
+                     value_end( name);
+
+                     return true;
+                  }
+
+
+                  template<typename T>
+                  void read( T& value)
+                  {
+                     value = string::from< T>( *get_data());
+                  }
+
+                  void read( bool& value)
+                  { 
+                     if( *get_data() == "true") value = true;
+                     else if( *get_data() == "false") value = false;
+                     else code::raise::error( code::casual::invalid_node, "unexpected type");
+                  }
+
+                  void read( char& value)
+                  {
+                     value = get_data()->empty() ? '\0' : get_data()->at( 0);
+                  }
+
+                  void read( std::string& value)
+                  {
+                     value = *get_data();
+                  }
+
+                  void read( std::u8string& value)
+                  {
+                     value = transcode::utf8::encode(*get_data());
+                  }
+
+                  void read( binary::span::Fixed< std::byte> value)
+                  {
+                     auto binary = transcode::base64::decode( *get_data());
+                     if( range::size( binary) != range::size( value))
+                        code::raise::error( code::casual::invalid_node, "binary size mismatch");
+
+                     algorithm::copy( binary, std::begin( value));
+                  }
+
+                  void read( platform::binary::type& value)
+                  {
+                     // Binary data might be double-decoded (in the end)
+                     value = transcode::base64::decode( *get_data());
+                  }
+
+                  policy::canonical::Representation canonical()
+                  {
+                     return {};
+                  }
+
+               private:
+
+                  auto get_data() const -> const data*
+                  {
+                     assert( ! m_data_stack.empty());
+                     return m_data_stack.back();
+                  }
+
+                  void pop_data()
+                  {
+                     assert( ! m_data_stack.empty());
+                     m_data_stack.pop_back();
+                  }
+
+                  auto get_node() const -> const tree*
+                  {
+                     assert( ! m_node_stack.empty());
+                     return m_node_stack.back();
+                  }
+
+                  void pop_node()
+                  {
+                     assert( ! m_node_stack.empty());
+                     m_node_stack.pop_back();
+                  }
+
+               private:
+
+                  tree m_document;
+                  std::vector<const data*> m_data_stack;
+                  std::vector<const tree*> m_node_stack;
+               };
+
+            } // reader
+
+
+            namespace writer
+            {
+               // TODO: Make it streamable
+               std::string encode( const std::string& data)
+               {
+                  std::ostringstream stream;
+                  for( const auto sign : data)
+                  {
+                     // TODO: handle all control-characters (and back-slash)
+                     //if( std::iscntrl( sign, std::locale::classic())){ ... }
+
+                     switch( sign)
+                     {
+                     case '\\': stream << "\\\\";  break;
+                     case '\0': stream << "\\0";   break;
+                     case '\a': stream << "\\a";   break;
+                     case '\b': stream << "\\b";   break;
+                     case '\f': stream << "\\f";   break;
+                     case '\n': stream << "\\n";   break;
+                     case '\r': stream << "\\r";   break;
+                     case '\t': stream << "\\t";   break;
+                     case '\v': stream << "\\v";   break;
+                     default: stream.put( sign);   break;
+                     }
+                  }
+
+                  return stream.str();
+               }
+
+               void write_flat( const tree& node, std::ostream& stream, const std::string& name = "")
+               {
+                  for( const auto& value : node.values)
+                  {
+                     stream << value.first << '=' << encode( value.second) << '\n';
+                  }
+
+                  for( const auto& child : node.children)
+                  {
+                     const auto qualified = name.empty() ? child.first : name + '.' + child.first;
+
+                     // Let's print useless empty sections anyway ('cause
+                     // reading need 'em as of today)
+                     {
+                        stream << '\n' << '[' << qualified << ']' << '\n';
+                     }
+
+                     write_flat( child.second, stream, qualified);
+                  }
+               }
+               
+               class Implementation
+               {
+               public:
+
+                  using name = const char;
+
+                  constexpr static auto archive_properties() { return common::serialize::archive::Property::named;}
+
+                  constexpr static auto keys() { return local::keys();}
+
+                  Implementation() : m_node_stack{ &m_document } {}
+
+                  platform::size::type container_start( const platform::size::type size, const char* const name)
+                  {
+                     // we do not know whether it's node or data
+
+                     if( name)
+                        m_name_stack.push_back( name);
+                     else
+                        code::raise::error( code::casual::invalid_node, "nested containers not supported (yet)");
+
+                     return size;
+                  }
+                  
+                  void container_end( const char* const name)
+                  {
+                     if( name)
+                        pop_name();
+                  }
+
+                  void composite_start( const char* const name)
+                  {
+                     if( ! name && m_name_stack.empty())
+                        return;
+                        
+                     const auto final = name ? name : get_name();
+
+                     const auto child = get_node()->children.emplace( final, tree());
+
+                     m_node_stack.push_back( &child->second);
+                  }
+
+                  void composite_end(  const char* const name)
+                  {
+                     pop_node();
+                  }
+
+                  template< typename T>
+                  void write( T data, const char* const name)
+                  {
+                     write( encode( data), name);
+                  }
+
+                  void write( std::string data, const char* const name)
+                  {
+                     const auto final = name ? name : get_name();
+
+                     get_node()->values.emplace( final, std::move( data));
+                  }
+
+                  const tree& document() const { return m_document;}
+
+                  void consume( std::ostream& destination) 
+                  {
+                     write_flat( Implementation::document(), destination);
+                  }
+
+               private:
+
+                  auto get_name() const -> name*
+                  {
+                     assert( ! m_name_stack.empty());
+                     return m_name_stack.back();
+                  }
+
+                  void pop_name()
+                  {
+                     assert( ! m_name_stack.empty());
+                     m_name_stack.pop_back();
+                  }
+
+                  auto get_node() const -> tree*
+                  {
+                     assert( ! m_node_stack.empty());
+                     return m_node_stack.back();
+                  }
+
+                  void pop_node()
+                  {
+                     assert( ! m_node_stack.empty());
+                     m_node_stack.pop_back();
+                  }
+
+                  template< concepts::arithmetic T>
+                  std::string encode( T value) const
+                  {
+                     return std::to_string( value);
+                  }
+
+                  // A few overloads
+                  
+                  std::string encode( bool value) const
+                  {
+                     return value ? "true" : "false";
+                  }
+
+                  std::string encode( char value) const
+                  {
+                     return { value};
+                  }
+
+                  std::string encode( std::string_view value) const
+                  {
+                     return std::string{ value};
+                  }
+
+                  std::string encode( std::span< const std::byte> value) const
+                  {
+                     // Binary data might be double-encoded
+                     return transcode::base64::encode( value);
+                  }
+
+                  std::string encode( std::u8string_view value) const
+                  {
+                     return transcode::utf8::decode( value);
+                  }
+
+                  tree m_document;
+                  std::vector<name*> m_name_stack; // for containers
+                  std::vector<tree*> m_node_stack;
+
+               }; // Implementation
+
+            } // writer
+         } //
+      } // local
+      
+      namespace strict
+      {
+         serialize::Reader reader( const std::string& source) { return create::reader::strict::create< local::reader::Implementation>( source);}
+         serialize::Reader reader( std::istream& source) { return create::reader::strict::create< local::reader::Implementation>( source);}
+         serialize::Reader reader( const platform::binary::type& source) { return create::reader::strict::create< local::reader::Implementation>( source);}
+      } // strict
+
+      namespace relaxed
+      {    
+         serialize::Reader reader( const std::string& source) { return create::reader::relaxed::create< local::reader::Implementation>( source);}
+         serialize::Reader reader( std::istream& source) { return create::reader::relaxed::create< local::reader::Implementation>( source);}
+         serialize::Reader reader( const platform::binary::type& source) { return create::reader::relaxed::create< local::reader::Implementation>( source);}
+      } // relaxed
+
+      serialize::Writer writer()
+      {
+         return serialize::create::writer::create< local::writer::Implementation>();
+      }
+
+   } // ini
+
+   template struct create::reader::Registration< ini::local::reader::Implementation>;
+   template struct create::writer::Registration< ini::local::writer::Implementation>;
+
+} // casual::common::serialize

--- a/middleware/common/source/serialize/toml.cpp
+++ b/middleware/common/source/serialize/toml.cpp
@@ -31,7 +31,7 @@ namespace casual
                constexpr auto keys() 
                {
                   using namespace std::string_view_literals; 
-                  return array::make( "toml"sv, ".toml"sv, "ini"sv, ".ini"sv, buffer::type::toml);
+                  return array::make( "toml"sv, ".toml"sv, buffer::type::toml);
                };
 
                namespace reader

--- a/middleware/common/unittest/source/serialize/test_ini.cpp
+++ b/middleware/common/unittest/source/serialize/test_ini.cpp
@@ -1,0 +1,231 @@
+//! 
+//! Copyright (c) 2015, The casual project
+//!
+//! This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+//!
+
+
+
+#include <gtest/gtest.h>
+
+
+#include "common/serialize/ini.h"
+
+#include "common/unittest.h"
+
+#include <sstream>
+#include <locale>
+
+#include "../../include/test_vo.h"
+
+
+
+namespace casual::common
+{
+   namespace
+   {
+      namespace local
+      {
+         template<typename T>
+         void value_to_string( T&& value, std::string& string)
+         {
+            auto writer = serialize::ini::writer();
+            writer << CASUAL_NAMED_VALUE( value);
+            writer.consume( string);
+         }
+
+         template<typename T>
+         void string_to_value( const std::string& string, T& value)
+         {
+            auto reader = serialize::ini::strict::reader( string);
+            reader >> CASUAL_NAMED_VALUE( value);
+         }
+
+      } // local
+   } //
+
+   TEST( common_serialize_ini_archive, writer_archive_type)
+   {
+      common::unittest::Trace trace;
+
+      auto writer = serialize::ini::writer();
+
+      static_assert( serialize::archive::is::dynamic< decltype( writer)>);
+      EXPECT_TRUE( writer.dynamic_properties() == common::serialize::archive::Property::named) << CASUAL_NAMED_VALUE( writer.dynamic_properties());
+   }
+
+   TEST( common_serialize_ini_archive, reader_archive_type)
+   {
+      common::unittest::Trace trace;
+
+      std::string buffer;
+      auto reader = serialize::ini::strict::reader( buffer);
+
+      static_assert( serialize::archive::is::dynamic< decltype( reader)>);
+      EXPECT_TRUE( reader.dynamic_properties() == common::serialize::archive::Property::named) << CASUAL_NAMED_VALUE( reader.dynamic_properties());
+   }
+
+   TEST( common_serialize_ini_archive, write_read_string_with_new_line)
+   {
+      common::unittest::Trace trace;
+
+      std::string ini;
+      std::string source = "foo\nbar";
+      local::value_to_string( source, ini);
+      std::string target;
+      local::string_to_value( ini, target);
+
+      EXPECT_TRUE( source == target);
+   }
+
+   TEST( common_serialize_ini_archive, write_read_boolean)
+   {
+      common::unittest::Trace trace;
+
+      std::string ini;
+      local::value_to_string( true, ini);
+      bool target = false;
+      local::string_to_value( ini, target);
+      EXPECT_TRUE( target == true);
+   }
+
+   TEST( common_serialize_ini_archive, write_read_decimal)
+   {
+      common::unittest::Trace trace;
+
+      std::string ini;
+      float source = 3.14;
+      local::value_to_string( source, ini);
+      float target = 0.0;
+      local::string_to_value( ini, target);
+      EXPECT_TRUE( source == target);
+   }
+
+   TEST( common_serialize_ini_archive, write_read_container)
+   {
+      common::unittest::Trace trace;
+
+      std::string ini;
+      std::vector<long> source{ 1, 3, 5, 7 };
+      local::value_to_string( source, ini);
+      std::vector<long> target;
+      local::string_to_value( ini, target);
+      EXPECT_TRUE( source == target);
+   }
+
+   namespace
+   {
+      struct SomeVO
+      {
+         struct FirstVO
+         {
+            long integer;
+            std::string string;
+
+            CASUAL_CONST_CORRECT_SERIALIZE
+            (
+               CASUAL_SERIALIZE( integer);
+               CASUAL_SERIALIZE( string);
+            )
+         };
+
+
+         struct OtherVO
+         {
+            struct InnerVO
+            {
+               long long huge;
+
+               CASUAL_CONST_CORRECT_SERIALIZE
+               (
+                  CASUAL_SERIALIZE( huge);
+               )
+
+            };
+
+            InnerVO first_inner;
+            InnerVO other_inner;
+
+
+            CASUAL_CONST_CORRECT_SERIALIZE
+            (
+               CASUAL_SERIALIZE( first_inner);
+               CASUAL_SERIALIZE( other_inner);
+            )
+         };
+
+         bool boolean;
+         FirstVO first;
+         short tiny;
+         std::vector<OtherVO> others;
+
+         CASUAL_CONST_CORRECT_SERIALIZE
+         (
+            CASUAL_SERIALIZE( boolean);
+            CASUAL_SERIALIZE( first);
+            CASUAL_SERIALIZE( tiny);
+            CASUAL_SERIALIZE( others);
+         )
+
+      };
+
+      TEST( common_serialize_ini_archive, write_read_serializable)
+      {
+         common::unittest::Trace trace;
+
+         std::string ini;
+         SomeVO source;
+         source.boolean = true;
+         source.first.integer = 654321;
+         source.first.string = "foo";
+         source.tiny = 123;
+         {
+            SomeVO::OtherVO other;
+            other.first_inner.huge = 123456789;
+            other.other_inner.huge = 987654321;
+            source.others.push_back( other);
+         }
+         {
+            SomeVO::OtherVO other;
+            other.first_inner.huge = 13579;
+            other.other_inner.huge = 97531;
+            source.others.push_back( other);
+         }
+
+
+         local::value_to_string( source, ini);
+         SomeVO target;
+         local::string_to_value( ini, target);
+
+         EXPECT_TRUE( source.boolean == target.boolean);
+         EXPECT_TRUE( source.first.integer == target.first.integer);
+         EXPECT_TRUE( source.first.string == target.first.string);
+         EXPECT_TRUE( source.tiny == target.tiny);
+         ASSERT_TRUE( target.others.size() == 2);
+         EXPECT_TRUE( source.others.at( 0).first_inner.huge == target.others.at( 0).first_inner.huge);
+         EXPECT_TRUE( source.others.at( 0).other_inner.huge == target.others.at( 0).other_inner.huge);
+         EXPECT_TRUE( source.others.at( 1).first_inner.huge == target.others.at( 1).first_inner.huge);
+         EXPECT_TRUE( source.others.at( 1).other_inner.huge == target.others.at( 1).other_inner.huge);
+      }
+
+
+      TEST( common_serialize_ini_archive, test_control_characters)
+      {
+         common::unittest::Trace trace;
+
+         std::vector< char> result;
+         for( short idx = 0; idx < 255; ++idx)
+         {
+            if( std::iscntrl( static_cast<char>( idx), std::locale{}))
+            {
+               result.push_back( idx);
+            }
+         }
+
+         auto expected = std::vector< char>{ 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,127};
+
+         EXPECT_TRUE( result == expected);
+      }
+   }
+
+} // casual::common


### PR DESCRIPTION
TOML is not INI compatible and thus .ini-files cannot be handled at all but after this commit we can handle .ini-files again but still limited data structures (exaclty as in 1.8)

This will also fix some broken unit-test-case's