### PR TITLE
buffer: added payload 0 size to pool gives `null` buffer handle

### DIFF
--- a/documentation/changelog.md
+++ b/documentation/changelog.md
@@ -5,6 +5,7 @@ This is the changelog for `casual` and all changes are listed in this document.
 
 ### Fixes
 - queue: queue-group now takes uncommitted messages into account for _empty_ ([#703](https://github.com/casualcore/casual/issues/703))
+- buffer: added payload with 0 size to buffer pool now create a valid handle/pointer ([#705](https://github.com/casualcore/casual/issues/705))
 
 
 ## [1.8.13] - 2026-03-31

--- a/middleware/common/source/buffer/pool.cpp
+++ b/middleware/common/source/buffer/pool.cpp
@@ -87,8 +87,14 @@ namespace casual
       {
          Trace trace{ "buffer::pool::Holder::adopt"};
 
+         log::debug( "payload: ", payload);
+
          if( payload.null())
             return {};
+
+         // we need to reserve at least 1 byte, to get a valid unique address for the buffer. 
+         if( payload.data.capacity() == 0)
+            payload.data.reserve( 1);
 
          // This is the only place where a buffer is consumed by the pool, hence can only happen
          // during service-invocation.
@@ -104,6 +110,10 @@ namespace casual
 
          if( payload.null())
             return { {}, {}};
+
+         // we need to reserve at least 1 byte, to get a valid unique address for the buffer. 
+         if( payload.data.capacity() == 0)
+            payload.data.reserve( 1);
 
          auto size = payload.data.size();
          auto& pool = get_pool( payload.type);

--- a/middleware/example/server/source/example.cpp
+++ b/middleware/example/server/source/example.cpp
@@ -5,7 +5,8 @@
 //!
 
 
-#include "xatmi.h"
+#include "casual/xatmi.h"
+#include "casual/xatmi/extended.h"
 
 #include "common/algorithm.h"
 #include "common/algorithm/compare.h"
@@ -70,15 +71,35 @@ namespace casual
 
                   return result;
                }
-            } // namespace receive
-         } // namespace
-      } // namespace local
+
+            } // receive
+
+            auto extract_headers( const char* buffer)
+            {
+               std::vector< std::string> fields;
+
+               auto callback = []( const char* header, void* context) -> int
+               {
+                  auto fields = static_cast< std::vector< std::string>* >( context);
+                  fields->emplace_back( header);
+                  return 0;
+               };
+
+               ::casual_header_browse( buffer, callback, &fields);
+
+               return fields;
+            }
+
+
+         } // <unnamed>
+      } // local
 
       extern "C"
       {
 
          void casual_example_echo( TPSVCINFO* info)
          {
+            common::log::debug( "header: ", local::extract_headers( info->data));
             tpreturn( TPSUCCESS, 0, info->data, info->len, 0);
          }
 

--- a/middleware/xatmi/source/xatmi/internal/server/service.cpp
+++ b/middleware/xatmi/source/xatmi/internal/server/service.cpp
@@ -31,6 +31,7 @@ namespace casual
                TPSVCINFO information( casual::server::service::invoke::Parameter& argument)
                {
                   common::Trace trace{ "server::xatmi::local::transform::information"};
+                  common::log::debug( "argument: ", argument);
 
                   TPSVCINFO result{};
 

--- a/middleware/xatmi/unittest/source/server/test_service.cpp
+++ b/middleware/xatmi/unittest/source/server/test_service.cpp
@@ -9,8 +9,10 @@
 #include "common/unittest.h"
 
 #include "casual/xatmi/internal/server/service.h"
-
 #include "casual/xatmi.h"
+#include "casual/xatmi/extended.h"
+
+#include "server/service/invoke.h"
 
 namespace casual
 {
@@ -41,12 +43,26 @@ namespace casual
                return parameter;
             }
 
+            auto extract_header( const char* buffer)
+            {
+               std::vector< std::string> result;
+               ::casual_header_browse( buffer, []( const char* header, void* context) -> int
+               {
+                  auto state = static_cast< std::vector< std::string>*>( context);
+                  state->push_back( header);
+                  return 0;
+
+               }, &result);
+
+               return result;
+            }
+
          } // <unnamed>
       } // local
 
 
 
