### PR TITLE
Gateway - Fix transform of conversation connect request from v1_2, and added unittest, issue 709. 

### DIFF
--- a/middleware/gateway/include/gateway/message/protocol/transform.h
+++ b/middleware/gateway/include/gateway/message/protocol/transform.h
@@ -144,6 +144,7 @@ namespace casual
          result.buffer = std::move( message.buffer);
          result.parent = std::move( message.parent.service);
          result.pending = message.pending;
+         result.duplex = message.duplex;
          result.service.name = std::move( message.service.name);
          result.service.timeout.duration = message.deadline.remaining.value_or( common::chronology::duration{});
          result.trid = std::move( message.trid);
@@ -158,6 +159,7 @@ namespace casual
          result.buffer = std::move( message.buffer);
          result.parent.service = std::move( message.parent);
          result.pending = message.pending;
+         result.duplex = message.duplex;
          result.service.name = std::move( message.service.name);
          
          if( message.service.timeout.duration > common::chronology::duration{})

--- a/middleware/gateway/unittest/source/test_protocol.cpp
+++ b/middleware/gateway/unittest/source/test_protocol.cpp
@@ -8,6 +8,7 @@
 
 #include "gateway/message.h"
 #include "gateway/message/protocol.h"
+#include "gateway/message/protocol/transform.h"
 #include "gateway/documentation/protocol/example.h"
 
 #include "common/serialize/native/network.h"
@@ -104,7 +105,72 @@ namespace casual
       static_assert( gateway::message::protocol::version< gateway::message::domain::disconnect::Request>().min == gateway::message::protocol::Version::v1_1);
       static_assert( gateway::message::protocol::version< gateway::message::domain::disconnect::Reply>().min == gateway::message::protocol::Version::v1_1);
 
-        /* 
+      // TODO
+      // This test should perhaps be in a new file (unittest/source/protocol/test_transform.cpp?)
+      // as the focus of the test is to test the actual transformation of a
+      // protocol message. This is different from the main purpose of the other tests
+      // in this file.
+      // There may also be a need to do more tests of the protocol version transform
+      // methods in the future´, and it may be more logical to have the tests in a dedicated
+      // file and with its own test_suit_name.  
+      //
+      // To avoid introducing a new file in the midle of the change from casual_make to
+      // cmake the test has been added to this existing file.
+      //
+      // This particular test was triggered by a bug where one member ("duplex")
+      // of the conversation::connect::V1_2::callee::request was not copied 
+      // the current version of the message when transformed.    
+      TEST(gateway_protocol, transform_conversation_connect_to_from_v1_2)
+      {
+         using Request = common::message::conversation::connect::callee::Request;
+         using v1_2_Request = common::message::conversation::connect::v1_2::callee::Request;
+
+         Request request;
+         documentation::protocol::example::detail::fill(request);
+         // Change value of duplex. The value "send" set by fill
+         // corresponds to the default initialization value of duplex.
+         // To be able to detect a missing "copy" of duplex we need a
+         // "non-default" value.
+         request.duplex = decltype(request.duplex)::receive;
+         // Transform to V1_2. The transform::to requires a rvalue reference,
+         // so the "transform source" may be "destroyed". Pass a copy so that
+         // "request" can be used later.  
+         auto v1_2_request =
+            gateway::message::protocol::transform::to< v1_2_Request>( Request( request));
+         // check
+         // deadline.remaining should be copied to service.timeot.duration
+         EXPECT_EQ(v1_2_request.service.timeout.duration, request.deadline.remaining);
+         EXPECT_EQ(v1_2_request.parent, request.parent.service);
+         // request.parent.span is lost
+         // remaining fields verified after roundtrip
+         
+         // transform back to current version
+         // transform::from also requires a rvalue reference argument, so its
+         // argument may be destroyed.
+         Request roundtrip_request =
+            gateway::message::protocol::transform::from( std::move( v1_2_request)); 
+         // Check if equal to/equivalent with original. We only check "non generic"
+         // fields. There are expected differences after a roundtrip!
+         // 
+         // deadline.remaining:
+         // This is service.timeout.duration in the V1_2 format of the message. A "roundtrip"
+         // transformation should preserve the value.
+         //
+         // parent:
+         // In V1_2 this is a member "parent" with a string with the parent service name.
+         // in the current version it is a structure with members parent.service
+         // and parent.span. A roundtrip transformation is expected to loose the span.
+         EXPECT_EQ( roundtrip_request.service.name, request.service.name);
+         EXPECT_EQ( roundtrip_request.deadline.remaining, request.deadline.remaining);
+         EXPECT_EQ( roundtrip_request.parent.service, request.parent.service);
+         decltype( request.parent.span) empty_span;
+         EXPECT_EQ( roundtrip_request.parent.span, empty_span);
+         EXPECT_EQ( roundtrip_request.trid, request.trid);
+         EXPECT_EQ( roundtrip_request.duplex, request.duplex);
+         EXPECT_EQ( roundtrip_request.buffer.type, request.buffer.type);
+         EXPECT_EQ( roundtrip_request.buffer.data, request.buffer.data);
+      }
+      /* 
          // connect request
          // current 1.4
          {


### PR DESCRIPTION
Fixed the transform of conversation::connect::callee::request <--> conversattion::connect::v1_2::callee::request.

duplex field was not copied during the transformation. This resulted in failures when a connect request has the value "receive" in the duplex filed (i.e. wen the "connecting" party specifies TPSENDONLY in the tpconnect call, indicating that more data will be sent after the connect.

Also added a simple unittest. The test should probably be moved to a new file in the 1.9 stream. In this PR it was added to an existing file to simplify a future merge merge of patch/1.8/main to feature/1.9/main.   