### PR TITLE
http: inbound handles wildcards in accept header field

### DIFF
--- a/middleware/http/include/http/common.h
+++ b/middleware/http/include/http/common.h
@@ -80,6 +80,18 @@ namespace casual
                std::string_view content( std::string_view buffer);
                std::string_view buffer( std::string_view content);
             } // to
+
+            namespace wild
+            {
+               bool match( std::string_view lhs, std::string_view rhs);
+
+               namespace to
+               {
+                  std::string_view content( std::string_view buffer);
+                  std::string_view buffer( std::string_view content);
+               } // to
+            } // wild
+
          } // convert
       } //protocol
 

--- a/middleware/http/source/common.cpp
+++ b/middleware/http/source/common.cpp
@@ -92,27 +92,38 @@ namespace casual
             {
                namespace
                {
+                  const std::array mapping
+                  {
+                     std::pair{ common::buffer::type::x_octet, protocol::x_octet},
+                     std::pair{ common::buffer::type::binary, protocol::binary},
+                     std::pair{ common::buffer::type::json, protocol::json},
+                     std::pair{ common::buffer::type::yaml, protocol::yaml},
+                     std::pair{ common::buffer::type::toml, protocol::toml},
+                     std::pair{ common::buffer::type::xml, protocol::xml},
+                     std::pair{ casual::buffer::field::key, protocol::field},
+                     std::pair{ casual::buffer::order::key, protocol::order},
+                     std::pair{ casual::buffer::string::key, protocol::string},
+                     std::pair{ common::buffer::type::null, protocol::null},
+                  };
+
                   constexpr std::size_t buffer_type = 0;
                   constexpr std::size_t content_type = 1;
 
                   template< std::size_t key_index, std::size_t value_index>
                   auto find( const auto& key) -> std::string_view
                   {
-                     static const std::array mapping
-                     {
-                        std::pair{ common::buffer::type::x_octet, protocol::x_octet},
-                        std::pair{ common::buffer::type::binary, protocol::binary},
-                        std::pair{ common::buffer::type::json, protocol::json},
-                        std::pair{ common::buffer::type::yaml, protocol::yaml},
-                        std::pair{ common::buffer::type::toml, protocol::toml},
-                        std::pair{ common::buffer::type::xml, protocol::xml},
-                        std::pair{ casual::buffer::field::key, protocol::field},
-                        std::pair{ casual::buffer::order::key, protocol::order},
-                        std::pair{ casual::buffer::string::key, protocol::string},
-                        std::pair{ common::buffer::type::null, protocol::null},
-                     };
-
                      auto result = std::ranges::find( mapping, key, [] ( const auto& value) -> decltype(auto) { return std::get< key_index>( value);});
+
+                     if( result != std::end( mapping))
+                        return std::get< value_index>( *result);
+                     else
+                        return {};
+                  }
+
+                  template< std::size_t key_index, std::size_t value_index>
+                  auto scan( const auto& lhs) -> std::string_view
+                  {
+                     auto result = std::ranges::find_if( mapping, [&] ( const auto& value) -> decltype(auto) { return wild::match( lhs, std::get< key_index>( value));});
 
                      if( result != std::end( mapping))
                         return std::get< value_index>( *result);
@@ -135,6 +146,39 @@ namespace casual
                   return local::find< local::buffer_type, local::content_type>( buffer);
                }
             } // to
+
+            namespace wild
+            {
+               bool match( std::string_view lhs, std::string_view rhs)
+               {
+                  auto split = []( std::string_view value)
+                  {
+                     return value
+                        | std::views::split( '/')
+                        | std::views::transform( []( auto part){ return std::string_view{ part};})
+                        | std::ranges::to<std::vector>();
+                  };
+
+                  return std::ranges::equal( split( lhs), split( rhs), []( std::string_view lhs, std::string_view rhs )
+                     {
+                        return lhs == rhs || lhs == "*" || rhs == "*";
+                     });
+               }
+
+               namespace to
+               {
+                  std::string_view buffer( std::string_view content)
+                  {
+                     return local::scan< local::content_type, local::buffer_type>( content);
+                  }
+
+                  std::string_view content( std::string_view buffer)
+                  {
+                     return local::scan< local::buffer_type, local::content_type>( buffer);
+                  }
+               }// to
+            } // wild
+
          } // convert
       } // protocol
 