-      TEST( server_service, equality)
+      TEST( xatmi_server_service, equality)
       {
          common::unittest::Trace trace;
 
@@ -56,7 +72,7 @@ namespace casual
          EXPECT_TRUE( s1 == s2);
       }
 
-      TEST( server_service, in_equality)
+      TEST( xatmi_server_service, in_equality)
       {
          common::unittest::Trace trace;
 
@@ -66,13 +82,57 @@ namespace casual
          EXPECT_TRUE( s1 != s2) << trace.compose( CASUAL_NAMED_VALUE( s1), " - ", CASUAL_NAMED_VALUE( s2));
       }
 
-      TEST( server_xatmi_service, tpsvcinfo_name_correctly_copied)
+      TEST( xatmi_server_service, tpsvcinfo_name_correctly_copied)
       {
          common::unittest::Trace trace;
 
          auto service = internal::server::service::create( "service_foo", &local::service_foo);
 
          service( local::parameter( "service_foo"));
+
+      }
+
+      TEST( xatmi_server_service, invoke)
+      {
+         common::unittest::Trace trace;
+
+         auto service = []( TPSVCINFO* info)
+         {
+            EXPECT_TRUE( info->data != nullptr);
+
+            std::array< char, 8 + 1> type{};
+            std::array< char, 16 + 1> subtype{};
+            EXPECT_TRUE( ::tptypes( info->data, type.data(), subtype.data()) == 0);
+            EXPECT_TRUE( type.data() == std::string_view{ ".http"}) << CASUAL_NAMED_VALUE( type.data());
+            EXPECT_TRUE( subtype.data() == std::string_view{ "body"}) << CASUAL_NAMED_VALUE( subtype.data());
+
+
+            // check the header fields
+            auto fields = local::extract_header( info->data);
+
+            EXPECT_TRUE( std::ranges::contains( fields, "a:foo")) << CASUAL_NAMED_VALUE( fields);
+            EXPECT_TRUE( std::ranges::contains( fields, "b:bar")) << CASUAL_NAMED_VALUE( fields);
+            EXPECT_TRUE( std::ranges::contains( fields, "c:baz")) << CASUAL_NAMED_VALUE( fields);
+
+            tpreturn( TPSUCCESS, 0, info->data, info->len, 0);
+         };
+
+         auto a = internal::server::service::create( "a", service);
+
+         server::service::invoke::Parameter argument{
+            .service = { .name = "a" },
+            .header = { { { "a", "foo"}, { "b", "bar"}, { "c", "baz"}}},
+            .payload = common::buffer::Payload{ common::buffer::type::http, 0},
+         };
+
+         auto result = a( std::move( argument));
+
+         EXPECT_TRUE( result.code.result == decltype( result.code.result)::success);
+         EXPECT_TRUE( result.payload.type == common::buffer::type::http);
+         EXPECT_TRUE( result.payload.data.empty());
+         EXPECT_TRUE( result.header.at( "a").value() == "foo") << CASUAL_NAMED_VALUE( result.header);
+         EXPECT_TRUE( result.header.at( "b").value() == "bar") << CASUAL_NAMED_VALUE( result.header);
+         EXPECT_TRUE( result.header.at( "c").value() == "baz") << CASUAL_NAMED_VALUE( result.header);
 
       }
 

