### PR TITLE
Feature/1.9/replace various archives with polylite

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,6 @@ find_package(pugixml REQUIRED)
 find_package(yaml-cpp REQUIRED)
 find_package(GTest REQUIRED)
 find_package(cppcodec REQUIRED)
-find_package(tomlplusplus REQUIRED)
 
 include(FetchContent)
 FetchContent_Declare(
@@ -24,9 +23,19 @@ FetchContent_Declare(
   SOURCE_DIR     casual-thirdparty
 )
 
-FetchContent_MakeAvailable( 
-    casual_thirdparty 
+FetchContent_Declare(
+  polylite
+  GIT_REPOSITORY https://github.com/KristianIvarsson/polylite.git
+  GIT_TAG        4.2.0
 )
+
+FetchContent_MakeAvailable( 
+    casual_thirdparty
+    polylite
+)
+
+add_library(polylite INTERFACE)
+target_include_directories(polylite INTERFACE "${polylite_SOURCE_DIR}/include")
 
 set(CASUAL_THIRDPARTY_SOURCE_DIR "${casual_thirdparty_SOURCE_DIR}")
 set(CASUAL_THIRDPARTY_BINARY_DIR "${casual_thirdparty_BINARY_DIR}")

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -3,7 +3,6 @@ yaml-cpp/0.8.0
 pugixml/1.15
 gtest/1.16.0
 cppcodec/0.2
-tomlplusplus/3.4.0
 [generators]
 CMakeDeps
 CMakeToolchain

--- a/middleware/buffer/source/field.cpp
+++ b/middleware/buffer/source/field.cpp
@@ -1454,10 +1454,6 @@ namespace casual
                   template< typename T, typename A>
                   void assign( A& archive)
                   {
-                     T value;
-                     archive >> common::serialize::named::value::make( value, "value");
-                     
-                     
                      m_value.resize( sizeof( T));
                      archive >> common::serialize::named::value::make( *reinterpret_cast< T*>( m_value.data()), "value");
                   }

--- a/middleware/common/CMakeLists.txt
+++ b/middleware/common/CMakeLists.txt
@@ -94,7 +94,6 @@ target_sources(casual-common
 target_include_directories(casual-common PRIVATE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../xatmi/include>
-  $<BUILD_INTERFACE:${CASUAL_THIRDPARTY_SOURCE_DIR}/rapidjson/include>
 )
 
 target_link_directories(casual-common PRIVATE
@@ -102,10 +101,10 @@ target_link_directories(casual-common PRIVATE
 )
 
 target_link_libraries(casual-common PRIVATE
+  polylite
   yaml-cpp
   pugixml::pugixml
   cppcodec::cppcodec
-  tomlplusplus::tomlplusplus
   $<$<PLATFORM_ID:Darwin>:iconv>
   $<$<PLATFORM_ID:Linux>:pthread>
   $<$<PLATFORM_ID:Linux>:uuid>
@@ -144,7 +143,6 @@ target_sources(casual-unittest
 target_include_directories(casual-unittest PRIVATE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../xatmi/include>
-  $<BUILD_INTERFACE:${CASUAL_THIRDPARTY_SOURCE_DIR}/rapidjson/include>
 )
 
 target_link_directories(casual-unittest PRIVATE

--- a/middleware/common/include/common/serialize/detail/poly.h
+++ b/middleware/common/include/common/serialize/detail/poly.h
@@ -1,0 +1,348 @@
+//! 
+//! Copyright (c) 2015, The casual project
+//!
+//! This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+//!
+
+#pragma once
+
+#include "casual/platform.h"
+#include "common/transcode.h"
+#include "common/code/raise.h"
+#include "common/code/casual.h"
+#include "common/serialize/archive.h"
+
+#include <ranges>
+#include <vector>
+#include <cassert>
+
+#include <poly/node.hpp>
+
+namespace casual::common::serialize::detail::poly
+{
+   class reader
+   {
+   public:
+
+      struct official
+      {
+         auto operator() ( const ::poly::node& root)
+         {
+            std::visit( *this, root);
+            return std::exchange( m_info, {});
+         }
+
+         void operator() ( const auto&) 
+         {
+            m_info.attribute( m_name);
+         }
+
+         void operator() ( const ::poly::node::nothing&) 
+         {
+
+         }
+
+         void operator() ( const ::poly::node::array& node)
+         {
+            m_info.container_start( m_name);
+            for( const auto& item : node)
+            {
+               m_name = nullptr;
+               std::visit( *this, item);
+            }
+            m_info.container_end();
+         }
+
+         void operator() ( const ::poly::node::object& node)
+         {
+            m_info.composite_start( m_name);
+            for( const auto& [ name, data] : node)
+            {
+               m_name = name.data();
+               std::visit( *this, data);
+            }
+            m_info.composite_end();
+         }
+
+      private:
+
+         policy::canonical::Representation m_info;
+         const char* m_name = nullptr;
+
+      };
+
+
+      using base = reader;
+
+      reader( auto&& node) : m_root{ std::forward< decltype( node)>( node)}, m_stack{ &m_root} {}
+
+      std::tuple< platform::size::type, bool> container_start( platform::size::type size, const char* const name)
+      {
+         if( auto node = append< ::poly::node::array, ::poly::node::nothing>( name))
+         {
+            if( node->is_nothing())
+               return { 0, true};
+
+            auto& array = node->as_array();
+
+            for( auto& item : std::ranges::reverse_view( array))
+               m_stack.push_back( &item);
+            
+            return { array.size(), true};
+         }
+
+         return {};
+      }
+
+      void container_end( const char*)
+      {
+         m_stack.pop_back();
+      }
+
+      bool composite_start( const char* const name)
+      {
+         return append< ::poly::node::object, ::poly::node::nothing>( name) != nullptr;
+      }
+
+      void composite_end( const char* const name)
+      {
+         m_stack.pop_back();
+      }
+
+      bool read( bool& value, const char* const name)
+      {
+         return assign< ::poly::node::boolean>( name, value);
+      }
+
+      bool read( std::integral auto& value, const char* const name)
+      {
+         return assign< ::poly::node::integer>( name, value);
+      }
+      
+      bool read( std::floating_point auto& value, const char* const name)
+      {
+         return assign< ::poly::node::decimal, ::poly::node::integer>( name, value);
+      }
+      
+      bool read( std::string& value, const char* const name)
+      {
+         if( assign< ::poly::node::string>( name, value))
+            return value = transcode::utf8::string::decode( std::move( value)), true;
+         return false;
+      }
+      
+      bool read( char& value, const char* const name)
+      {
+         std::string data;
+         if( read( data, name))
+            return value = *data.data(), true;
+         return false;
+      }
+      
+      bool read( std::u8string& value, const char* const name)
+      {
+         std::string data;
+         if( read( data, name))
+            return value = transcode::utf8::cast( std::move( data)), true;
+         return false;
+      }
+
+      bool read( platform::binary::type& value, const char* const name)
+      {
+         std::string data;
+         if( read( data, name))
+            return value = transcode::base64::decode( std::move( data)), true;
+
+         return false;
+      }
+
+      bool read( binary::span::Fixed< std::byte> value, const char* const name)
+      {
+         platform::binary::type data;
+         if( read( data, name))
+         {
+            if( range::size( data) != range::size( value))
+               code::raise::error( code::casual::invalid_node, "binary size mismatch");
+
+            algorithm::copy( data, std::begin( value));
+
+            return true;
+         }
+
+         return false;
+      }
+
+      auto canonical() const
+      {
+         return official{}( m_root);
+      }
+
+   protected:
+
+      auto search( const char* const name) -> ::poly::node*
+      {
+         if( name)
+         {
+            if( auto node = (*m_stack.back())( name))
+               return &(*node);
+
+            return nullptr;
+         }
+
+         assert( ! m_stack.empty());
+         auto result = m_stack.back();
+         m_stack.pop_back();
+         return result;
+      }
+
+      template< typename... types>
+      auto verify( const char* const name) -> ::poly::node*
+      {
+         if( auto node = search( name))
+         {
+            if( (std::holds_alternative< types>( *node) || ...))
+               return node;
+            
+            // treat nothing as non existent and not as an error
+            if( ! std::holds_alternative< ::poly::node::nothing>( *node))
+               code::raise::error( code::casual::invalid_node, "unexpected type");
+         }
+
+         return nullptr;
+      }
+
+      template< typename... types>
+      auto append( const char* const name) -> ::poly::node*
+      {
+         if( auto node = verify< types...>( name))
+            return m_stack.push_back( node), node;
+
+         return nullptr;
+      }
+
+      template< typename... types>
+      bool assign( const char* const name, auto& data)
+      {
+         if( auto node = verify< types...>( name))
+         {
+            std::visit( [&data]( auto& node)
+            {
+               if constexpr( (std::same_as< std::remove_cvref_t< decltype( node)>, types> || ...))
+                  data = std::move( node);
+            }, *node);
+
+            return true;
+         }
+
+         return false;
+      }
+      
+   protected:
+
+      ::poly::node m_root;
+      std::vector< ::poly::node*> m_stack;
+   };
+
+
+   class writer
+   {
+   public:
+
+      writer() : m_stack{ &m_root} {}
+
+      platform::size::type container_start( const platform::size::type size, const char* const name)
+      {
+         complex(name, ::poly::node::array{}).as_array().reserve( size);
+
+         return size;
+      }
+      
+      void container_end( const char* const name)
+      {
+         m_stack.pop_back();
+      }
+
+      void composite_start( const char* const name)
+      {
+         complex( name, ::poly::node::object{});
+      }
+
+      void composite_end( const char* const name)
+      {
+         m_stack.pop_back();
+      }
+
+      void write( auto&& data, const char* const name)
+      {
+         trivial( name, std::forward< decltype( data)>( data));
+      }
+
+      void write( char data, const char* const name)
+      {
+         trivial( name, transcode::utf8::string::encode( std::string{ data}));
+      }
+
+      void write( std::string_view data, const char* const name)
+      {
+         trivial( name, transcode::utf8::string::encode( data));
+      }
+
+      void write( std::u8string_view data, const char* const name)
+      {
+         trivial( name, std::string{ transcode::utf8::cast( data)});
+      }
+
+      void write( const std::string& data, const char* const name)
+      {
+         trivial( name, transcode::utf8::string::encode( data));
+      }
+
+      void write( const std::u8string& data, const char* const name)
+      {
+         trivial( name, std::string{ transcode::utf8::cast( data)});
+      }
+
+      void write( std::span< const std::byte> data, const char* const name)
+      {
+         trivial( name, transcode::base64::encode( data));
+      }
+
+      void write( binary::span::Fixed< const std::byte> data, const char* const name)
+      {
+         trivial( name, transcode::base64::encode( data));
+      }
+
+   protected:
+
+      auto conduct( const char* const name) -> ::poly::node&
+      {
+         if( name)
+            return (*m_stack.back())[ name];
+
+         if( m_stack.back()->is_array())
+            return m_stack.back()->as_array().emplace_back();
+
+         return *m_stack.back();
+      }
+   
+      void trivial( const char* const name, auto&& data)
+      {
+         auto& slot = conduct( name);
+         slot = std::forward< decltype( data)>( data);
+      }
+
+      auto complex( const char* const name, auto&& data) -> ::poly::node&
+      {
+         auto& slot = conduct( name);
+         slot = std::forward< decltype( data)>( data);
+         return m_stack.push_back( &slot), slot;
+      }
+
+   protected:
+
+      ::poly::node m_root;
+      std::vector< ::poly::node*> m_stack;
+
+   };
+
+} // casual::common::serialize::detail::poly

--- a/middleware/common/source/serialize/json.cpp
+++ b/middleware/common/source/serialize/json.cpp
@@ -6,555 +6,122 @@
 
 
 #include "common/serialize/json.h"
+
 #include "common/serialize/create.h"
-
-#include "common/code/raise.h"
-#include "common/code/casual.h"
-
-#include "common/transcode.h"
-#include "common/functional.h"
+#include "common/binary/span.h"
 #include "common/buffer/type.h"
 
-#include <iterator>
-#include <istream>
-#include <functional>
+#include "common/serialize/detail/poly.h"
 
-#include <iostream>
-
-#define RAPIDJSON_HAS_STDSTRING 1
-// make sure we get unique rapidjson symbols, to not clash with other rapidjson usages from users
-#define RAPIDJSON_NAMESPACE_BEGIN namespace rapidjson { namespace {
-#define RAPIDJSON_NAMESPACE_END } }
-
-#include <rapidjson/document.h>
-#include <rapidjson/error/en.h>
-#include <rapidjson/stringbuffer.h>
-#include <rapidjson/prettywriter.h>
-         
+#include <poly/json.hpp>
 
 namespace casual
 {
-
-
-   namespace common
+   namespace common::serialize
    {
-      namespace serialize
+      namespace json
       {
-         namespace json
+         namespace local
          {
-            namespace local
+            namespace
             {
-               namespace
+               constexpr auto keys() 
                {
-                  constexpr auto keys() 
+                  using namespace std::string_view_literals; 
+                  return array::make( "json"sv, ".json"sv, "jsn"sv, ".jsn"sv, buffer::type::json);
+               };
+
+               namespace reader
+               {
+                  struct Implementation : common::serialize::detail::poly::reader
                   {
-                     using namespace std::string_view_literals; 
-                     return array::make( "json"sv, ".json"sv, "jsn"sv, ".jsn"sv, buffer::type::json);
+                     constexpr static auto archive_properties() { return common::serialize::archive::Property::named;}
+
+                     constexpr static auto keys() { return local::keys();}
+
+                     Implementation( std::istream& value) : base{ ::poly::json::parse( value)} {}
+                     Implementation( std::string_view value) : base{ ::poly::json::parse( value)} {}
+                     Implementation( const std::vector<std::byte>& value) : Implementation{ std::string_view{ common::binary::span::to_string_like( value)}} {}
+                  };
+               } // reader
+               
+               
+               namespace writer
+               {
+                  struct Implementation : common::serialize::detail::poly::writer
+                  {
+                     constexpr static auto archive_properties() { return common::serialize::archive::Property::named;}
+
+                     constexpr static auto keys() { return local::keys();}
+                     
+                     void consume( std::ostream& destination)
+                     {
+                        ::poly::json::compact::write( m_root, destination);
+                     }
                   };
 
-                  namespace reader
+                  namespace pretty
                   {
-                     namespace check
+                     struct Implementation : writer::Implementation
                      {
-                        // This is a help to check some to avoid terminate (via assert)
-                        template<typename C, typename F>
-                        auto trivial( const rapidjson::Value* const value, C&& checker, F&& fetcher)
+                        void consume( std::ostream& destination)
                         {
-                           if( invoke( checker, value))
-                              return invoke( fetcher, value);
-
-                           // TODO operations: more information about what type and so on...
-                           code::raise::error( code::casual::invalid_node, "unexpected type");
+                           ::poly::json::elegant::write( m_root, destination);
                         }
-
-                        auto string( const rapidjson::Value* const value)
-                        {
-                           if( invoke( &rapidjson::Value::IsString, value))
-                              return std::string_view{ value->GetString(), value->GetStringLength()};
-
-                           // TODO operations: more information about what type and so on...
-                           code::raise::error( code::casual::invalid_node, "unexpected type");
-                        }
-                     } // check
-
-                            
-                     const rapidjson::Document& parse( rapidjson::Document& document, const char* json)
-                     {
-                        // To support empty documents
-                        if( ! json || json[ 0] == '\0')
-                           document.Parse( "{}");
-                        else
-                           document.Parse( json);
-                        
-                        if( document.HasParseError())
-                           code::raise::error( code::casual::invalid_document, rapidjson::GetParseError_En( document.GetParseError()));
-                        
-                        return document;
-                     }
-
-
-
-                     const rapidjson::Document& parse( rapidjson::Document& document, std::istream& stream)
-                     {
-                        // note: istreambuf_iterator does not skip whitespace, which is what we want.
-                        const std::string buffer{
-                           std::istreambuf_iterator<char>(stream),
-                           {}};
-
-                        return parse( document, buffer.c_str());
-                     }
-
-                     const rapidjson::Document& parse( rapidjson::Document& document, const std::string& json)
-                     {
-                        return parse( document, json.c_str());
-                     }
-
-                     const rapidjson::Document& parse( rapidjson::Document& document, const char* json, const platform::size::type size)
-                     {
-                        // To ensure null-terminated string
-                        const std::string buffer{ json, json + size};
-                        return parse( document, buffer.c_str());
-                     }
-
-                     const rapidjson::Document& parse( rapidjson::Document& document, const platform::binary::type& json)
-                     {
-                        auto span = binary::span::to_string_like( json);
-
-                        if( ! span.empty() && span.back() == '\0')
-                           return parse( document, span.data());
-                        else
-                           return parse( document, span.data(), span.size());
-                     }
-
-                     namespace canonical
-                     {
-                        struct Parser 
-                        {
-                           using Node = rapidjson::Value;
-                           auto operator() ( const Node& document)
-                           {
-                              deduce( document, nullptr);
-                              return std::exchange( m_canonical, {});
-                           }
-
-                        private:
-
-                           void deduce( const Node& node, const char* name)
-                           {
-                              switch( node.GetType())
-                              { 
-                                 case rapidjson::Type::kNumberType: scalar( node, name); break;
-                                 case rapidjson::Type::kStringType: scalar( node, name); break;
-                                 case rapidjson::Type::kTrueType: scalar( node, name); break;
-                                 case rapidjson::Type::kFalseType: scalar( node, name); break;
-                                 case rapidjson::Type::kArrayType: sequence( node, name); break;
-                                 case rapidjson::Type::kObjectType: map( node, name); break;
-                                 case rapidjson::Type::kNullType: /*???*/ break;
-                              }
-                           }
-
-                           void scalar( const Node& node, const char* name)
-                           {
-                              m_canonical.attribute( name);
-                           }
-
-                           void sequence( const Node& node, const char* name)
-                           {
-                              m_canonical.container_start( name);
-
-                              for( auto current = node.Begin(); current != node.End(); ++current)
-                                 deduce( *current, nullptr);  
-                              
-                              m_canonical.container_end();
-                           }
-
-                           void map( const Node& node, const char* name)
-                           {
-                              m_canonical.composite_start( name);
-
-                              for( auto current = node.MemberBegin(); current != node.MemberEnd(); ++current)
-                                 deduce( current->value, current->name.GetString());
-                              
-                              m_canonical.composite_end();
-                           }
-
-                           policy::canonical::Representation m_canonical;
-                        };
-
-                        auto parse( const rapidjson::Value& document)
-                        {
-                           return Parser{}( document);
-                        }
-
-                     } // canonical
-
-                     class Implementation
-                     {
-                     public:
-
-                        constexpr static auto archive_properties() { return common::serialize::archive::Property::named;}
-
-                        constexpr static auto keys() { return local::keys();}
-
-                        template< typename... Ts>
-                        explicit Implementation( Ts&&... ts) : m_stack{ & reader::parse( m_document, std::forward< Ts>( ts)...)} 
-                        {
-                           
-                        }
-                        ~Implementation() = default;
-
-                        std::tuple< platform::size::type, bool> container_start( platform::size::type size, const char* name)
-                        {
-                           auto node = structured_node( name);
-
-                           if( ! node)
-                              return std::make_tuple( 0, false);
-
-                           // This check is to avoid terminate (via assert)
-                           if( ! node->IsArray())
-                              code::raise::error( code::casual::invalid_node, "expected array - name: ", name ? name : "");
-
-                           // Stack 'em backwards
-
-                           auto range = range::reverse( range::make( node->Begin(), node->End()));
-
-                           for( auto& value : range)
-                              m_stack.push_back( &value);
-
-                           return std::make_tuple( range.size(), true);
-                        }
-
-                        void container_end( const char*)
-                        {
-                           m_stack.pop_back();
-                        }
-
-                        bool composite_start( const char* name)
-                        {
-                           if( auto node = structured_node( name))
-                           {
-                              // This check is to avoid terminate (via assert)
-                              if( ! node->IsObject())
-                                 code::raise::error( code::casual::invalid_node, "expected object - name: ", name ? name : "");
-
-                              return true;
-                           }
-                           return false;
-                        }
-
-                        void composite_end( const char*)
-                        {
-                           m_stack.pop_back();
-                        }
-
-
-                        template< typename T>
-                        bool read( T& value, const char* name)
-                        {
-                           if( name)
-                           {
-                              if( auto child = named_child( name); child && ! child->IsNull())
-                              {
-                                 read( child, value);               
-                                 return true;
-                              }
-                              return false;
-                           }
-                           
-                           // we assume it is a value from a previous pushed sequence node.
-                           // and we consume it.
-                           read( m_stack.back(), value);
-                           m_stack.pop_back();
-                           
-                           return true;
-                        }
-
-                        policy::canonical::Representation canonical()
-                        {
-                           return canonical::parse( m_document);
-                        }
-                     
-                     private:
-
-                        const rapidjson::Value* named_child( const char* name)
-                        {
-                           assert( name);
-
-                           auto node = m_stack.back();
-
-                           if( auto found = node->FindMember( name); found != node->MemberEnd())
-                              return &found->value;
-
-                           return nullptr;
-                        }
-                        
-                        const rapidjson::Value* structured_node( const char* name)
-                        {
-                           // if not named, we assume it is a value from a previous pushed sequence node, or root document
-                           if( ! name)
-                              return m_stack.back();
-
-                           if( auto node = named_child( name))
-                           {
-                              // we push it to promote the node to 'current scope'. 
-                              // composite_end/container_end will pop it.
-                              m_stack.push_back( node);
-                              return m_stack.back();
-                           }
-
-                           return nullptr;
-                        }
-
-                        static void read( const rapidjson::Value* node, bool& value)
-                        { value = check::trivial( node, &rapidjson::Value::IsBool, &rapidjson::Value::GetBool); }
-                        static void read( const rapidjson::Value* node, short& value)
-                        { value = check::trivial( node, &rapidjson::Value::IsInt, &rapidjson::Value::GetInt); }
-                        static void read( const rapidjson::Value* node, int& value)
-                        { value = check::trivial( node, &rapidjson::Value::IsInt, &rapidjson::Value::GetInt); }
-                        static void read( const rapidjson::Value* node, long& value)
-                        { value = check::trivial( node, &rapidjson::Value::IsInt64, &rapidjson::Value::GetInt64); }
-                        static void read( const rapidjson::Value* node, long long& value)
-                        { value = check::trivial( node, &rapidjson::Value::IsInt64, &rapidjson::Value::GetInt64); }
-                        static void read( const rapidjson::Value* node, float& value)
-                        { value = check::trivial( node, &rapidjson::Value::IsNumber, &rapidjson::Value::GetDouble); }
-                        static void read( const rapidjson::Value* node, double& value)
-                        { value = check::trivial( node, &rapidjson::Value::IsNumber, &rapidjson::Value::GetDouble); }
-                        static void read( const rapidjson::Value* node, char& value)
-                        { value = *transcode::utf8::string::decode( check::string( node)).data(); }
-                        static void read( const rapidjson::Value* node, std::string& value)
-                        { value = transcode::utf8::string::decode( check::string( node)); }
-                        static void read( const rapidjson::Value* node, std::u8string& value)
-                        { value = transcode::utf8::cast( check::string( node)); }
-                        static void read( const rapidjson::Value* node, platform::binary::type& value)
-                        { value = transcode::base64::decode( check::string( node)); }
-
-                        static void read( const rapidjson::Value* node, binary::span::Fixed< std::byte> value)
-                        { 
-                           auto binary = transcode::base64::decode( check::string( node));
-                           
-                           if( range::size( binary) != range::size( value))
-                              code::raise::error( code::casual::invalid_node, "binary size mismatch - wanted: ", range::size( value), " got: ", range::size( binary));
-
-                           algorithm::copy( binary, std::begin( value));
-                        }
-                  
-
-                        rapidjson::Document m_document;
-                        std::vector< const rapidjson::Value*> m_stack;
                      };
+                  } // pretty
 
-                  } // reader
-                  
-                  
-                  namespace writer
-                  {
-                     template< typename Writer>
-                     class basic_implementation
-                     {
-                     public:
+               } // writer
+            } //
+         } // local
 
-                        constexpr static auto archive_properties() { return common::serialize::archive::Property::named;}
+         namespace strict
+         {
+            serialize::Reader reader( const std::string& source) { return create::reader::strict::create< local::reader::Implementation>( source);}
+            serialize::Reader reader( std::istream& source) { return create::reader::strict::create< local::reader::Implementation>( source);}
+            serialize::Reader reader( const platform::binary::type& source) { return create::reader::strict::create< local::reader::Implementation>( source);}
+         } // strict
 
-                        constexpr static auto keys() { return local::keys();}
-                        
-                        explicit basic_implementation()
-                           : m_allocator( &m_document.GetAllocator()), m_stack{ &m_document}
-                        {
-                           m_document.SetObject();
-                        }
+         namespace relaxed
+         {    
+            serialize::Reader reader( const std::string& source) { return create::reader::relaxed::create< local::reader::Implementation>( source);}
+            serialize::Reader reader( std::istream& source) { return create::reader::relaxed::create< local::reader::Implementation>( source);}
+            serialize::Reader reader( const platform::binary::type& source) { return create::reader::relaxed::create< local::reader::Implementation>( source);}
+         } // relaxed
 
-                        platform::size::type container_start( platform::size::type size, const char* name)
-                        {
-                           start( name);
-                           m_stack.back()->SetArray();
+         namespace consumed
+         {    
+            serialize::Reader reader( const std::string& source) { return create::reader::consumed::create< local::reader::Implementation>( source);}
+            serialize::Reader reader( std::istream& source) { return create::reader::consumed::create< local::reader::Implementation>( source);}
+            serialize::Reader reader( const platform::binary::type& source) { return create::reader::consumed::create< local::reader::Implementation>( source);}
+         } // consumed
 
-                           return size;
-                        }
-
-                        void container_end( const char* name)
-                        {
-                           end( name);
-                        }
-
-                        void composite_start( const char* name)
-                        {
-                           start( name);
-                           m_stack.back()->SetObject();
-                        }
-                        void composite_end(  const char* name)
-                        {
-                           end( name);
-                        }
-
-                        void start( const char* name)
-                        {
-                           // Both AddMember and PushBack returns the parent (*this)
-                           // instead of a reference to the added value (despite what
-                           // the documentation says) and thus we need to do some
-                           // cumbersome iterator stuff to get a reference/pointer to it
-
-                           auto& parent = *m_stack.back();
-
-                           if( name)
-                           {
-                              parent.AddMember( rapidjson::Value( name, *m_allocator), rapidjson::Value(), *m_allocator);
-                              m_stack.push_back( &(*(parent.MemberEnd() - 1)).value);
-                           }
-                           else
-                           {
-                              switch( parent.GetType())
-                              {
-                                 case rapidjson::Type::kObjectType:
-                                    // do nothing?
-                                    break;
-
-                                 default:
-                                    // We assume we're in a container
-                                    parent.PushBack( rapidjson::Value(), *m_allocator);
-                                    m_stack.push_back( &(*(parent.End() - 1)));
-                                    break;
-                              }
-
-                           }
-                        }
-
-                        template< typename T>
-                        void write( const T& value, const char* name)
-                        {
-                           start( name);
-                           write( value);
-                           end( name);
-                        }
-                        
-                        void end( const char* name)
-                        {
-                           m_stack.pop_back();
-                        }
-
-                        void write( bool value) { m_stack.back()->SetBool( value); }
-                        void write( char value) { write( std::string{ value}); }
-                        void write( short value) { m_stack.back()->SetInt( value); }
-                        void write( int value) { m_stack.back()->SetInt( value); }
-                        void write( long value) { m_stack.back()->SetInt64( value); }
-                        void write( long long value) { m_stack.back()->SetInt64( value); }
-                        void write( float value) { m_stack.back()->SetDouble( value); }
-                        void write( double value) { m_stack.back()->SetDouble( value); }
-                        void write( std::string_view value) { m_stack.back()->SetString( transcode::utf8::string::encode( value), *m_allocator);}
-                        void write( std::u8string_view value) { m_stack.back()->SetString( reinterpret_cast< const char*>( value.data()), value.size(), *m_allocator);}
-                        void write( std::span< const std::byte> value) { m_stack.back()->SetString( transcode::base64::encode( value), *m_allocator);}
-
-                        const rapidjson::Document& document() const { return m_document;}
-
-                        auto consume( platform::binary::type& destination)
-                        {
-                           rapidjson::StringBuffer buffer;
-                           Writer writer( buffer);
-
-                           if( m_document.Accept( writer))
-                           {
-                              auto span = binary::span::make( buffer.GetString(), buffer.GetSize());
-                              destination.assign( std::begin( span), std::end( span));
-                              reset();
-                           }
-                           else
-                           {
-                              // TODO: Better
-                              code::raise::error( code::casual::invalid_document, "failed to write document");
-                           }
-                        }
-
-                        void consume( std::ostream& json)
-                        {
-                           rapidjson::StringBuffer buffer;
-                           Writer writer( buffer);
-                           if( m_document.Accept( writer))
-                           {
-                              json << buffer.GetString();
-                              reset();
-                           }
-                           else
-                           {
-                              // TODO: Better
-                              code::raise::error( code::casual::invalid_document, "failed to write document");
-                           }
-                        }
-
-                     private:
-
-                        void reset()
-                        {
-                           rapidjson::Document document;
-                           m_document.Swap( document);
-                           m_allocator = &m_document.GetAllocator();
-
-                           m_stack.erase( std::begin( m_stack) + 1, std::end( m_stack));
-                           m_document.SetObject();
-                        }
-
-                        rapidjson::Document m_document;
-                        rapidjson::Document::AllocatorType* m_allocator;
-                        std::vector< rapidjson::Value*> m_stack;
-                     };
-
-                     using Implementation = basic_implementation< rapidjson::Writer< rapidjson::StringBuffer>>;
-
-                     namespace pretty
-                     {
-                        using Implementation = basic_implementation< rapidjson::PrettyWriter< rapidjson::StringBuffer>>;
-                     } // pretty
-
-                  } // writer
-               } // <unnamed>
-            } // local
-
-            namespace strict
-            {
-               serialize::Reader reader( const std::string& source) { return create::reader::strict::create< local::reader::Implementation>( source);}
-               serialize::Reader reader( std::istream& source) { return create::reader::strict::create< local::reader::Implementation>( source);}
-               serialize::Reader reader( const platform::binary::type& source) { return create::reader::strict::create< local::reader::Implementation>( source);}
-            } // strict
-
-            namespace relaxed
-            {    
-               serialize::Reader reader( const std::string& source) { return create::reader::relaxed::create< local::reader::Implementation>( source);}
-               serialize::Reader reader( std::istream& source) { return create::reader::relaxed::create< local::reader::Implementation>( source);}
-               serialize::Reader reader( const platform::binary::type& source) { return create::reader::relaxed::create< local::reader::Implementation>( source);}
-            } // relaxed
-
-            namespace consumed
-            {    
-               serialize::Reader reader( const std::string& source) { return create::reader::consumed::create< local::reader::Implementation>( source);}
-               serialize::Reader reader( std::istream& source) { return create::reader::consumed::create< local::reader::Implementation>( source);}
-               serialize::Reader reader( const platform::binary::type& source) { return create::reader::consumed::create< local::reader::Implementation>( source);}
-            } // consumed
-
-            namespace pretty
-            {
-               serialize::Writer writer()
-               {
-                  return serialize::create::writer::create< local::writer::pretty::Implementation>();
-               }
-            } // pretty
-
+         namespace pretty
+         {
             serialize::Writer writer()
             {
-               return serialize::create::writer::create< local::writer::Implementation>();
+               return serialize::create::writer::create< local::writer::pretty::Implementation>();
             }
+         } // pretty
 
-         } // json
-         
-         namespace create
+         serialize::Writer writer()
          {
-            namespace reader
-            {
-               template struct Registration< json::local::reader::Implementation>;
-            } // writer
-            namespace writer
-            {
-               template struct Registration< json::local::writer::pretty::Implementation>;
-            } // writer
-         } // create
+            return serialize::create::writer::create< local::writer::Implementation>();
+         }
 
-      } // serialize
-   } // common
+      } // json
+      
+      namespace create
+      {
+         namespace reader
+         {
+            template struct Registration< json::local::reader::Implementation>;
+         } // writer
+         namespace writer
+         {
+            template struct Registration< json::local::writer::pretty::Implementation>;
+         } // writer
+      } // create
+
+   } // common::serialize
 } // casual

