### PR TITLE
discovery: discovery from SM short-circuit reply -> "sticky" trid fails

### DIFF
--- a/documentation/changelog.md
+++ b/documentation/changelog.md
@@ -1,10 +1,11 @@
 # Changelog
 This is the changelog for `casual` and all changes are listed in this document.
 
-## [1.8.14] - 2026-04-15
+## [1.8.14] - 2026-04-22
 
 ### Fixes
 - queue: queue-group now takes uncommitted messages into account for _empty_ ([#703](https://github.com/casualcore/casual/issues/703))
+- discovery: request from `SM` does not short-circuit reply -> `SM` can route based on "sticky" trid ([#679](https://github.com/casualcore/casual/issues/679))
 
 
 ## [1.8.13] - 2026-03-31

--- a/middleware/common/include/common/algorithm/random.h
+++ b/middleware/common/include/common/algorithm/random.h
@@ -30,7 +30,7 @@ namespace casual
       }
 
       template< concepts::range R>
-      auto shuffle( R&& range)
+      decltype( auto) shuffle( R&& range)
       {
          std::ranges::shuffle( range, random::generator());
          return std::forward< R>( range);

--- a/middleware/domain/source/discovery/handle.cpp
+++ b/middleware/domain/source/discovery/handle.cpp
@@ -276,7 +276,12 @@ namespace casual
                         return content::send_reply_if_included( state, shared->content, request);
                      };
 
-                     algorithm::container::erase_if( shared->api, send_if_included);
+                     // For API requests, we need to wait for all replies to give SM a chance to
+                     // correlate "sticky" transactions.
+
+                     // For discovery requests, we can send a reply as soon as the requested
+                     // services/queues have been discovered, so we can "short-circuit" the
+                     // discovery and avoid waiting for all replies.
                      algorithm::container::erase_if( shared->discovery, send_if_included);
 
                      if( shared->api.empty() && shared->discovery.empty())

--- a/middleware/domain/unittest/source/test_discovery.cpp
+++ b/middleware/domain/unittest/source/test_discovery.cpp
@@ -16,6 +16,7 @@
 #include "common/communication/instance.h"
 #include "common/array.h"
 #include "common/message/server.h"
+#include "common/algorithm/random.h"
 
 namespace casual
 {
@@ -689,6 +690,55 @@ domain:
 
       }
 
+      TEST( domain_discovery, discover_provider_10__api_discover__expect_no_short_circuit_reply)
+      {
+         common::unittest::Trace trace;
+
+         auto domain = unittest::manager();
+
+         std::array< communication::ipc::inbound::Device, 10> providers;
+
+         for( auto& provider : providers)
+            discovery::provider::registration( provider, discovery::provider::Ability::discover);
+
+         // send one request to discovery
+         const auto correlation = discovery::request( { "a"}, {});
+
+         // we'll reply from all providers, since it's an api request, and we don't short-circuit api requests
+         {
+            auto send_reply_and_expect_no_short_circuit = [ correlation]( auto& provider)
+            {
+               // check that we don't get a reply yet, since discovery should not short-circuit "api" requests.
+               // since we're replying 10 times, we should get a reply if we short-circuit before we reply from all providers.
+               // the first receive in this loop will be a 'no-op' 
+               EXPECT_TRUE( ! communication::ipc::non::blocking::receive< message::discovery::api::Reply>( correlation));
+
+               auto request = communication::device::receive< message::discovery::Request>( provider);
+               auto reply = common::message::reverse::type( request);
+               reply.content.services = algorithm::transform( request.content.services, []( auto& name)
+               {
+                  return common::message::service::concurrent::advertise::Service{
+                     name,
+                     "",
+                     common::service::transaction::Type::none,
+                     common::service::visibility::Type::discoverable
+                  };
+               });
+
+               communication::device::blocking::send( request.process.ipc, reply);
+            };
+
+            std::ranges::for_each( algorithm::random::shuffle( providers), send_reply_and_expect_no_short_circuit);
+         }
+
+         // we expect a reply to our original request
+         {
+            auto reply = communication::ipc::receive< message::discovery::api::Reply>( correlation);
+            ASSERT_TRUE( reply.content.services.size() == 1);
+            EXPECT_TRUE( reply.content.services.at( 0).name == "a");
+         }
+
+      }
 
 
       TEST( domain_discovery, act_as_SM_GW__discover_q1_s2_q1_q2__s1_q1_is_known___extended_discovery_for_s2_q2__all_is_found___expect_s1_s2_q1_q2__in_reply)

--- a/middleware/queue/include/queue/manager/admin/model.h
+++ b/middleware/queue/include/queue/manager/admin/model.h
@@ -41,7 +41,8 @@ namespace casual
          std::string note;
          Size size;
 
-         friend bool operator == ( const Group& lhs, common::process::compare_equal_to_handle auto rhs) { return lhs.process == rhs;}
+         inline friend bool operator == ( const Group& lhs, common::process::compare_equal_to_handle auto rhs) { return lhs.process == rhs;}
+         inline friend bool operator == ( const Group& lhs, std::string_view rhs) { return lhs.alias == rhs;}
 
          CASUAL_CONST_CORRECT_SERIALIZE(
             CASUAL_SERIALIZE( process);

--- a/middleware/queue/unittest/source/test_queue.cpp
+++ b/middleware/queue/unittest/source/test_queue.cpp
@@ -196,9 +196,9 @@ domain:
          auto state = unittest::state();
 
          ASSERT_TRUE( state.groups.size() == 3) << CASUAL_NAMED_VALUE( state.groups);
-         EXPECT_TRUE( state.groups.at( 0).alias == "group") << CASUAL_NAMED_VALUE( state.groups);
-         EXPECT_TRUE( state.groups.at( 1).alias == "group.2") << CASUAL_NAMED_VALUE( state.groups);
-         EXPECT_TRUE( state.groups.at( 2).alias == "C") << CASUAL_NAMED_VALUE( state.groups);
+         EXPECT_TRUE( common::algorithm::contains( state.groups, "group")) << CASUAL_NAMED_VALUE( state.groups);
+         EXPECT_TRUE( common::algorithm::contains( state.groups, "group.2")) << CASUAL_NAMED_VALUE( state.groups);
+         EXPECT_TRUE( common::algorithm::contains( state.groups, "C")) << CASUAL_NAMED_VALUE( state.groups);
       }
 
       TEST( casual_queue, enqueue_to_persistent_group__shutdown__boot_same_persistent_group__expect_metrics_reset)


### PR DESCRIPTION
Before:
* SM sends a `domain_discovery_api_request`
* discovery fan-out `domain_discovery_request` to all "outbounds"
* If/when the first reply contains the requested service discovery sends `domain_discovery_api_reply` to SM
* SM has limited options to correlate "sticky" trids.

Now:
discovery sends `domain_discovery_api_reply` when all fan-out requests has been replied. Hence, SM has full potential to correlate "sticky" trids.

Resolves #679