--- a/test/unittest/source/test_http.cpp
+++ b/test/unittest/source/test_http.cpp
@@ -336,7 +336,7 @@ http {
             casual::service::unittest::advertise( { "forward/service"});
 
             auto executing = administration::unittest::cli::command::non::blocking::execute( 
-               "curl -sS -H 'Content-Type: application/some-type' -X GET 'http://localhost:8042/some/path?foo=bar'"
+               "curl -sS -H 'Content-Type: application/some-type' -H 'a:foo' -H 'b:bar' -X GET 'http://localhost:8042/some/path?foo=bar'"
             );
 
 
@@ -345,8 +345,10 @@ http {
 
                EXPECT_TRUE( request.buffer.data.empty()) << CASUAL_NAMED_VALUE( request);
                EXPECT_TRUE( request.buffer.type == common::buffer::type::http);
-
+               
                EXPECT_TRUE( request.header.at( "content-type").value() == "application/some-type") << CASUAL_NAMED_VALUE( request.header);
+               EXPECT_TRUE( request.header.at( "a").value() == "foo") << CASUAL_NAMED_VALUE( request.header);
+               EXPECT_TRUE( request.header.at( "b").value() == "bar") << CASUAL_NAMED_VALUE( request.header);
 
                EXPECT_TRUE( request.parent.service == "GET /some/path?foo=bar HTTP/1.1") << CASUAL_NAMED_VALUE( request.parent.service);
                

--- a/test/unittest/source/xatmi/test_call.cpp
+++ b/test/unittest/source/xatmi/test_call.cpp
@@ -373,6 +373,57 @@ domain:
          tpfree( buffer);
       }
 
+      TEST( test_xatmi_call, tpcall_echo_zero_length_buffer_with_header__expect_header_to_be_replied)
+      {
+         common::unittest::Trace trace;
+
+         auto domain = local::domain();
+
+         auto allocate_http = []()
+         {
+            auto buffer = tpalloc( ".http", "body", 0);
+            EXPECT_TRUE( buffer != nullptr) << "tperrno: " << tperrno;
+            return buffer;
+         };
+
+         auto buffer = allocate_http();
+         
+         const std::vector< std::string> headers = { "a:foo", "b:bar", "c:baz"};
+
+         // associate headers with buffer
+         {
+            auto raw_header = algorithm::transform( headers, []( const std::string& header) { return header.c_str();});
+            ::casual_header_associate( buffer, raw_header.data(), raw_header.size());
+         }
+
+         auto extract_header = []( auto handle)
+         {
+            std::vector< std::string> headers;
+
+            auto callback = []( const char* header, void* context) -> int
+            {
+               auto headers = static_cast< std::vector< std::string>*>( context);
+               headers->emplace_back( header);
+               return 0;
+            };
+
+            ::casual_header_browse( handle, callback, &headers);
+            return headers;
+         };
+         
+         auto output_buffer = allocate_http();
+         auto output_len = tptypes( output_buffer, nullptr, nullptr);
+         EXPECT_TRUE( output_len == 0);
+         
+         EXPECT_TRUE( ::tpcall( "casual/example/echo", buffer, 0, &output_buffer, &output_len, 0) == 0) << "tperrno: " << tperrnostring( tperrno);
+         EXPECT_TRUE( output_buffer != buffer);
+
+         EXPECT_TRUE( extract_header( output_buffer) == headers) << "received: " << common::string::compose( extract_header( output_buffer));
+
+         tpfree( buffer);
+         tpfree( output_buffer);
+      }
+
       TEST( test_xatmi_call, tpcall_service_resource_echo__rm_xa_start_gives_XA_RBROLLBACK__expect_TPESVCERR)
       {
          common::unittest::Trace trace;


### PR DESCRIPTION
Before:
When a `payload` with zero size was `adopt` or `insert` to buffer pool, we didn't get a unique address for the buffer.
* User can't really use the buffer.
* User can't access header fields for the buffer

Now:
We make sure to reserve one byte if the `payload` is empty before we add the `payload` to the buffer pool via `adopt` and `insert`

Resolves #705