### PR TITLE
queue: state service does not have deterministic ordering of groups

### DIFF
--- a/middleware/queue/source/manager/transform.cpp
+++ b/middleware/queue/source/manager/transform.cpp
@@ -24,6 +24,8 @@ namespace casual
 
             admin::model::State result;
 
+            auto alias_less_than = []( const auto& lhs, const auto& rhs){ return lhs.alias < rhs.alias;};
+
             // groups
             for( auto& group : groups)
             {
@@ -66,14 +68,15 @@ namespace casual
                algorithm::transform_if( group.queues, 
                   std::back_inserter( result.queues), 
                   transform_queue,
-                  [&group]( auto& queue){ return !algorithm::find( group.zombies, queue.id);});
+                  [ &group]( auto& queue){ return ! algorithm::find( group.zombies, queue.id);});
  
                algorithm::transform_if( group.queues, 
                   std::back_inserter( result.zombies), 
                   transform_queue,
-                  [&group]( auto& queue){ return algorithm::find( group.zombies, queue.id);});
- 
+                  [ &group]( auto& queue){ return algorithm::find( group.zombies, queue.id);});
             }
+
+            std::ranges::sort( result.groups, alias_less_than);
             
             
             // forward
@@ -138,8 +141,9 @@ namespace casual
                };
 
                algorithm::transform( forward.queues, std::back_inserter( result.forward.queues), transform_queue);
-
             }
+
+            std::ranges::sort( result.forward.groups, alias_less_than);
 
             // find remote queues and add to model
             for( auto& queue : state.queues)
@@ -154,13 +158,17 @@ namespace casual
                });
             }
 
+            // remotes
+
             auto transform_remote_domains = []( const auto& remote)
             {
                return admin::model::remote::Domain{ remote.alias, remote.process, remote.order, remote.description};
             };
 
             algorithm::transform( state.remotes, std::back_inserter( result.remote.domains), transform_remote_domains);
-        
+
+            std::ranges::sort( result.remote.domains, alias_less_than);
+         
             return result;
          }
 

--- a/middleware/queue/unittest/source/test_forward.cpp
+++ b/middleware/queue/unittest/source/test_forward.cpp
@@ -277,11 +277,12 @@ domain:
                         service: queue/unittest/service
 )");
          auto state = unittest::state();
-
+         
+         // expect the groups to be sorted by alias.
          ASSERT_TRUE( state.forward.groups.size() == 3) << CASUAL_NAMED_VALUE( state.forward.groups);
-         EXPECT_TRUE( state.forward.groups.at( 0).alias == "forward") << CASUAL_NAMED_VALUE( state.forward.groups);
-         EXPECT_TRUE( state.forward.groups.at( 1).alias == "forward.2") << CASUAL_NAMED_VALUE( state.forward.groups);
-         EXPECT_TRUE( state.forward.groups.at( 2).alias == "C") << CASUAL_NAMED_VALUE( state.forward.groups);
+         EXPECT_TRUE( state.forward.groups.at( 0).alias == "C") << CASUAL_NAMED_VALUE( state.forward.groups);
+         EXPECT_TRUE( state.forward.groups.at( 1).alias == "forward") << CASUAL_NAMED_VALUE( state.forward.groups);
+         EXPECT_TRUE( state.forward.groups.at( 2).alias == "forward.2") << CASUAL_NAMED_VALUE( state.forward.groups);
       }
       
 


### PR DESCRIPTION
This patch:
* order queue groups by alias ascending
* order queue forward groups by alias ascending
* order "queue remote" by alias escending

This will also make the CLI print groups in deterministic order.

Resolves #730