### PR TITLE
queue: treat queue names prefixed with . as hidden

### DIFF
--- a/middleware/administration/unittest/source/cli/test_queue.cpp
+++ b/middleware/administration/unittest/source/cli/test_queue.cpp
@@ -218,6 +218,53 @@ d.error  A       0  0.000      0     0    0  ED   0   0   0  -
          EXPECT_TRUE( capture.standard.out == expected) << capture.standard.out;
       }
 
+      TEST( cli_queue, hidden_queues)
+      {
+         common::unittest::Trace trace;
+
+         auto domain = local::domain( R"(
+domain:
+   name: A
+   queue:
+      groups:
+         -  alias: A
+            queues:
+               -  name: a
+               -  name: .b
+)");
+
+         // .b should be hidden by default
+         {
+            auto capture = local::execute( R"(casual --porcelain true queue --list-queues)");
+            auto rows = string::split( capture.standard.out, '\n');
+            EXPECT_TRUE( algorithm::any_of( rows, []( auto& row){ return row.starts_with( "a|");}));
+            EXPECT_TRUE( algorithm::none_of( rows, []( auto& row){ return row.starts_with( ".b|");}));
+         }
+
+         // .b should be shown with --all
+         {
+            auto capture = local::execute( R"(casual --porcelain true queue --list-queues --all)");
+            auto rows = string::split( capture.standard.out, '\n');
+            EXPECT_TRUE( algorithm::any_of( rows, []( auto& row){ return row.starts_with( "a|");}));
+            EXPECT_TRUE( algorithm::any_of( rows, []( auto& row){ return row.starts_with( ".b|");}));
+         }
+
+         // instances
+         {
+            auto capture = local::execute( R"(casual --porcelain true queue --list-queue-instances)");
+            auto rows = string::split( capture.standard.out, '\n');
+            EXPECT_TRUE( algorithm::any_of( rows, []( auto& row){ return row.starts_with( "a|");}));
+            EXPECT_TRUE( algorithm::none_of( rows, []( auto& row){ return row.starts_with( ".b|");}));
+         }
+
+         {
+            auto capture = local::execute( R"(casual --porcelain true queue --list-queue-instances --all)");
+            auto rows = string::split( capture.standard.out, '\n');
+            EXPECT_TRUE( algorithm::any_of( rows, []( auto& row){ return row.starts_with( "a|");}));
+            EXPECT_TRUE( algorithm::any_of( rows, []( auto& row){ return row.starts_with( ".b|");}));
+         }
+      }
+
       TEST( cli_queue, list_forward_groups)
       {
          common::unittest::Trace trace;

--- a/middleware/common/include/common/name.h
+++ b/middleware/common/include/common/name.h
@@ -1,0 +1,24 @@
+//! 
+//! Copyright (c) 2015, The casual project
+//!
+//! This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+//!
+
+#pragma once
+
+#include <string_view>
+
+namespace casual
+{
+   namespace common::name
+   {
+      namespace hidden
+      {
+         //! @returns true if the `name` is _hidden_ (starts with `.`)
+         inline bool name( std::string_view value)
+         {
+            return value.starts_with( '.');
+         }
+      } // hidden
+   } // common::name
+} // casual

--- a/middleware/common/include/common/service/type.h
+++ b/middleware/common/include/common/service/type.h
@@ -9,6 +9,7 @@
 
 #include "common/code/xatmi.h"
 #include "common/serialize/macro.h"
+#include "common/name.h"
 
 #include <string>
 #include <iosfwd>
@@ -38,12 +39,6 @@ namespace casual
          constexpr std::string_view admin = ".admin";
          constexpr std::string_view deprecated = ".deprecated";
       } // category