--- a/middleware/common/source/serialize/toml.cpp
+++ b/middleware/common/source/serialize/toml.cpp
@@ -8,14 +8,12 @@
 #include "common/serialize/toml.h"
 
 #include "common/serialize/create.h"
-
-#include "common/transcode.h"
+#include "common/binary/span.h"
 #include "common/buffer/type.h"
 
-#include "common/code/raise.h"
-#include "common/code/casual.h"
+#include "common/serialize/detail/poly.h"
 
-#include <toml++/toml.hpp>
+#include <poly/toml.hpp>
 
 namespace casual
 {
@@ -23,7 +21,6 @@ namespace casual
    {
       namespace toml
       {
-
          namespace local
          {
             namespace
@@ -36,189 +33,27 @@ namespace casual
 
                namespace reader
                {
-                  class Implementation
+                  // TOML requires object as root (see reader::adapt)
+                  auto adapt( ::poly::node node) -> ::poly::node
                   {
-                  public:
+                     if( node.as_object().empty())
+                        return ::poly::node{};
 
+                     if( node.as_object().begin()->first.empty())
+                        return std::move( node.as_object().begin()->second);
+
+                     return node;
+                  }
+
+                  struct Implementation : common::serialize::detail::poly::reader
+                  {
                      constexpr static auto archive_properties() { return common::serialize::archive::Property::named;}
 
                      constexpr static auto keys() { return local::keys();}
 
-                     Implementation( std::istream& toml) : m_table{ ::toml::parse( toml)} {}
-
-                     Implementation( std::string_view toml) : m_table{ ::toml::parse( toml)} {}
-
-                     Implementation( const std::vector<std::byte>& toml) : m_table{ ::toml::parse( std::string_view{ common::binary::span::to_string_like( toml)})} {}
-
-                     std::tuple< platform::size::type, bool> container_start( const platform::size::type size, const char* const name)
-                     {
-                        if( append( name, &::toml::node::is_array))
-                        {
-                           const auto array = m_stack.back()->as_array();
-
-                           for( const auto& node : range::reverse( range::make( array->begin(), array->end())))
-                              m_stack.push_back( &node);
-                           
-                           return { array->size(), true};
-                        }
-
-                        return {};
-                     }
-
-                     void container_end( const char* const name) 
-                     {
-                        m_stack.pop_back();
-                     }
-
-                     bool composite_start( const char* const name)
-                     {
-                        //
-                        // To support (possible unnamed) other types than table as root
-                        if( m_stack.empty())
-                           return m_stack.push_back( &m_table), true;
-
-                        return append(name, &::toml::node::is_table);
-                     }
-
-                     void composite_end(  const char* const name)
-                     {
-                        m_stack.pop_back();
-                     }
-
-                     bool read( bool& value, const char* name)
-                     {
-                        return assign( name, static_cast< const ::toml::value<bool>*(::toml::node::*)() const>( &::toml::node::as_boolean), value);
-                     }
-
-                     template<typename T>
-                     bool read( T& value, const char* name) requires std::is_integral_v< T>
-                     {
-                        return assign( name, static_cast< const ::toml::value<std::int64_t>*(::toml::node::*)() const>( &::toml::node::as_integer), value);
-                     }
-                     
-                     template<typename T>
-                     bool read( T& value, const char* name) requires std::is_floating_point_v< T>
-                     {
-                        return assign( name, static_cast< const ::toml::value<double>*(::toml::node::*)() const>( &::toml::node::as_floating_point), value);
-                     }
-                     
-                     bool read( std::string_view& value, const char* name)
-                     {
-                        return assign( name, static_cast< const ::toml::value<std::string>*(::toml::node::*)() const>( &::toml::node::as_string), value);
-                     }
-
-                     bool read( char& value, const char* name)
-                     {
-                        std::string_view data;
-                        if( read( data, name))
-                           return value = transcode::utf8::string::decode( data).at( 0), true;
-
-                        return false;
-                     }
-
-                     bool read( std::string& value, const char* name)
-                     {
-                        std::string_view data;
-                        if( read( data, name))
-                           return value = transcode::utf8::string::decode( data), true;
-
-                        return false;
-                     }
-
-                     bool read( std::u8string& value, const char* name)
-                     {
-                        std::string_view data;
-                        if( read( data, name))
-                           return value = transcode::utf8::cast( data), true;
-
-                        return false;
-                     }
-
-                     bool read( platform::binary::type& value, const char* name)
-                     {
-                        std::string_view data;
-                        if( read( data, name))
-                           return value = transcode::base64::decode( data), true;
-
-                        return false;
-                     }
-
-                     bool read( binary::span::Fixed< std::byte> value, const char* name)
-                     {
-                        std::string_view data;
-                        if( read( data, name))
-                        {
-                           const auto binary = transcode::base64::decode( data);
-                           if( range::size( binary) != range::size( value))
-                              code::raise::error( code::casual::invalid_node, "binary size mismatch");
-
-                           algorithm::copy( binary, std::begin( value));
-
-                           return true;
-                        }
-
-                        return false;
-                     }
-
-                     policy::canonical::Representation canonical()
-                     {
-                        return {};
-                     }
-
-                  private:
-
-                     auto search( const char* name) -> const ::toml::node*
-                     {
-                        //
-                        // To support (possible unnamed) other types than table as root
-                        if( m_stack.empty())
-                        {
-                           m_stack.push_back( &m_table);
-                           name = name ? name : "";
-                        }
-                        
-                        if( name)
-                        {
-                           auto node = m_stack.back()->as_table()->find( name);
-
-                           if( node != m_stack.back()->as_table()->end())
-                              return &node->second;
-                           else
-                              return nullptr;
-                        }
-
-                        auto result = m_stack.back();
-                        m_stack.pop_back();
-                        return result;
-                     }
-
-
-                     bool assign( const char* name, const auto& type, auto& data)
-                     {
-                        if( const auto node = search( name))
-                        {
-                           if( const auto result = std::invoke< decltype( type)>( type, node))
-                           {
-                              return data = static_cast< const std::decay_t< decltype( data)>&>( result->get()), true;
-                           }
-                        }
-
-                        return false;
-                     }
-
-                     bool append( const char* name, const auto& type)
-                     {
-                        if( auto node = search( name))
-                           if( std::invoke< decltype( type)>( type, node))
-                              return m_stack.push_back( node), true;
-
-                        return false;
-                     }
-
-                  private:
-
-                     ::toml::table m_table;
-                     std::vector< const ::toml::node*> m_stack;
+                     Implementation( std::istream& value) : base{ adapt( ::poly::toml::parse( value))} {}
+                     Implementation( std::string_view value) : base{ adapt( ::poly::toml::parse( value))} {}
+                     Implementation( const std::vector<std::byte>& value) : Implementation{ std::string_view{ common::binary::span::to_string_like( value)}} {}
                   };
 
                } // reader
@@ -226,113 +61,28 @@ namespace casual
 
                namespace writer
                {
-                  
-                  class Implementation
+                  // TOML requires object as root (see writer::adapt)
+                  auto adapt( ::poly::node node) -> ::poly::node
                   {
-                  public:
+                     if( node.is_object())
+                        return node;
+                     
+                     return ::poly::node::object{ { {}, std::move( node)}};
+                  }
 
+                  struct Implementation : common::serialize::detail::poly::writer
+                  {
                      constexpr static auto archive_properties() { return common::serialize::archive::Property::named;}
 
                      constexpr static auto keys() { return local::keys();}
 
                      Implementation() = default;
 
-                     platform::size::type container_start( const platform::size::type size, const char* const name)
-                     {
-                        handle_object(name, ::toml::array{})->as_array()->reserve( size);
-
-                        return size;
-                     }
-                     
-                     void container_end( const char* const name)
-                     {
-                        m_stack.pop_back();
-                     }
-
-                     void composite_start( const char* const name)
-                     {
-                        //
-                        // To support (possible unnamed) other types than table as root
-                        if( m_stack.empty())
-                           return m_stack.push_back( &m_table);
-
-                        handle_object( name, ::toml::table{});
-                     }
-
-                     void composite_end( const char* const name)
-                     {
-                        m_stack.pop_back();
-                     }
-
-                     void write( auto&& data, const char* const name)
-                     {
-                        handle_member( name, std::forward< decltype( data)>( data));
-                     }
-
-                     void write( char data, const char* const name)
-                     {
-                        handle_member( name, transcode::utf8::string::encode( std::string{ data}));
-                     }
-
-                     void write( const std::string& data, const char* const name)
-                     {
-                        handle_member( name, transcode::utf8::string::encode( data));
-                     }
-
-                     void write( const std::u8string& data, const char* const name)
-                     {
-                        handle_member( name, transcode::utf8::cast( data));
-                     }
-
-                     void write( std::span< const std::byte> data, const char* const name)
-                     {
-                        handle_member( name, transcode::base64::encode( data));
-                     }
-
-                     void write( binary::span::Fixed< const std::byte> data, const char* const name)
-                     {
-                        handle_member( name, transcode::base64::encode( data));
-                     }
-
                      void consume( std::ostream& destination)
                      {
-                        destination << m_table;
+                        ::poly::toml::write( adapt( std::move( m_root)), destination);
                      }
-
-                  private:
-
-                     auto handle_member( const char* name, auto&& data) -> ::toml::node*
-                     {
-                        //
-                        // To support (possible unnamed) other types than table as root
-                        if( m_stack.empty())
-                        {
-                           m_stack.push_back( &m_table);
-                           name = name ? name : "";
-                        }
-
-                        if( m_stack.back()->is_table())
-                           return &m_stack.back()->as_table()->insert( name, std::move( data)).first->second;
-
-                        m_stack.back()->as_array()->push_back( data);
-                        return &m_stack.back()->as_array()->back();
-                     }
-
-                     auto handle_object( const char* name, auto&& data) -> ::toml::node*
-                     {
-                        m_stack.push_back( handle_member( name, std::move( data)));
-
-                        if( m_stack.back()) return m_stack.back();
-
-                        return m_stack.pop_back(), nullptr;
-                     }
-
-                  private:
-
-                     ::toml::table m_table;
-                     std::vector< ::toml::node*> m_stack;
-
-                  }; // Implementation
+                  };
 
                } // writer
             } // 

--- a/middleware/common/source/serialize/yaml.cpp
+++ b/middleware/common/source/serialize/yaml.cpp
@@ -16,8 +16,11 @@
 #include "common/transcode.h"
 #include "common/buffer/type.h"
 
-#include <yaml-cpp/yaml.h>
-#include <yaml-cpp/binary.h>
+#include "common/serialize/detail/poly.h"
+
+#include <poly/yaml.hpp>
+
+#include <format>
 
 namespace casual
 {
@@ -37,422 +40,101 @@ namespace casual
 
                namespace reader
                {
-                  namespace load
+                  namespace detail
                   {
-                     YAML::Node document( std::istream& stream)
+                     template< typename... types>
+                     struct overloaded : types...
                      {
-                        try
-                        {
-                           auto result = YAML::Load( stream);
-
-                           if( result)
-                              return result;
-                           else
-                              code::raise::error( code::casual::invalid_document, "no document");
-                        }
-                        catch( const YAML::ParserException& e)
-                        {
-                           code::raise::error( code::casual::invalid_document, e.what());
-                        }
-                     }
-
-                     YAML::Node document( const std::string& yaml)
-                     {
-                        // we need a real document
-                        std::istringstream stream{ yaml.empty() ? "---\n" : yaml};
-                        return document( stream);
-                     }
-
-                     YAML::Node document( const platform::binary::type& yaml)
-                     {
-                        auto span = binary::span::to_string_like( yaml);
-                        return document( std::string( span.data(), span.size()));
-                     }
-
-                  } // load
-
-                  namespace canonical
-                  {
-                     struct Parser 
-                     {
-                        auto operator() ( const YAML::Node& document)
-                        {
-                           deduce( document, nullptr);
-                           return std::exchange( m_canonical, {});
-                        }
-
-                     private:
-
-                        void deduce( const YAML::Node& node, const char* name)
-                        {
-                           switch( node.Type())
-                           { 
-                              case YAML::NodeType::Undefined: break; // ?!?
-                              case YAML::NodeType::Null: break; // ?!?
-                              case YAML::NodeType::Scalar: scalar( node, name); break;
-                              case YAML::NodeType::Sequence: sequence( node, name); break;
-                              case YAML::NodeType::Map: map( node, name); break;
-                           }
-                        }
-
-                        void scalar( const YAML::Node& node, const char* name)
-                        {
-                           m_canonical.attribute( name);
-                        }
-
-                        void sequence( const YAML::Node& node, const char* name)
-                        {
-                           m_canonical.container_start( name);
-
-                           for( auto& current : node)
-                              deduce( current, nullptr);
-                           
-                           m_canonical.container_end();
-                        }
-
-                        void map( const YAML::Node& node, const char* name)
-                        {
-                           m_canonical.composite_start( name);
-
-                           for( auto current = node.begin(); current != node.end(); ++current)
-                              deduce( current->second, current->first.as<std::string>().data());
-                           
-                           m_canonical.composite_end();
-                        }
-
-                        policy::canonical::Representation m_canonical;
+                        using types::operator()...;
                      };
 
-                     auto parse( const YAML::Node& document)
-                     {
-                        return Parser{}( document);
-                     }
-                     
-                  } // canonical
+                     template< typename... types>
+                     overloaded( types...) -> overloaded< types...>;
 
-                  class Implementation
+                     template< typename type>
+                     concept arithmetic = std::integral< type> || std::floating_point< type>;
+                  } // detail
+
+
+                  struct Implementation : common::serialize::detail::poly::reader
                   {
-                  public:
-
                      constexpr static auto archive_properties() { return common::serialize::archive::Property::named;}
 
                      constexpr static auto keys() { return local::keys();}
 
-                     template< typename... Ts>
-                     Implementation( Ts&&... ts) : m_stack{ load::document( std::forward< Ts>( ts)...)}, m_document{ range::back( m_stack)} {}
+                     Implementation( std::string_view value) : base{ ::poly::yaml::parse( value)} {}
+                     Implementation( std::istream& value) : base{ ::poly::yaml::parse( value)} {}
+                     Implementation( const std::vector<std::byte>& value) : Implementation{ std::string_view{ common::binary::span::to_string_like( value)}} {}
 
-                     std::tuple< platform::size::type, bool> container_start( platform::size::type size, const char* name)
+                     using base::read;
+
+                     bool read( std::string& value, const char* const name)
                      {
-                        auto node = structured_node( name);
-
-                        if( ! node)
-                           return std::make_tuple( 0, false);
-
-                        size = node.size();
-
-                        if( size)
+                        if( auto node = verify< ::poly::node::string, ::poly::node::boolean, ::poly::node::integer, ::poly::node::decimal, ::poly::node::nothing>( name))
                         {
-                           // If there are elements, it must be a sequence
-                           if( node.Type() != YAML::NodeType::Sequence)
-                              code::raise::error( code::casual::invalid_document, "expected sequence for node: ", name);
+                           std::visit
+                           (
+                              detail::overloaded
+                              {
+                                 [&]( ::poly::node::string& data) { value = std::move( data); },
+                                 [&]( detail::arithmetic auto& data) { value = std::format( "{}", data); },
+                                 [&]( auto& data) {}
+                              },
+                              *node
+                           );
 
-                           // We stack'em in reverse order
-                           for( auto index = size; index > 0; --index)
-                              m_stack.push_back( node[ index - 1]);
+                           return true;
                         }
 
-                        return std::make_tuple( size, true);
+                        return false;
                      }
 
-                     void container_end( const char* name)
+                     bool read( platform::binary::type& value, const char* const name)
                      {
-                        m_stack.pop_back();
-                     }
-
-                     bool composite_start( const char* name)
-                     {
-                        return predicate::boolean( structured_node( name));
-                     }
-
-                     void composite_end( const char* name)
-                     {
-                        m_stack.pop_back();
-                     }
-
-                     template< typename T>
-                     bool read( T& value, const char* name)
-                     {
-
-                        if( name)
+                        if( auto node = verify< ::poly::node::binary, ::poly::node::string>( name))
                         {
-                           // has name == has to exist in a map
-                           if( auto node = current_map_node( name))
-                           {
-                              read( node, value);
-                              return true;
-                           }
-
-                           return false;
+                           if( node->is_binary())
+                              return value = std::move( node->as_binary()), true;
+                           
+                           return value = transcode::base64::decode( std::move( node->as_string())), true;
                         }
-
-                        assert( ! m_stack.empty());
-            
-                        // we assume it is a value from a previous pushed sequence node.
-                        // and we consume it.
-                        read( m_stack.back(), value);
-                        m_stack.pop_back();
-                        
-                        return true;
+                        return false;
                      }
 
-                     policy::canonical::Representation canonical()
+                     bool read( binary::span::Fixed< std::byte> value, const char* const name)
                      {
-                        return canonical::parse( m_document);
-                     }
-
-                  private:
-
-                     YAML::Node current_map_node( const char* name)
-                     {
-                        assert( name);
-                        assert( ! m_stack.empty());
-
-                        // the back node should be a "map"
-                        if( m_stack.back().Type() != YAML::NodeType::Map)
-                           code::raise::error( code::casual::invalid_document, "expected map for '", name, "'");
-
-                        return m_stack.back()[ name];
-                     }
-
-                     YAML::Node structured_node( const char* name)
-                     {
-                        // if not named, we assume it is a value from a previous pushed sequence node, or root document
-                        if( ! name)
+                        platform::binary::type data;
+                        if( read( data, name))
                         {
-                           assert( ! m_stack.empty());
-                           return m_stack.back();
+                           if( range::size( data) != range::size( value))
+                              code::raise::error( code::casual::invalid_node, "binary size mismatch");
+                           algorithm::copy( data, std::begin( value));
+                           return true;
                         }
-
-                        if( auto node = current_map_node( name))
-                        {
-                           // we push it to promote the node to 'current scope'. 
-                           // composite_end/container_end will pop it.
-                           m_stack.push_back( node);
-                           return m_stack.back();
-                        }
-
-                        // 'nil' value. default ctor sets an "ok state", end operator bool returns true, 
-                        // not intuitive...
-                        return YAML::Node{ YAML::NodeType::Undefined};
+                        return false;
                      }
-
-                     template<typename T>
-                     static void consume( const YAML::Node& node, T& value)
-                     {
-                        try
-                        {
-                           // node can be null, if no value is set to the node.
-                           if( ! node.IsNull())
-                              value = node.as<T>();
-                        }
-                        catch( const YAML::InvalidScalar& e)
-                        {
-                           code::raise::error( code::casual::invalid_node, e.what());
-                        }
-                     }
-
-                     static std::string_view scalar( const YAML::Node& node)
-                     {
-                        try
-                        {
-                           if( node.IsNull())
-                              return {};
-                           else
-                              return node.Scalar();
-                        }
-                        catch( const YAML::InvalidScalar& e)
-                        {
-                           code::raise::error( code::casual::invalid_node, e.what());
-                        }
-                     }
-
-
-                     static void read( const YAML::Node& node, bool& value) { consume( node, value);}
-                     static void read( const YAML::Node& node, short& value) { consume( node, value);}
-                     static void read( const YAML::Node& node, int& value) { consume( node, value);}
-                     static void read( const YAML::Node& node, long& value) { consume( node, value);}
-                     static void read( const YAML::Node& node, long long& value) { consume( node, value);}
-                     static void read( const YAML::Node& node, float& value) { consume( node, value);}
-                     static void read( const YAML::Node& node, double& value) { consume( node, value);}
-                     static void read( const YAML::Node& node, char& value)
-                     {
-                        value = *transcode::utf8::string::decode( scalar( node)).data();
-                     }
-                     static void read( const YAML::Node& node, std::string& value)
-                     {
-                        value = transcode::utf8::string::decode( scalar( node));
-                     }
-                     static void read( const YAML::Node& node, std::u8string& value)
-                     {
-                        value = transcode::utf8::cast( scalar( node));
-                     }
-                     static void read( const YAML::Node& node, platform::binary::type& value)
-                     {
-                        YAML::Binary binary;
-                        consume( node, binary);
-
-                        auto span = binary::span::make( binary.data(), binary.size());
-                        value.assign( std::begin( span), std::end( span));
-                     }
-                     static void read( const YAML::Node& node, binary::span::Fixed< std::byte> value)
-                     {
-                        YAML::Binary binary;
-                        consume( node, binary);
-                        auto span = binary::span::make( binary.data(), binary.size());
-                        algorithm::copy( span, value);
-                     }
-
-                  protected:
-                     std::vector< YAML::Node> m_stack;
-                     YAML::Node m_document;
                   };
 
                } // reader
 
                namespace writer
                {
-
-                  class Implementation
+                  struct Implementation : common::serialize::detail::poly::writer
                   {
-                  public:
-
-                     enum class State : short
-                     {
-                        empty,
-                        implicit_map,
-                        unnamed_root,
-                     };
-
                      constexpr static auto archive_properties() { return common::serialize::archive::Property::named;}
 
-                     static decltype( auto) keys() { return local::keys();}
-
-                     Implementation()
+                     constexpr static auto keys() { return local::keys();}
+                     
+                     void consume( std::ostream& destination)
                      {
-                        m_output.SetFloatPrecision( std::numeric_limits< float >::max_digits10);
-                        m_output.SetDoublePrecision( std::numeric_limits< double >::max_digits10);
-                        m_output << YAML::BeginDoc;
+                        ::poly::yaml::write( m_root, destination);
                      }
-
-                     platform::size::type container_start( const platform::size::type size, const char* name)
-                     {
-                        possible_implicit_map( name);
-
-                        m_output << YAML::BeginSeq;
-
-                        return size;
-                     }
-
-                     void container_end( const char*)
-                     {
-                        m_output << YAML::EndSeq;
-                     }
-
-                     void composite_start( const char* name)
-                     {
-                        possible_implicit_map( name);
-                           
-                        m_output << YAML::BeginMap;
-                     }
-
-                     void composite_end( const char*)
-                     {
-                        m_output << YAML::EndMap;
-                     }
-
-                     template< typename T>
-                     void write( T value, const char* name)
-                     {
-                        possible_implicit_map( name);
-                        write( value);
-                     }
-
-                     const YAML::Emitter& document() const { return m_output;}
-
-                     std::string consume()
-                     {
-                        if( std::exchange( m_state, State::empty) == State::implicit_map)
-                           m_output << YAML::EndMap;
-
-                        m_output << YAML::EndDoc;
-
-                        auto size = m_output.size();
-                        auto offset = std::exchange( m_offset, size);
-
-                        m_output << YAML::BeginDoc;
-
-                        return std::string( m_output.c_str() + offset, size - offset);
-                     }
-
-                  private:
-
-                     void possible_implicit_map( const char* key)
-                     {
-                        if( key)
-                        {
-                           if( m_state == State::empty)
-                           {
-                              // we need to wrap in a map
-                              m_output << YAML::BeginMap;
-                              m_state = State::implicit_map;
-                           }
-                           
-                           m_output << YAML::Key << key;
-                           m_output << YAML::Value;
-                        }  
-                        else if( m_state == State::empty)
-                           m_state = State::unnamed_root;
-                     }
-
-
-                     template< concepts::arithmetic T>
-                     void write( T value)
-                     {
-                        m_output << value;
-                     }
-
-                     // A few overloads
-
-                     void write( char value)
-                     {
-                        m_output << YAML::SingleQuoted << transcode::utf8::string::encode( std::string{ value});
-                     }
-
-                     void write( std::string_view value)
-                     {
-                        m_output << YAML::DoubleQuoted << transcode::utf8::string::encode( value);
-                     }
-
-                     void write( std::u8string_view value)
-                     {
-                        m_output << YAML::DoubleQuoted << std::string{ transcode::utf8::cast( value)};
-                     }
-
-                     void write( std::span< const std::byte> value)
-                     {
-                        // TODO: Is this conformant ?
-                        const YAML::Binary binary( reinterpret_cast< const unsigned char*>( value.data()), value.size());
-                        m_output << binary;
-                     }
-
-                     State m_state = State::empty;
-                     YAML::Emitter m_output;
-                     platform::size::type m_offset = 0;
                   };
 
                } // writer
-            } // <unnamed>
+            } // 
          } // local
+
          namespace strict
          {
             serialize::Reader reader( const std::string& source) { return create::reader::strict::create< local::reader::Implementation>( source);}
@@ -486,7 +168,8 @@ namespace casual
          namespace reader
          {
             template struct Registration< yaml::local::reader::Implementation>;
-         } // writer
+         } // reader
+
          namespace writer
          {
             template struct Registration< yaml::local::writer::Implementation>;


### PR DESCRIPTION
It is hopefylly 100% backward compatible (as it seems to be according to unit tests), but semantically one (known) difference and that is that parsed documents are valid for just one serialization (due to the fact that data is moved from), but that could easily be changed (we do not have that much usage of it now either because of decoding and that decoding is not done in memory, so it is maybe a minor improvement (or degredation) that is useful in 2.0)