### PR TITLE
queue: _empty queue_ does not take uncommitted messages into account

### DIFF
--- a/middleware/queue/source/group/handle.cpp
+++ b/middleware/queue/source/group/handle.cpp
@@ -715,7 +715,7 @@ namespace casual
                                  .retry = { 
                                     .count = queue.retry.count, 
                                     .delay = queue.retry.delay},
-                                 .empty = queue.metric.count == 0
+                                 .empty = queue.metric.count == 0 && queue.metric.uncommitted == 0
                               
                               };
                            }

--- a/middleware/queue/unittest/source/test_queue.cpp
+++ b/middleware/queue/unittest/source/test_queue.cpp
@@ -12,6 +12,7 @@
 #include "queue/unittest/utility.h"
 #include "queue/common/queue.h"
 #include "queue/api/queue.h"
+#include "queue/group/queuebase.h"
 
 #include "common/array.h"
 #include "common/code/queue.h"
@@ -2121,6 +2122,56 @@ domain:
             EXPECT_FALSE( common::communication::ipc::non::blocking::receive< domain::message::discovery::topology::implicit::Update>());
             common::process::sleep( std::chrono::milliseconds{ 10});
          });
+
+      }
+
+     TEST( casual_queue, zombie_queue__uncommitted_message__expect_zombie_queue)
+      {
+         common::unittest::Trace trace;
+
+         auto path = common::unittest::file::temporary::name( ".db");
+         auto scope = common::unittest::environment::scoped::variable( "CASUAL_UNITTEST_QUEUEBASE", path.string());
+
+         // add 'uncommitted' message to the 'zombie' queue
+         {
+            group::Queuebase queuebase( path);
+            queuebase.create( group::queuebase::Queue{ .name = "a"});
+            auto zombie = queuebase.create( group::queuebase::Queue{ .name = "zombie"});
+
+            auto message = queue::ipc::message::group::enqueue::Request{};
+            {
+               message.process = common::process::handle();
+               message.queue = zombie.id;
+               message.message.payload.type = common::buffer::type::binary;
+               message.message.payload.data = common::unittest::random::binary( 42);
+               message.trid = common::transaction::id::create();
+            }
+
+            queuebase.enqueue( message);
+         }
+
+         // start domain without the 'zombie' queue, should be detected as a zombie queue
+         {
+
+            auto domain = local::domain( R"(
+domain:
+   name: A
+   queue:
+      groups:
+         -  alias: "Q"
+            queuebase: '${CASUAL_UNITTEST_QUEUEBASE}'
+            queues:
+               -  name: a
+               -  name: b
+)");
+
+            auto state = unittest::state();
+            ASSERT_TRUE( state.zombies.size() == 2) << CASUAL_NAMED_VALUE( state.zombies);
+            EXPECT_TRUE( common::algorithm::contains( state.zombies, "zombie.error")) << CASUAL_NAMED_VALUE( state.zombies);
+            EXPECT_TRUE( common::algorithm::contains( state.zombies, "zombie")) << CASUAL_NAMED_VALUE( state.zombies);
+            EXPECT_TRUE( common::algorithm::contains( state.queues, "a")) << CASUAL_NAMED_VALUE( state.queues);
+            EXPECT_TRUE( common::algorithm::contains( state.queues, "b")) << CASUAL_NAMED_VALUE( state.queues);
+         }
 
       }
 


### PR DESCRIPTION
Before:
When queue-group checks if a current queue is empty, to know if it's ok to remove the queue, uncommitted messages was excluded. This resulted in queue-group trying to remove a queue that has FK to messages, and sqlite, correctly, said stop.

Now:
We include uncommitted messages to determine if a queue is _empty_ or not.

Resolves: #703