-
-      namespace hidden
-      {
-         //! @returns true if the service `name` is _hidden_ (starts with `.`)
-         bool name( std::string_view service);         
-      } // hidden
 
       namespace visibility
       {

--- a/middleware/common/source/service/type.cpp
+++ b/middleware/common/source/service/type.cpp
@@ -22,15 +22,6 @@ namespace casual
 {
    namespace common::service
    {
-      namespace hidden
-      {
-         bool name( std::string_view service)
-         {
-            return service.starts_with( '.');
-         }
-
-      } // hidden
-
       namespace visibility
       {
          std::string_view description( Type value) noexcept

--- a/middleware/queue/source/manager/admin/cli.cpp
+++ b/middleware/queue/source/manager/admin/cli.cpp
@@ -13,6 +13,7 @@
 #include "queue/common/queue.h"
 
 #include "common/transaction/id.h"
+#include "common/name.h"
 
 #include "casual/argument.h"
 #include "common/terminal.h"
@@ -787,18 +788,37 @@ output columns:
 
                   auto option()
                   {
-                     auto invoke = []()
+                     struct State
                      {
+                        bool all = false;
+                     };
+                     auto shared = std::make_shared< State>();
+
+                     auto invoke = [ shared]()
+                     {
+                        auto filter = [ shared]( auto& queue)
+                        {
+                           if( shared->all)
+                              return true;
+                           return ! common::name::hidden::name( queue.name);
+                        };
+
                         auto state = call::state();
 
-                        format::queues( state, algorithm::sort( state.queues));
+                        format::queues( state, algorithm::sort( algorithm::filter( state.queues, filter)));
                      };
+
+                     auto flag = argument::Option{ [ shared]()
+                        {
+                           shared->all = true;
+                           return argument::option::invoke::preemptive{};
+                        }, {{ "-a", "--all"}}, "include hidden queues"};
 
                      return argument::Option{
                         std::move( invoke),
                         argument::option::Names{ { "-lq", "--list-queues"}, { "-q"}},
                         { "list information of all queues in current domain", legend}
-                     };
+                     }( { std::move( flag)});
                   }
                   
                } // queues
@@ -807,38 +827,76 @@ output columns:
                {
                   auto option()
                   {
-                     auto invoke = []()
+                     struct State
                      {
+                        bool all = false;
+                     };
+                     auto shared = std::make_shared< State>();
+
+                     auto invoke = [ shared]()
+                     {
+                        auto filter = [ shared]( auto& queue)
+                        {
+                           if( shared->all)
+                              return true;
+                           return ! common::name::hidden::name( queue.name);
+                        };
+
                         auto state = call::state();
 
-                        format::queues( state, algorithm::sort( state.zombies));
+                        format::queues( state, algorithm::sort( algorithm::filter( state.zombies, filter)));
 
                      };
+
+                     auto flag = argument::Option{ [ shared]()
+                        {
+                           shared->all = true;
+                           return argument::option::invoke::preemptive{};
+                        }, {{ "-a", "--all"}}, "include hidden zombie queues"};
 
                      return argument::Option{
                         std::move( invoke),
                         argument::option::Names{ { "-lz", "--list-zombies"}, { "-z"}},
                         R"(list information of all zombie queues in current domain)"
-                     };
+                     }( { std::move( flag)});
                   }
                   
-               } // queues
+               } // zombies
 
                namespace queue::instances
                {
                   auto option()
                   {
-                     auto invoke = []()
+                     struct State
                      {
+                        bool all = false;
+                     };
+                     auto shared = std::make_shared< State>();
+
+                     auto invoke = [ shared]()
+                     {
+                        auto filter = [ shared]( auto& instance)
+                        {
+                           if( shared->all)
+                              return true;
+                           return ! common::name::hidden::name( instance.queue);
+                        };
+
                         auto state = call::state();
-                        format::queue::instances( normalize::instances( state));
+                        format::queue::instances( algorithm::sort( algorithm::filter( normalize::instances( state), filter)));
                      };
                      
+                     auto flag = argument::Option{ [ shared]()
+                        {
+                           shared->all = true;
+                           return argument::option::invoke::preemptive{};
+                        }, {{ "-a", "--all"}}, "include hidden queue instances"};
+
                      return argument::Option{
                         std::move( invoke),
                         {{ "-lqi", "--list-queue-instances"}},
                         R"(list instances for all queues, including external instances)"
-                     };
+                     }( { std::move( flag)});
                   }
                   
                } // queue::instances
@@ -2164,8 +2222,10 @@ Example:
                   auto metric_enqueued = []( auto& queue){ return queue.metric.enqueued;};
                   auto metric_dequeued = []( auto& queue){ return queue.metric.dequeued;};
 
+                  auto is_hidden = []( auto& queue){ return common::name::hidden::name( queue.name);};
+
                   auto split = algorithm::partition( state.queues, []( auto& queue){ return queue.type() == decltype( queue.type())::queue;});
-                  auto queues = std::get< 0>( split);
+                  auto [ hidden, queues] = algorithm::partition( std::get< 0>( split), is_hidden);
                   auto errors = std::get< 1>( split);
 
                   auto commit_count = []( auto& forward){ return forward.metric.commit.count;};
@@ -2175,6 +2235,8 @@ Example:
 
                   return {
                      { "queue.manager.group.count", string::compose( state.groups.size())},
+                     { "queue.manager.queue.hidden.count", string::compose( hidden.size())},
+                     { "queue.manager.queue.hidden.message.count", string::compose( hidden.empty() ? 0 : accumulate( message_count)( hidden))},
                      { "queue.manager.queue.count", string::compose( queues.size())},
                      { "queue.manager.queue.message.count", string::compose( accumulate( message_count)( queues))},
                      { "queue.manager.queue.message.size", string::compose( accumulate( message_size)( queues))},

--- a/middleware/service/source/manager/admin/cli.cpp
+++ b/middleware/service/source/manager/admin/cli.cpp
@@ -16,6 +16,7 @@
 
 #include "casual/argument.h"
 #include "common/chronology.h"
+#include "common/name.h"
 #include "common/terminal.h"
 #include "common/exception/capture.h"
 #include "common/algorithm/compare.h"
@@ -454,7 +455,7 @@ output columns:
                            {
                               if( shared->all)
                                  return true; 
-                              return ! common::service::hidden::name( service.name);
+                              return ! common::name::hidden::name( service.name);
                            };
 
                            auto state = manager::admin::api::state();
@@ -496,7 +497,7 @@ output columns:
                            {
                               if( shared->all)
                                  return true; 
-                              return ! common::service::hidden::name( instance.service);
+                              return ! common::name::hidden::name( instance.service);
                            };
 
                            auto state = admin::api::state();
@@ -577,7 +578,7 @@ output columns:
                   {
                      auto state = admin::api::state();
 
-                     auto is_hidden = []( auto& service){ return common::service::hidden::name( service.name);};
+                     auto is_hidden = []( auto& service){ return common::name::hidden::name( service.name);};
 
                      auto [ hidden, services] = algorithm::partition( state.services, is_hidden);
 
@@ -668,7 +669,7 @@ output columns:
                         {
                            auto is_hidden = []( auto& service)
                            { 
-                              return common::service::hidden::name( service.name);
+                              return common::name::hidden::name( service.name);
                            };
 
                            auto state = manager::admin::api::state();


### PR DESCRIPTION
Did it for zombies too out of some sense of symmetry, don't know if reasonable?