### PR TITLE
tools: some minor fixes for tools generating servers

### DIFF
--- a/middleware/tools/documentation/build/server.development.md
+++ b/middleware/tools/documentation/build/server.development.md
@@ -35,7 +35,7 @@ The `echo` service will have `auto` transaction semantics, see below.
 
 
 ```bash
-$ casual-build-server --output simple-server --service echo --link-directives echo.cpp
+$ casual-build-server --output simple-server --service echo --build-directives echo.cpp
 ```
 
 ### advanced
@@ -62,12 +62,11 @@ server:
       function: echo
 
       # transaction characteristics
-      # Can be one of the following
-      # - auto : if a transaction is present join it, else start a new one (default)
-      # - join : if a transaction is present join it,
+      # - auto : if a transaction is present join it or else start a new one (default)
+      # - join : if a transaction is present join it
       # - none : don't join any transaction
       # - atomic : start a new transaction regardless.
-      # - branch : do not use unless you know what you're doing...
+      # - branch : branch the transaction if present (do not use unless you know what you're doing)
       transaction: join
 ```
 

--- a/middleware/tools/source/build/server/generate/main.cpp
+++ b/middleware/tools/source/build/server/generate/main.cpp
@@ -97,22 +97,19 @@ namespace casual
                         }
                      }
                      
-                     constexpr auto description = R"(Generates a server 'main' source file
-
-)";
-
                      void main(int argc, const char** argv)
                      {
-                        Trace trace{ "tools::build::server::generate::local::main"};
-
                         Settings settings;
 
                         using namespace casual::argument;
-                        parse( description, {
+                        auto outcome = parse( "generates a server 'main' source file", {
                            Option( std::tie( settings.server.definition), {{ "-d", "--definition"}}, "path to server definition file")( argument::cardinality::one()),
                            Option( std::tie( settings.server.definition), {{ "-o", "--output"}}, "output file name - if not provided 'stdout' will be used"),
                            Option( std::tie( settings.files.system), {{ "--system-configuration"}, { "-p", "--properties-file"}}, "path to system configuration file"),
                         }, argc, argv);
+
+                        if( outcome != argument::Outcome::parsed)
+                           return;
 
                         local::generate( std::move( settings));
                      }


### PR DESCRIPTION
The documentation for casual-build-server referred to depracated arguments but this commit fixes that

The result of running casual-build-server-generate with just --help resulted in an error and this commit removes that error

Resolves issue #691