--- a/middleware/http/source/inbound/call.cpp
+++ b/middleware/http/source/inbound/call.cpp
@@ -13,13 +13,12 @@
 #include "common/communication/instance.h"
 #include "common/code/category.h"
 
-
 namespace casual
 {
-   using namespace common;
-
    namespace http::inbound::call
    { 
+      using namespace common;
+
       namespace local
       {
          namespace
@@ -32,36 +31,59 @@ namespace casual
             namespace buffer
             {
                //! @returns string pieces (views) owned by the caller
-               auto type( const casual::Header& header) -> std::vector< std::string_view>
+               auto type( const casual::header::Fields& fields) -> std::string_view
                {
-                  auto content = algorithm::find( header.fields, "content-type");
+                  //
+                  // HTTP behaviour is normally to allow different content-type than what is accepted 
+                  //
+                  // ... but currently in casual, the source and target buffer need to be of the same
+                  // type and thus we must make sure that any possible content-type is among accepted
 
-                  if( auto accept = algorithm::find( header.fields, "accept"))
+                  auto content = fields.find( "content-type");
+
+                  // only consider the first possible header field
+                  if( auto accept = fields.find( "accept"))
                   {
                      auto accepts = 
                         accept->value() |
-                        std::views::split(',') | 
+                        std::views::split( ',') | 
                         std::views::transform( []( auto type){ return std::string_view{ common::string::trim( type)};});
                      
                      if( content)
                      {
-                        if( algorithm::find( accepts, content->value()))
-                           return { content->value()};
-
-                        // HTTP behaviour is normally to allow different content-type than what is accepted 
-                        // ... but currently, the source and target buffer need to be of the same type
-                        return {};
+                        if( std::ranges::any_of( accepts, [&content]( auto accept){ return protocol::convert::wild::match( content->value(), accept);}))
+                           return protocol::convert::to::buffer( content->value());
                      }
+                     else
+                     {
+                        auto rank = []( std::string_view value)
+                        {
+                           auto parts =
+                              value
+                              | std::views::split( '/')
+                              | std::views::transform( []( auto part){ return std::string_view{ part};});
 
-                     return accepts | std::ranges::to< std::vector>();
+                           return std::ranges::count( parts, "*"sv);
+                        };                     
+
+                        // order them with the most significant first
+                        auto ranges = accepts | std::ranges::to< std::vector>();
+                        std::ranges::stable_sort( ranges, [&rank]( auto lhs, auto rhs){ return rank( lhs) < rank( rhs);});
+                        // find potential matching buffer-type
+                        auto target = ranges | std::views::transform( []( auto value){ return protocol::convert::wild::to::buffer( value);});
+                        auto result = std::ranges::find_if( target, [] ( auto value) { return ! value.empty();});
+                        
+                        if(result != std::end( target)) 
+                           return *result;
+                     }
+                  }
+                  else
+                  {
+                     if( content)
+                        return protocol::convert::to::buffer( content->value());
                   }
 
-                  if( content)
-                     return { content->value()};
-
-                  // HTTP behaviour is normally to assume '*/*' if no content-type is given
-                  // ... but currently, the buffer type must be explicit
-                  return {};
+                  [[unlikely]] return {};
                }
 
             } // buffer
@@ -410,14 +432,12 @@ namespace casual
       {
          auto type( const casual::Header& header) -> std::string_view
          {
-            auto source = local::buffer::type( header);
-            auto target = source | std::views::transform( []( auto value){ return protocol::convert::to::buffer( value);});
-            auto result = std::ranges::find_if( target, [] ( auto value) { return ! value.empty();});
-            
-            if(result != std::end( target)) 
-               return *result;
+            auto result = local::buffer::type( header.fields);
 
+            if( result.empty()) 
             common::code::raise::error( code::not_acceptable, "invalid or missing 'content-type'/'accept' headers");
+
+            return result;
          }
       } // buffer
 

--- a/middleware/http/unittest/source/inbound/test_call.cpp
+++ b/middleware/http/unittest/source/inbound/test_call.cpp
@@ -401,13 +401,71 @@ domain:
          EXPECT_TRUE( call::buffer::type( header) == ".json/") << call::buffer::type( header);
       }
 
+      TEST( http_inbound_call_buffer_type, wildcard_accept_and_content_type__expect_buffer)
+      {
+         casual::Header header{ .fields = {{
+            { "Accept", "*/*"},
+            { "Content-Type", "application/json"},
+         }}};
+
+         EXPECT_TRUE( call::buffer::type( header) == ".json/") << call::buffer::type( header);
+      }
+
+      TEST( http_inbound_call_buffer_type, type_wildcard_accept_and_content_type__expect_buffer)
+      {
+         casual::Header header{ .fields = {{
+            { "Accept", "application/*"},
+            { "Content-Type", "application/json"},
+         }}};
+
+         EXPECT_TRUE( call::buffer::type( header) == ".json/") << call::buffer::type( header);
+      }
+
+      TEST( http_inbound_call_buffer_type, type_wildcard_accept_and_different_content_type__expect_exception)
+      {
+         casual::Header header{ .fields = {{
+            { "Accept", "text/*"},
+            { "Content-Type", "application/json"},
+         }}};
+
+         EXPECT_THROW({
+            call::buffer::type( header);
+         }, std::system_error);
+      }
+
+      TEST( http_inbound_call_buffer_type, wildcard_accept_without_content_type__expect_success)
+      {
+         casual::Header header{ .fields = {{
+            { "Accept", "*/*"},
+         }}};
+
+         EXPECT_NO_THROW( call::buffer::type( header));
+      }
+
+      TEST( http_inbound_call_buffer_type, type_wildcard_accept_without_content_type__expect_success)
+      {
+         casual::Header header{ .fields = {{
+            { "Accept", "application/*"},
+         }}};
+
+         EXPECT_NO_THROW( call::buffer::type( header));
+      }
+
+      TEST( http_inbound_call_buffer_type, explicit_accept_with_type_wildcard_without_content_type__expect_buffer)
+      {
+         casual::Header header{ .fields = {{
+            { "Accept", "application/*, application/json"},
+         }}};
+
+         EXPECT_TRUE( call::buffer::type( header) == ".json/") << call::buffer::type( header);
+      }
+
       TEST( http_inbound_call_buffer_type, different_accept_and_content_type__expect_exception)
       {
-         const Header header{
-            .fields = { { 
-               { "Accept", "application/toml, application/yaml"}, 
-               { "Content-Type", "application/json"}}}
-         };
+         const Header header{ .fields = { { 
+            { "Accept", "application/toml, application/yaml"}, 
+            { "Content-Type", "application/json"},
+         }}};
 
          EXPECT_THROW({
             call::buffer::type( header);
@@ -416,11 +474,10 @@ domain:
 
       TEST( http_inbound_call_buffer_type, intersect_content_and_accept_type__expect_buffer)
       {
-         const Header header{
-            .fields = { { 
+         const Header header{ .fields = { { 
                { "Accept", "application/toml, application/json, application/yaml"}, 
-               { "Content-Type", "application/json"}}}
-         };
+               { "Content-Type", "application/json"},
+         }}};
 
          EXPECT_TRUE( call::buffer::type( header) == ".json/") << call::buffer::type( header);
       }


### PR DESCRIPTION
Afore: An error was issued when all header media types contained wildcards

After: Wildcards are now handled for matching the best media - or buffer type

Resolves: #708