### PR TITLE
common: epoll could mutate the "event-buffer" while iterating over it

### DIFF
--- a/middleware/common/include/common/communication/select/epoll.h
+++ b/middleware/common/include/common/communication/select/epoll.h
@@ -132,7 +132,8 @@ namespace casual
          }
 
          inline auto descriptor() const { return m_epoll;}
-         inline auto& events() { return m_events; }
+
+         std::span< ::epoll_event> event_buffer();
 
          const auto& entries() const { return m_entries;}
 

--- a/middleware/common/source/communication/select/epoll.cpp
+++ b/middleware/common/source/communication/select/epoll.cpp
@@ -225,7 +225,6 @@ namespace casual
             // update the epoll
             auto event = local::crate_event( descriptor, found->event);
             local::update( m_epoll, local::update_op::modify, descriptor, &event);
-         
          }
          else
          {
@@ -234,7 +233,6 @@ namespace casual
             local::update( m_epoll, local::update_op::add, descriptor, &event);
 
             m_entries.push_back( directive::detail::Entry{ .descriptor = descriptor, .event = flag});
-            m_events.resize( m_entries.size());
          }
       }
 
@@ -258,9 +256,15 @@ namespace casual
                // if we have no flags left, remove the entry
                local::update( m_epoll, local::update_op::remove, descriptor);
                m_entries.erase( std::begin( found));
-               m_events.resize( m_entries.size());
             }
          }
+      }
+
+      std::span< ::epoll_event> Directive::event_buffer()
+      {
+         // we only resize the event buffer when select asks for it.
+         m_events.resize( m_entries.size());
+         return m_events;
       }
 
 
@@ -336,8 +340,11 @@ namespace casual
                Trace trace{ "common::communication::select::dispatch::detail::select"};
                log::debug( "directive: ", directive);
 
-               // use the event "buffer"
-               auto& events = directive.events();
+               // use the event "buffer". This is the only place where we potentially resize 
+               // the event buffer. Hence, other stuff can mutate the `Directive` by adding or remove
+               // descriptors, during iteration over the event buffer, without worrying about 
+               // invalidating the buffer.
+               auto events = directive.event_buffer();
 
                auto event_count = local::epoll_wait( 
                   directive.descriptor(),


### PR DESCRIPTION
Before: epoll Directive has an internal _event-buffer_ that is passed to epoll_pwait, to get the events from the wait. This is then used by the select abstraction to iterate over read/write events and dispatch to corresponding handlers.
A handler could then add additional descriptors to the directive, and the buffer could be reallocated, and we have UB.

Now: We still have the buffer (for performance) but we only resize the buffer when we're about to do epoll_pwait. Hence, we don't alter the buffer between epoll_waits.

Resolves #684